### PR TITLE
[codex] fix quick review state handling

### DIFF
--- a/apps/desktop/src/lib/quick-review-state.test.ts
+++ b/apps/desktop/src/lib/quick-review-state.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { diffRangeFromSourceLabel, repoPrefKey } from "./quick-review-state";
+
+describe("diffRangeFromSourceLabel", () => {
+  it("strips the cli prefix and agent name", () => {
+    assert.equal(diffRangeFromSourceLabel("cli:claude:main...feature"), "main...feature");
+  });
+
+  it("passes through non-cli labels", () => {
+    assert.equal(diffRangeFromSourceLabel("manual review"), "manual review");
+  });
+});
+
+describe("repoPrefKey", () => {
+  it("supports unicode repository paths", () => {
+    assert.doesNotThrow(() => repoPrefKey("/Users/sarthak/こんにちは"));
+  });
+});

--- a/apps/desktop/src/lib/quick-review-state.ts
+++ b/apps/desktop/src/lib/quick-review-state.ts
@@ -1,0 +1,17 @@
+export function diffRangeFromSourceLabel(sourceLabel: string | null | undefined): string {
+  if (!sourceLabel) return "";
+  if (!sourceLabel.startsWith("cli:")) return sourceLabel;
+
+  const firstSeparator = sourceLabel.indexOf(":", 4);
+  if (firstSeparator < 0) return sourceLabel;
+  return sourceLabel.slice(firstSeparator + 1);
+}
+
+export function repoPrefKey(repoPath: string): string {
+  const bytes = new TextEncoder().encode(repoPath);
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary);
+}

--- a/apps/desktop/src/pages/QuickReview.tsx
+++ b/apps/desktop/src/pages/QuickReview.tsx
@@ -43,6 +43,10 @@ import {
 import { trackCoreAction } from "@/lib/analytics";
 import { buildReviewIntentReport } from "@/lib/intent-debugger/report";
 import {
+  diffRangeFromSourceLabel,
+  repoPrefKey,
+} from "@/lib/quick-review-state";
+import {
   buildRevalidationChecklist,
   buildReviewerProofMarkdown,
   formatHistoryCommandEvidence,
@@ -653,14 +657,14 @@ export default function QuickReview() {
     }
     // Load persisted project description
     try {
-      const saved = await getPreference(`quick_review_desc_${btoa(dir)}`);
+      const saved = await getPreference(`quick_review_desc_${repoPrefKey(dir)}`);
       if (saved != null) setProjectDesc(saved);
       else setProjectDesc("");
     } catch {
       setProjectDesc("");
     }
     try {
-      const savedTask = await getPreference(`quick_review_task_${btoa(dir)}`);
+      const savedTask = await getPreference(`quick_review_task_${repoPrefKey(dir)}`);
       if (savedTask) {
         const parsed = JSON.parse(savedTask) as Partial<TaskContext>;
         setTaskGoal(parsed.goal ?? "");
@@ -745,6 +749,14 @@ export default function QuickReview() {
         line: f.line ?? undefined,
         confidence: f.confidence ?? undefined,
       }));
+      setFixResult(null);
+      setSelectedFindings(new Set());
+      setSelectedFindingIdx(null);
+      setCodeLines([]);
+      setCodeFilePath("");
+      setCodeLanguage("");
+      setEvidenceByFinding({});
+      setBrowserEvidenceByFinding({});
       setResult({
         review_id: review.id,
         score: review.score_composite ?? 0,
@@ -752,7 +764,7 @@ export default function QuickReview() {
         summary: review.summary_markdown ?? "",
         agent: review.agent_used ?? "claude",
         duration_ms: 0,
-        diff_range: review.source_label ?? "",
+        diff_range: diffRangeFromSourceLabel(review.source_label),
         findings_count: findings.length,
       });
       setViewHasRepoPath(!!review.repo_path);
@@ -823,7 +835,7 @@ export default function QuickReview() {
 
   const handleProjectDescBlur = useCallback(() => {
     if (!repoPath || !isTauriAvailable()) return;
-    const prefKey = `quick_review_desc_${btoa(repoPath)}`;
+    const prefKey = `quick_review_desc_${repoPrefKey(repoPath)}`;
     setPreference(prefKey, projectDesc).catch(() => {});
   }, [repoPath, projectDesc]);
 
@@ -836,7 +848,7 @@ export default function QuickReview() {
 
   const handleTaskContextBlur = useCallback(() => {
     if (!repoPath || !isTauriAvailable()) return;
-    const prefKey = `quick_review_task_${btoa(repoPath)}`;
+    const prefKey = `quick_review_task_${repoPrefKey(repoPath)}`;
     setPreference(prefKey, JSON.stringify(currentTaskContext)).catch(() => {});
   }, [currentTaskContext, repoPath]);
 


### PR DESCRIPTION
## What changed
- Parse the real git diff range back out of stored `source_label` when reopening past reviews.
- Clear stale review/fix selection state when loading a historical review.
- Replace `btoa(repoPath)` preference keys with a Unicode-safe repo key helper.
- Add a small unit test for the new helper behavior.

## Why
- Stored CLI reviews encode `source_label` as `cli:<agent>:<diff_range>`, so reusing it directly as `diff_range` corrupts downstream proof/review flows.
- Opening a different past review could inherit the previous review's selected finding, code snapshot, or fix state.
- `btoa()` throws on Unicode paths, which breaks per-repo Quick Review persistence outside ASCII-only repo paths.

## Impact
- Historical reviews now reopen with the correct diff context.
- The review UI no longer leaks stale selection/fix state across reviews.
- Quick Review settings now persist for repos under non-ASCII paths.

## Validation
- `node --import tsx --test src/lib/quick-review-state.test.ts`
- `npm run test:review-proof`
- `npm run test:agent-fix-packet`
- `npx eslint apps/desktop/src/pages/QuickReview.tsx apps/desktop/src/lib/quick-review-state.ts apps/desktop/src/lib/quick-review-state.test.ts`
