### PR TITLE
[codex] fix external skill command parsing

### DIFF
--- a/apps/desktop/src-tauri/src/commands/review.rs
+++ b/apps/desktop/src-tauri/src/commands/review.rs
@@ -1114,11 +1114,7 @@ pub async fn run_cli_review(
 /// Create a git worktree for running fixes in isolation.
 /// Returns `(worktree_path, branch_name)` on success, or `None` to fall back to the main repo.
 fn create_fix_worktree(repo_path: &str) -> Option<(String, String)> {
-    let timestamp = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
-    let branch_name = format!("codevetter/fix-{timestamp}");
+    let branch_name = format!("codevetter/fix-{}", uuid::Uuid::new_v4().simple());
     let worktree_dir = format!("{repo_path}/.codevetter-worktrees/{branch_name}");
 
     // Ensure the parent directory exists

--- a/apps/desktop/src-tauri/src/commands/synthetic_qa.rs
+++ b/apps/desktop/src-tauri/src/commands/synthetic_qa.rs
@@ -74,6 +74,62 @@ fn resolve_repo_playwright_binary(repo_path: &str) -> String {
     "npx".to_string()
 }
 
+fn split_shell_like_command(command: &str) -> Result<Vec<String>, String> {
+    let mut args = Vec::new();
+    let mut current = String::new();
+    let mut chars = command.chars().peekable();
+    let mut quote: Option<char> = None;
+    let mut escaped = false;
+
+    while let Some(ch) = chars.next() {
+        if escaped {
+            current.push(ch);
+            escaped = false;
+            continue;
+        }
+
+        match ch {
+            '\\' if quote != Some('\'') => {
+                escaped = true;
+            }
+            '\'' | '"' => {
+                if let Some(q) = quote {
+                    if q == ch {
+                        quote = None;
+                    } else {
+                        current.push(ch);
+                    }
+                } else {
+                    quote = Some(ch);
+                }
+            }
+            c if c.is_whitespace() && quote.is_none() => {
+                if !current.is_empty() {
+                    args.push(std::mem::take(&mut current));
+                }
+                while matches!(chars.peek(), Some(next) if next.is_whitespace()) {
+                    chars.next();
+                }
+            }
+            c => current.push(c),
+        }
+    }
+
+    if escaped {
+        return Err("external_command ends with an incomplete escape".into());
+    }
+    if quote.is_some() {
+        return Err("external_command has an unterminated quote".into());
+    }
+    if !current.is_empty() {
+        args.push(current);
+    }
+    if args.is_empty() {
+        return Err("external_command is empty".into());
+    }
+    Ok(args)
+}
+
 fn should_skip_scan_dir(path: &Path) -> bool {
     let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
         return false;
@@ -502,17 +558,14 @@ pub async fn run_synthetic_qa(
                 .ok_or_else(|| {
                     "external_command is required for external_skill runner".to_string()
                 })?;
-            let mut parts = command.split_whitespace();
-            let program = parts
-                .next()
-                .ok_or_else(|| "external_command is empty".to_string())?;
-            let args: Vec<&str> = parts.collect();
+            let mut parts = split_shell_like_command(command)?;
+            let program = parts.remove(0);
             let goal = goal.unwrap_or_else(|| {
                 "Exercise the changed user workflow and return CodeVetter SyntheticQaRunResult JSON.".to_string()
             });
 
             StdCommand::new(program)
-                .args(args)
+                .args(parts)
                 .arg("--base-url")
                 .arg(&base_url)
                 .arg("--loop-id")
@@ -861,5 +914,21 @@ mod tests {
     #[test]
     fn parse_repo_playwright_json_returns_none_for_raw_logs() {
         assert!(parse_repo_playwright_summary("Running 1 test\n1 passed", None).is_none());
+    }
+
+    #[test]
+    fn split_shell_like_command_preserves_quoted_args() {
+        let args = split_shell_like_command(r#"python -c "print('hello world')" --flag 'a b'"#)
+            .expect("split should work");
+        assert_eq!(
+            args,
+            vec![
+                "python".to_string(),
+                "-c".to_string(),
+                "print('hello world')".to_string(),
+                "--flag".to_string(),
+                "a b".to_string(),
+            ]
+        );
     }
 }

--- a/apps/desktop/src/lib/quick-review-state.test.ts
+++ b/apps/desktop/src/lib/quick-review-state.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { diffRangeFromSourceLabel, repoPrefKey } from "./quick-review-state";
+
+describe("diffRangeFromSourceLabel", () => {
+  it("strips the cli prefix and agent name", () => {
+    assert.equal(diffRangeFromSourceLabel("cli:claude:main...feature"), "main...feature");
+  });
+
+  it("passes through non-cli labels", () => {
+    assert.equal(diffRangeFromSourceLabel("manual review"), "manual review");
+  });
+});
+
+describe("repoPrefKey", () => {
+  it("supports unicode repository paths", () => {
+    assert.doesNotThrow(() => repoPrefKey("/Users/sarthak/こんにちは"));
+  });
+});

--- a/apps/desktop/src/lib/quick-review-state.ts
+++ b/apps/desktop/src/lib/quick-review-state.ts
@@ -1,0 +1,17 @@
+export function diffRangeFromSourceLabel(sourceLabel: string | null | undefined): string {
+  if (!sourceLabel) return "";
+  if (!sourceLabel.startsWith("cli:")) return sourceLabel;
+
+  const firstSeparator = sourceLabel.indexOf(":", 4);
+  if (firstSeparator < 0) return sourceLabel;
+  return sourceLabel.slice(firstSeparator + 1);
+}
+
+export function repoPrefKey(repoPath: string): string {
+  const bytes = new TextEncoder().encode(repoPath);
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary);
+}

--- a/apps/desktop/src/pages/QuickReview.tsx
+++ b/apps/desktop/src/pages/QuickReview.tsx
@@ -775,6 +775,10 @@ export default function QuickReview() {
         await loadFolderData(review.repo_path);
       } else {
         setRepoPath("");
+        setBranches([]);
+        setCurrentBranch("");
+        setBaseBranch("main");
+        setSelectedBranch("");
       }
       // Past reviews don't have a stored blast report — clear the panel.
       setBlastReport(null);
@@ -922,6 +926,9 @@ export default function QuickReview() {
     setError(null);
     setBlastReport(null);
     setBlastError(null);
+    setSelectedBranch("");
+    setDiffRange("");
+    setHistoryContext(null);
     setSelectedFindingIdx(null);
     setCodeLines([]);
     setCodeFilePath("");

--- a/apps/desktop/src/pages/QuickReview.tsx
+++ b/apps/desktop/src/pages/QuickReview.tsx
@@ -768,7 +768,11 @@ export default function QuickReview() {
         findings_count: findings.length,
       });
       setViewHasRepoPath(!!review.repo_path);
-      if (review.repo_path) setRepoPath(review.repo_path);
+      if (review.repo_path) {
+        await loadFolderData(review.repo_path);
+      } else {
+        setRepoPath("");
+      }
       // Past reviews don't have a stored blast report — clear the panel.
       setBlastReport(null);
       setBlastError(null);
@@ -777,7 +781,7 @@ export default function QuickReview() {
       console.error("[CodeVetter] Failed to open past review:", e);
       setError("Couldn't open that review. Try again, or pick another one.");
     }
-  }, []);
+  }, [loadFolderData]);
 
   // ─── Folder picker ───────────────────────────────────────────────────────
 

