### PR TITLE
fix(perf): indexer CPU loop (incremental FTS + bounded backfill) + log-scale chart (v1.1.94)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code-reviewer/desktop",
-  "version": "1.1.93",
+  "version": "1.1.94",
   "private": true,
   "scripts": {
     "dev": "lsof -ti:1420 | xargs kill -9 2>/dev/null; vite",

--- a/apps/desktop/src-tauri/src/db/queries.rs
+++ b/apps/desktop/src-tauri/src/db/queries.rs
@@ -980,7 +980,34 @@ pub fn sync_session_message_archive_fts(conn: &Connection) -> Result<i64, rusqli
         return Ok(0);
     }
 
-    conn.execute("DELETE FROM session_message_archive_fts", [])?;
+    // Incremental sync. The old code DELETE'd and re-INSERT'd the ENTIRE FTS
+    // table on any count change — with 300k+ archive rows that's a multi-second
+    // CPU burn on every index pass that adds a single message (and the backfill
+    // pass re-triggered it constantly). Instead insert only rows past the FTS
+    // high-water mark (archive ids are monotonic) — O(new rows). Fall back to a
+    // full rebuild only when FTS has *more* rows than the archive (rows were
+    // deleted / a session re-indexed), so stale FTS entries get cleared.
+    if fts_count > archive_count {
+        conn.execute("DELETE FROM session_message_archive_fts", [])?;
+        return conn
+            .execute(
+                "INSERT INTO session_message_archive_fts (
+                    archive_id, session_id, adapter_id, agent_type, role, kind,
+                    content_text, tool_name, source_ref
+                 )
+                 SELECT a.id, a.session_id, a.adapter_id, a.agent_type, a.role, a.kind,
+                        a.content_text, a.tool_name, a.source_ref
+                 FROM session_message_archive a",
+                [],
+            )
+            .map(|rows| rows as i64);
+    }
+
+    let max_fts_id: i64 = conn.query_row(
+        "SELECT COALESCE(MAX(archive_id), 0) FROM session_message_archive_fts",
+        [],
+        |row| row.get(0),
+    )?;
     conn.execute(
         "INSERT INTO session_message_archive_fts (
             archive_id, session_id, adapter_id, agent_type, role, kind,
@@ -988,8 +1015,9 @@ pub fn sync_session_message_archive_fts(conn: &Connection) -> Result<i64, rusqli
          )
          SELECT a.id, a.session_id, a.adapter_id, a.agent_type, a.role, a.kind,
                 a.content_text, a.tool_name, a.source_ref
-         FROM session_message_archive a",
-        [],
+         FROM session_message_archive a
+         WHERE a.id > ?1",
+        params![max_fts_id],
     )
     .map(|rows| rows as i64)
 }
@@ -1112,17 +1140,24 @@ pub fn list_sessions_needing_archive_backfill(
     limit: i64,
 ) -> Result<Vec<SessionArchiveBackfillCandidate>, rusqlite::Error> {
     let limit = limit.clamp(1, 5_000);
+    // Only sessions with NO archive rows at all need a backfill. The old
+    // criterion `archived < message_count` was unsatisfiable for many sessions
+    // (message_count counts non-archivable events like tool results), so those
+    // sessions re-qualified on every pass and got their whole JSONL re-read
+    // (read_to_string) every 5 minutes — a sustained CPU drain that also kept
+    // re-triggering the FTS sync. A session that already has any archive rows
+    // has been indexed by the current path and is as complete as it gets.
     let mut stmt = conn.prepare(
         "SELECT s.id, s.agent_type, s.jsonl_path
          FROM cc_sessions s
          WHERE s.jsonl_path IS NOT NULL
            AND s.message_count > 0
            AND s.agent_type IN ('claude-code', 'codex')
-           AND (
-             SELECT COUNT(*)
+           AND NOT EXISTS (
+             SELECT 1
              FROM session_message_archive a
              WHERE a.session_id = s.id
-           ) < s.message_count
+           )
          ORDER BY datetime(s.last_message) DESC NULLS LAST
          LIMIT ?1",
     )?;

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-utils/schema.json",
   "identifier": "com.codevetter.desktop",
   "productName": "CodeVetter",
-  "version": "1.1.93",
+  "version": "1.1.94",
   "build": {
     "beforeDevCommand": "npm run dev",
     "beforeBuildCommand": "npm run build",

--- a/apps/desktop/src/pages/Home.tsx
+++ b/apps/desktop/src/pages/Home.tsx
@@ -663,6 +663,12 @@ function TokenUsageChart({
   const [pinned, setPinned] = useState<number | null>(null);
   const data = mode === "daily" ? daily : weekly;
   const max = Math.max(1, ...data.map((d) => d.generated));
+  // Bar HEIGHT uses a log scale so one huge outlier day (e.g. an automated
+  // agent run generating 100s of M) doesn't flatten every normal day into an
+  // invisible sliver. Color/opacity stay on the linear ratio so the peak still
+  // reads as "hot" and normal days as "cool".
+  const logMax = Math.log10(max + 1);
+  const barFrac = (v: number) => (v <= 0 ? 0 : Math.log10(v + 1) / logMax);
   const total = data.reduce((acc, d) => acc + d.generated, 0);
   const cacheTotal = data.reduce((acc, d) => acc + d.cache, 0);
   const n = data.length;
@@ -848,7 +854,7 @@ function TokenUsageChart({
           />
         ))}
         {data.map((d, i) => {
-          const h = (d.generated / max) * chartH;
+          const h = barFrac(d.generated) * chartH;
           const ratio = d.generated / max;
           const x = padX + i * barW + barW * 0.15;
           const y = padTop + chartH - h;


### PR DESCRIPTION
## CPU fix (the ~90% spike)
Pre-existing indexer loop, surfaced by a huge 8305-message codex session:
- **`sync_session_message_archive_fts`** rebuilt the **entire** FTS table (~318k rows) on every pass that added a message → now inserts only rows past the FTS high-water mark (O(new)); full rebuild only when FTS has *more* rows than the archive.
- **`list_sessions_needing_archive_backfill`** used `archived < message_count`, unsatisfiable for ~30 sessions (message_count counts non-archivable events) → they re-read their whole JSONL every 5 min and re-triggered the full FTS rebuild. Now only zero-archive sessions qualify.

## Chart
- Bar **height** is log-scaled so one outlier day doesn't flatten the rest; **color** stays linear so the peak still reads hot.

Verified: cargo check + tsc + vite build clean. No changes to the indexer thread files (no conflict with in-flight work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)