### PR TITLE
fix(perf): kill indexer CPU loop + background-QoS the indexer (v1.1.95)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code-reviewer/desktop",
-  "version": "1.1.94",
+  "version": "1.1.95",
   "private": true,
   "scripts": {
     "dev": "lsof -ti:1420 | xargs kill -9 2>/dev/null; vite",

--- a/apps/desktop/src-tauri/src/db/queries.rs
+++ b/apps/desktop/src-tauri/src/db/queries.rs
@@ -1140,18 +1140,21 @@ pub fn list_sessions_needing_archive_backfill(
     limit: i64,
 ) -> Result<Vec<SessionArchiveBackfillCandidate>, rusqlite::Error> {
     let limit = limit.clamp(1, 5_000);
-    // Only sessions with NO archive rows at all need a backfill. The old
-    // criterion `archived < message_count` was unsatisfiable for many sessions
-    // (message_count counts non-archivable events like tool results), so those
-    // sessions re-qualified on every pass and got their whole JSONL re-read
-    // (read_to_string) every 5 minutes — a sustained CPU drain that also kept
-    // re-triggering the FTS sync. A session that already has any archive rows
-    // has been indexed by the current path and is as complete as it gets.
+    // Backfill only sessions the indexer has NEVER cursored (offset == 0) and
+    // that have no archive rows. Crucial: once a session has been read by the
+    // indexer (offset > 0) it has produced whatever archive rows it can — some
+    // sessions legitimately yield ZERO (no archivable content, or a malformed
+    // transcript). The old criterion (`archived < message_count`, then
+    // `NOT EXISTS archive`) kept re-qualifying those forever, re-reading their
+    // whole JSONL (read_to_string, 100s of MB) every 5 minutes and pegging the
+    // CPU + churning the FTS index. `mark_unarchivable_sessions_indexed` sets
+    // offset>0 for stuck sessions so they drop out here.
     let mut stmt = conn.prepare(
         "SELECT s.id, s.agent_type, s.jsonl_path
          FROM cc_sessions s
          WHERE s.jsonl_path IS NOT NULL
            AND s.message_count > 0
+           AND s.last_indexed_byte_offset = 0
            AND s.agent_type IN ('claude-code', 'codex')
            AND NOT EXISTS (
              SELECT 1

--- a/apps/desktop/src-tauri/src/db/schema.rs
+++ b/apps/desktop/src-tauri/src/db/schema.rs
@@ -29,6 +29,29 @@ pub fn run_migrations(conn: &Connection) -> Result<(), rusqlite::Error> {
         [],
     );
 
+    // Stop the indexer pegging the CPU on "unarchivable" sessions. A handful of
+    // sessions (malformed / archive-less transcripts — e.g. a 118 MB codex log)
+    // have message_count>0 but produce ZERO archive rows and never get a byte
+    // cursor, so the full index AND the archive backfill re-read their whole
+    // JSONL (100s of MB total, via read_to_string) on EVERY pass — sustained
+    // ~90% CPU that also churns the FTS index. Mark them fully-indexed
+    // (offset = size) so the incremental path treats them as consumed and the
+    // backfill (offset=0 only) excludes them. Idempotent + cheap; if such a file
+    // later grows, file_size > offset re-engages the incremental parser.
+    let _ = conn.execute(
+        "UPDATE cc_sessions
+         SET last_indexed_byte_offset = file_size_bytes,
+             last_indexed_line_count = message_count
+         WHERE message_count > 0
+           AND last_indexed_byte_offset = 0
+           AND file_size_bytes > 0
+           AND agent_type IN ('claude-code', 'codex')
+           AND NOT EXISTS (
+             SELECT 1 FROM session_message_archive a WHERE a.session_id = cc_sessions.id
+           )",
+        [],
+    );
+
     // T-Rex: discovery_method tags findings as 'inspection' (the default,
     // legacy LLM review pass) vs 'execution' (the sandbox runner caught it).
     let _ = conn.execute(

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -59,6 +59,27 @@ fn repair_path_for_gui() {
     log::info!("repair_path_for_gui: prepended {}", prefix.join(":"));
 }
 
+/// Drop the calling thread to macOS *background* QoS. The OS then schedules its
+/// work on efficiency cores and throttles it hard whenever the user is doing
+/// anything else — so the background indexer "feels like it isn't running" even
+/// while it grinds through a large catch-up. No-op off macOS.
+#[cfg(target_os = "macos")]
+fn set_thread_background_qos() {
+    extern "C" {
+        fn pthread_set_qos_class_self_np(
+            qos_class: std::os::raw::c_uint,
+            relative_priority: std::os::raw::c_int,
+        ) -> std::os::raw::c_int;
+    }
+    // QOS_CLASS_BACKGROUND = 0x09
+    unsafe {
+        pthread_set_qos_class_self_np(0x09, 0);
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn set_thread_background_qos() {}
+
 fn main() {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
 
@@ -97,6 +118,7 @@ fn main() {
             std::thread::Builder::new()
                 .name("initial-index".into())
                 .spawn(move || {
+                    set_thread_background_qos();
                     log::info!("Starting quick index on startup...");
                     match run_initial_index(bg_data_dir.clone()) {
                         Ok(msg) => log::info!("Quick index complete: {msg}"),
@@ -140,6 +162,7 @@ fn main() {
             std::thread::Builder::new()
                 .name("periodic-index".into())
                 .spawn(move || {
+                    set_thread_background_qos();
                     std::thread::sleep(std::time::Duration::from_secs(15));
                     loop {
                         log::info!("Periodic re-index starting...");
@@ -202,6 +225,7 @@ fn main() {
             std::thread::Builder::new()
                 .name("transcript-tail".into())
                 .spawn(move || {
+                    set_thread_background_qos();
                     std::thread::sleep(std::time::Duration::from_secs(20));
                     // Grok/Cursor aren't transcript-tailable, so they only
                     // refreshed on the 5-min full index and lagged Claude/Codex.

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-utils/schema.json",
   "identifier": "com.codevetter.desktop",
   "productName": "CodeVetter",
-  "version": "1.1.94",
+  "version": "1.1.95",
   "build": {
     "beforeDevCommand": "npm run dev",
     "beforeBuildCommand": "npm run build",

--- a/apps/desktop/src/pages/Home.tsx
+++ b/apps/desktop/src/pages/Home.tsx
@@ -663,12 +663,24 @@ function TokenUsageChart({
   const [pinned, setPinned] = useState<number | null>(null);
   const data = mode === "daily" ? daily : weekly;
   const max = Math.max(1, ...data.map((d) => d.generated));
-  // Bar HEIGHT uses a log scale so one huge outlier day (e.g. an automated
-  // agent run generating 100s of M) doesn't flatten every normal day into an
-  // invisible sliver. Color/opacity stay on the linear ratio so the peak still
-  // reads as "hot" and normal days as "cool".
-  const logMax = Math.log10(max + 1);
-  const barFrac = (v: number) => (v <= 0 ? 0 : Math.log10(v + 1) / logMax);
+  // Linear scale, but clamped to a robust ceiling (~the busiest *normal* day)
+  // so a single outlier run doesn't flatten every other day into a sliver.
+  // Days above the ceiling clip to full height with a small cap marker. The
+  // ceiling is the ~92nd percentile of non-zero days, floored at a fraction of
+  // the true max so it's never absurdly small.
+  const sortedVals = data
+    .map((d) => d.generated)
+    .filter((v) => v > 0)
+    .sort((a, b) => a - b);
+  const axisMax = sortedVals.length
+    ? Math.max(
+        sortedVals[Math.min(sortedVals.length - 1, Math.floor(sortedVals.length * 0.92))],
+        max * 0.15,
+        1,
+      )
+    : 1;
+  const barFrac = (v: number) => Math.min(1, v / axisMax);
+  const isClipped = (v: number) => v > axisMax;
   const total = data.reduce((acc, d) => acc + d.generated, 0);
   const cacheTotal = data.reduce((acc, d) => acc + d.cache, 0);
   const n = data.length;
@@ -854,8 +866,9 @@ function TokenUsageChart({
           />
         ))}
         {data.map((d, i) => {
-          const h = barFrac(d.generated) * chartH;
-          const ratio = d.generated / max;
+          const ratio = barFrac(d.generated); // clamped 0..1 (linear, capped axis)
+          const h = ratio * chartH;
+          const clipped = isClipped(d.generated);
           const x = padX + i * barW + barW * 0.15;
           const y = padTop + chartH - h;
           const w = barW * 0.7;
@@ -893,6 +906,18 @@ function TokenUsageChart({
                 rx={1}
                 filter={isActive || (isLatest && d.generated > 0) ? "url(#bar-glow)" : undefined}
               />
+              {/* Clip marker: this day exceeds the capped axis (an outlier). */}
+              {clipped && (
+                <rect
+                  x={x}
+                  y={padTop}
+                  width={w}
+                  height={2}
+                  fill="#ffe09a"
+                  pointerEvents="none"
+                  rx={1}
+                />
+              )}
               {isPinned && (
                 <rect
                   x={x}


### PR DESCRIPTION
Profiled the sustained ~99% CPU (1.1.94 didn't fix it). It was **SQLite FTS5 churn** fueled by ~30 "unarchivable" sessions (164 MB, incl. a 118 MB codex log) with messages but **zero** archive rows — they never satisfied the index skip's `archived>0`, so the full index *and* the backfill re-read all 164 MB **every pass forever**.

## Fixes
- **`queries.rs`**: backfill requires `last_indexed_byte_offset = 0` — a session the indexer already read is never re-read, even with 0 archive rows.
- **`schema.rs`**: startup data-fix marks stuck (offset=0, zero-archive) sessions as fully read → drop out of re-parse + backfill.
- **`main.rs`**: indexer threads run at macOS **background QoS** — efficiency cores, yields to the user → "feels like it isn't running" even during catch-up.
- **`Home.tsx`**: chart drops log scale (per request) → clamped-linear axis (~92nd pct ceiling), outliers clip with a marker.

## Verified (optimized release build, real run)
- CPU settles from catch-up peak → idle (vs 1.1.94's permanent 99%); QoS dips show it yielding to foreground.
- 0 sessions with a re-read backlog; FTS in sync; this live session caught up (behind=0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)