### PR TITLE
perf(battery): pause animations + polling when hidden (v1.1.92)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code-reviewer/desktop",
-  "version": "1.1.91",
+  "version": "1.1.92",
   "private": true,
   "scripts": {
     "dev": "lsof -ti:1420 | xargs kill -9 2>/dev/null; vite",

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-utils/schema.json",
   "identifier": "com.codevetter.desktop",
   "productName": "CodeVetter",
-  "version": "1.1.91",
+  "version": "1.1.92",
   "build": {
     "beforeDevCommand": "npm run dev",
     "beforeBuildCommand": "npm run build",

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -9,6 +9,7 @@ import UpdateChecker from "@/components/update-checker";
 import { trackAppLaunch } from "@/lib/analytics";
 import { getPreference, isTauriAvailable } from "@/lib/tauri-ipc";
 import { useTrayMonitor } from "@/lib/use-tray-monitor";
+import { useWindowVisibilityClass } from "@/lib/use-visibility";
 // Pages are lazy-loaded so the initial bundle isn't dominated by the large
 // review/unpack screens — only the route the user lands on is fetched.
 const AgentMemories = lazy(() => import("@/pages/AgentMemories"));
@@ -145,6 +146,8 @@ function Shell() {
   const { showOnboarding, setShowOnboarding, ready } = useOnboarding();
   const { isOpen, close } = useCommandPalette();
   useTrayMonitor();
+  // Freeze CSS animations when the window is hidden/minimized (battery).
+  useWindowVisibilityClass();
 
   if (!ready) {
     return (

--- a/apps/desktop/src/globals.css
+++ b/apps/desktop/src/globals.css
@@ -172,6 +172,15 @@
     animation: cvScan 4.5s linear infinite;
   }
 
+  /* Battery: when the window is hidden/minimized, App.tsx adds `cv-hidden` to
+     <html>; freeze every animation so a backgrounded window does zero GPU/
+     compositing work. The always-on .cv-scan loop is the main offender. */
+  html.cv-hidden *,
+  html.cv-hidden *::before,
+  html.cv-hidden *::after {
+    animation-play-state: paused !important;
+  }
+
   .drag-region {
     -webkit-app-region: drag;
   }

--- a/apps/desktop/src/lib/use-visibility.ts
+++ b/apps/desktop/src/lib/use-visibility.ts
@@ -1,0 +1,63 @@
+import { useEffect, useRef } from "react";
+
+/** True when the app window is hidden / minimized / occluded. */
+export function isWindowHidden(): boolean {
+  return typeof document !== "undefined" && document.hidden;
+}
+
+/**
+ * Toggle a `cv-hidden` class on <html> whenever the window is hidden so CSS can
+ * freeze all animations (see globals.css). Call once at the app root. This is a
+ * battery win for a tray app that's often left running in the background — a
+ * minimized window does zero GPU/compositing work.
+ */
+export function useWindowVisibilityClass(): void {
+  useEffect(() => {
+    const apply = () => {
+      document.documentElement.classList.toggle("cv-hidden", isWindowHidden());
+    };
+    apply();
+    document.addEventListener("visibilitychange", apply);
+    return () => document.removeEventListener("visibilitychange", apply);
+  }, []);
+}
+
+/**
+ * Like setInterval, but only ticks while the window is visible. When hidden the
+ * timer is fully cleared (no background wakeups); on becoming visible again it
+ * fires `callback` once immediately to catch up, then resumes ticking. Use for
+ * dashboard/polling refreshes that are pointless when the user isn't looking.
+ */
+export function useVisibilityInterval(callback: () => void, ms: number): void {
+  const saved = useRef(callback);
+  useEffect(() => {
+    saved.current = callback;
+  }, [callback]);
+
+  useEffect(() => {
+    let id: ReturnType<typeof setInterval> | undefined;
+    const start = () => {
+      if (id == null) id = setInterval(() => saved.current(), ms);
+    };
+    const stop = () => {
+      if (id != null) {
+        clearInterval(id);
+        id = undefined;
+      }
+    };
+    const sync = () => {
+      if (isWindowHidden()) {
+        stop();
+      } else {
+        saved.current(); // catch up on resume
+        start();
+      }
+    };
+    if (!isWindowHidden()) start();
+    document.addEventListener("visibilitychange", sync);
+    return () => {
+      stop();
+      document.removeEventListener("visibilitychange", sync);
+    };
+  }, [ms]);
+}

--- a/apps/desktop/src/pages/Home.tsx
+++ b/apps/desktop/src/pages/Home.tsx
@@ -50,6 +50,7 @@ import {
   listProviderUsageLedger,
   triggerIndex,
 } from "@/lib/tauri-ipc";
+import { isWindowHidden, useVisibilityInterval } from "@/lib/use-visibility";
 
 // ─── Usage helpers ──────────────────────────────────────────────────────────
 
@@ -1132,7 +1133,10 @@ function WeeklyAgentSplit() {
     // later. Without refetching, this bar stays frozen on the partial numbers
     // (e.g. Claude far below its real total). Refresh when the indexer emits
     // its completion event, plus a periodic fallback.
-    const interval = setInterval(() => void fetchRows(), 60_000);
+    const interval = setInterval(() => {
+      if (isWindowHidden()) return; // battery: skip background refetches
+      void fetchRows();
+    }, 60_000);
     void (async () => {
       try {
         const { listen } = await import("@tauri-apps/api/event");
@@ -2017,18 +2021,14 @@ export default function Home() {
   }, [loadDashboard]);
 
   // ─── Periodic background sync every 60s ───────────────────────────────
-  // Tight loop keeps token-usage counters near-realtime. Backend indexer
-  // also runs every 60s so fresh JSONL bytes land in the DB before we read.
+  // Keeps token-usage counters near-realtime. Paused while the window is
+  // hidden (battery) — no point polling when the user isn't looking; it
+  // catches up immediately on return.
 
-  useEffect(() => {
+  useVisibilityInterval(() => {
     if (!isTauriAvailable()) return;
-
-    const interval = setInterval(() => {
-      refreshDashboard();
-    }, 60_000);
-
-    return () => clearInterval(interval);
-  }, [refreshDashboard]);
+    refreshDashboard();
+  }, 60_000);
 
   // ─── Auto-refresh live usage every 60s ─────────────────────────────────
 
@@ -2062,26 +2062,21 @@ export default function Home() {
     });
   }, []);
 
+  // Fetch live usage immediately once accounts are loaded.
   useEffect(() => {
-    if (!isTauriAvailable()) return;
-    // Don't start until accounts are loaded
-    if (accounts.length === 0) return;
-
-    // Fetch immediately on first load
+    if (!isTauriAvailable() || accounts.length === 0) return;
     const initialTimeout = setTimeout(() => {
       void refreshLiveUsage(accounts);
     }, 0);
-
-    // Then every 60 seconds
-    const interval = setInterval(() => {
-      void refreshLiveUsage(accounts);
-    }, 60_000);
-
-    return () => {
-      clearTimeout(initialTimeout);
-      clearInterval(interval);
-    };
+    return () => clearTimeout(initialTimeout);
   }, [accounts, refreshLiveUsage]);
+
+  // Then refresh every 60s — but only while the window is visible (battery);
+  // hitting provider APIs in the background is wasted work + network.
+  useVisibilityInterval(() => {
+    if (!isTauriAvailable() || accounts.length === 0) return;
+    void refreshLiveUsage(accounts);
+  }, 60_000);
 
   // Tray title + menu are managed globally by `useTrayMonitor` in App so they
   // stay current regardless of which page is mounted.

--- a/apps/desktop/src/pages/TRex.tsx
+++ b/apps/desktop/src/pages/TRex.tsx
@@ -93,8 +93,19 @@ export default function TRex() {
 
   useEffect(() => {
     refresh();
-    const t = setInterval(refresh, 15_000);
-    return () => clearInterval(t);
+    // Pause polling while the window is hidden (battery); refresh on return.
+    const t = setInterval(() => {
+      if (document.hidden) return;
+      refresh();
+    }, 15_000);
+    const onVisible = () => {
+      if (!document.hidden) refresh();
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    return () => {
+      clearInterval(t);
+      document.removeEventListener("visibilitychange", onVisible);
+    };
   }, [refresh]);
 
   const handleStart = async () => {


### PR DESCRIPTION
Ships the token-usage analytics work already on main as **v1.1.92**, plus background battery savings.

## Battery (this PR)
- **Freeze all CSS animations when the window is hidden** — `html.cv-hidden` class toggled on `visibilitychange` + a global `animation-play-state: paused` rule. Kills the always-on `.cv-scan` loop and all other animations when minimized/occluded → zero GPU/compositing in the background.
- **`useVisibilityInterval` hook** — pauses polling while hidden, catches up on return:
  - Home dashboard 60s sync
  - Live-usage 60s provider poll (also saves network)
  - TRex 15s poll
  - Per-agent split 60s refetch skips when hidden

## Version
- Bump `tauri.conf.json` + `package.json` → **1.1.92** (triggers auto-release).

## Deferred to 1.1.93
- `ResourceChip` 2s poll gating (file is in another in-flight branch)
- Rust indexer: interval coalescing, on-battery backoff, fsevents file-watching (needs `notify` dep)
- grok/cursor 60s tailing fix (`refresh_secondary_agents`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)