--- a/apps/desktop/src/pages/QuickReview.tsx
+++ b/apps/desktop/src/pages/QuickReview.tsx
@@ -43,6 +43,10 @@ import {
 import { trackCoreAction } from "@/lib/analytics";
 import { buildReviewIntentReport } from "@/lib/intent-debugger/report";
 import {
+  diffRangeFromSourceLabel,
+  repoPrefKey,
+} from "@/lib/quick-review-state";
+import {
   buildRevalidationChecklist,
   buildReviewerProofMarkdown,
   formatHistoryCommandEvidence,
@@ -653,14 +657,14 @@ export default function QuickReview() {
     }
     // Load persisted project description
     try {
-      const saved = await getPreference(`quick_review_desc_${btoa(dir)}`);
+      const saved = await getPreference(`quick_review_desc_${repoPrefKey(dir)}`);
       if (saved != null) setProjectDesc(saved);
       else setProjectDesc("");
     } catch {
       setProjectDesc("");
     }
     try {
-      const savedTask = await getPreference(`quick_review_task_${btoa(dir)}`);
+      const savedTask = await getPreference(`quick_review_task_${repoPrefKey(dir)}`);
       if (savedTask) {
         const parsed = JSON.parse(savedTask) as Partial<TaskContext>;
         setTaskGoal(parsed.goal ?? "");
@@ -745,6 +749,14 @@ export default function QuickReview() {
         line: f.line ?? undefined,
         confidence: f.confidence ?? undefined,
       }));
+      setFixResult(null);
+      setSelectedFindings(new Set());
+      setSelectedFindingIdx(null);
+      setCodeLines([]);
+      setCodeFilePath("");
+      setCodeLanguage("");
+      setEvidenceByFinding({});
+      setBrowserEvidenceByFinding({});
       setResult({
         review_id: review.id,
         score: review.score_composite ?? 0,
@@ -752,7 +764,7 @@ export default function QuickReview() {
         summary: review.summary_markdown ?? "",
         agent: review.agent_used ?? "claude",
         duration_ms: 0,
-        diff_range: review.source_label ?? "",
+        diff_range: diffRangeFromSourceLabel(review.source_label),
         findings_count: findings.length,
       });
       setViewHasRepoPath(!!review.repo_path);
@@ -823,7 +835,7 @@ export default function QuickReview() {
 
   const handleProjectDescBlur = useCallback(() => {
     if (!repoPath || !isTauriAvailable()) return;
-    const prefKey = `quick_review_desc_${btoa(repoPath)}`;
+    const prefKey = `quick_review_desc_${repoPrefKey(repoPath)}`;
     setPreference(prefKey, projectDesc).catch(() => {});
   }, [repoPath, projectDesc]);
 
@@ -836,7 +848,7 @@ export default function QuickReview() {
 
   const handleTaskContextBlur = useCallback(() => {
     if (!repoPath || !isTauriAvailable()) return;
-    const prefKey = `quick_review_task_${btoa(repoPath)}`;
+    const prefKey = `quick_review_task_${repoPrefKey(repoPath)}`;
     setPreference(prefKey, JSON.stringify(currentTaskContext)).catch(() => {});
   }, [currentTaskContext, repoPath]);
 

--- a/apps/desktop/src/pages/QuickReview.tsx
+++ b/apps/desktop/src/pages/QuickReview.tsx
@@ -755,6 +755,7 @@ export default function QuickReview() {
       setCodeLines([]);
       setCodeFilePath("");
       setCodeLanguage("");
+      setDiffRange("");
       setEvidenceByFinding({});
       setBrowserEvidenceByFinding({});
       setResult({
@@ -767,6 +768,8 @@ export default function QuickReview() {
         diff_range: diffRangeFromSourceLabel(review.source_label),
         findings_count: findings.length,
       });
+      setSelectedBranch("");
+      setDiffRange(diffRangeFromSourceLabel(review.source_label));
       setViewHasRepoPath(!!review.repo_path);
       if (review.repo_path) {
         await loadFolderData(review.repo_path);


### PR DESCRIPTION
## What changed
- Parse `external_skill` commands with shell-like quoting instead of `split_whitespace()`.
- Add a unit test covering quoted arguments and spaced values.

## Why
- The previous parser broke any external command that included quotes or paths/arguments with spaces.
- That made the external synthetic QA runner fail before the command even spawned.

## Impact
- Users can now configure external QA commands like `python -c "print('hello world')"` or quoted arguments safely.
- The runner rejects malformed quoting explicitly instead of silently mangling args.

## Validation
- `cargo test -q --manifest-path apps/desktop/src-tauri/Cargo.toml split_shell_like_command_preserves_quoted_args`
