### PR TITLE
feat(home): provider telemetry to the top (v1.1.96)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code-reviewer/desktop",
-  "version": "1.1.95",
+  "version": "1.1.96",
   "private": true,
   "scripts": {
     "dev": "lsof -ti:1420 | xargs kill -9 2>/dev/null; vite",

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-utils/schema.json",
   "identifier": "com.codevetter.desktop",
   "productName": "CodeVetter",
-  "version": "1.1.95",
+  "version": "1.1.96",
   "build": {
     "beforeDevCommand": "npm run dev",
     "beforeBuildCommand": "npm run build",

--- a/apps/desktop/src/pages/Home.tsx
+++ b/apps/desktop/src/pages/Home.tsx
@@ -2218,39 +2218,6 @@ export default function Home() {
         </div>
       )}
 
-      {/* Token usage chart */}
-      {tokenUsage && (
-        <div className="cv-frame overflow-hidden">
-          <div className="cv-terminal-bar h-10 px-4">
-            <BarChart3 size={14} className="text-[var(--cv-accent)]" />
-            <span className="cv-label">indexed local token burn</span>
-          </div>
-          <TokenUsageChart
-            daily={tokenUsage.daily_series}
-            weekly={tokenUsage.weekly_series}
-            agentByDay={agentByDay}
-          />
-          <WeeklyAgentSplit />
-        </div>
-      )}
-
-      {/* Activity heatmap + project/model breakdowns */}
-      {(agentByDay.length > 0 || projectUsage.length > 0 || modelUsage.length > 0) && (
-        <div className="cv-frame overflow-hidden">
-          <div className="cv-terminal-bar h-10 px-4">
-            <Activity size={14} className="text-[var(--cv-accent)]" />
-            <span className="cv-label">usage explorer · generated tokens</span>
-          </div>
-          <div className="space-y-5 p-4">
-            <UsageCalendarHeatmap data={agentByDay} />
-            <div className="grid gap-5 md:grid-cols-2">
-              <UsageByProject data={projectUsage} />
-              <UsageByModel data={modelUsage} />
-            </div>
-          </div>
-        </div>
-      )}
-
       {/* Usage — remaining per account */}
       <div className="cv-frame overflow-hidden">
         <div className="cv-terminal-bar h-10 px-4">
@@ -2352,6 +2319,39 @@ export default function Home() {
           </Card>
         )}
       </div>
+
+      {/* Token usage chart */}
+      {tokenUsage && (
+        <div className="cv-frame overflow-hidden">
+          <div className="cv-terminal-bar h-10 px-4">
+            <BarChart3 size={14} className="text-[var(--cv-accent)]" />
+            <span className="cv-label">indexed local token burn</span>
+          </div>
+          <TokenUsageChart
+            daily={tokenUsage.daily_series}
+            weekly={tokenUsage.weekly_series}
+            agentByDay={agentByDay}
+          />
+          <WeeklyAgentSplit />
+        </div>
+      )}
+
+      {/* Activity heatmap + project/model breakdowns */}
+      {(agentByDay.length > 0 || projectUsage.length > 0 || modelUsage.length > 0) && (
+        <div className="cv-frame overflow-hidden">
+          <div className="cv-terminal-bar h-10 px-4">
+            <Activity size={14} className="text-[var(--cv-accent)]" />
+            <span className="cv-label">usage explorer · generated tokens</span>
+          </div>
+          <div className="space-y-5 p-4">
+            <UsageCalendarHeatmap data={agentByDay} />
+            <div className="grid gap-5 md:grid-cols-2">
+              <UsageByProject data={projectUsage} />
+              <UsageByModel data={modelUsage} />
+            </div>
+          </div>
+        </div>
+      )}
 
       </div>
     </div>


### PR DESCRIPTION
Per request: the live provider/plan usage (remaining 5h/7d windows) now sits at the top of the dashboard, above the token chart + usage explorer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)