### PR TITLE
fix(perf): stop indexer re-parsing subagent transcripts every pass (v1.1.98)

### DIFF
--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -1,6 +1,6 @@
 # Project Status
 
-Last updated: 2026-06-12
+Last updated: 2026-06-21
 
 ## Current Scope
 
@@ -10,6 +10,7 @@ CodeVetter is a local-first desktop workbench for checking agent-generated code.
 
 - Desktop app and local workflow foundation are in place, with repo unpacking, review entry points, and local-first positioning documented in the README.
 - **Rust/Tauri backend cleanup (2026-06-20):** feature-gated `chromiumoxide` for optional live-browser agent work; pruned dead crates/deps; parallelized review paths for slimmer default builds when browser automation is off.
+- **Indexer CPU fix (v1.1.98, 2026-06-21):** killed the sustained ~95%-of-a-core background indexer burn. Root cause (found by profiling + replaying the indexer over a live-DB copy): subagent sidechain transcripts shared the parent's `sessionId`, collapsing onto one DB row so each was re-parsed + archive-replaced every pass; the skip also compared drift-prone nanosecond mtime strings. Fix: skip on exact byte-offset==file-size, key sidechains by unique per-file id, migrate the offset backlog, and repair the FTS sync's UUID handling. Verified: steady-state index pass 87s→1.9s. Guarded by new evals in `history.rs`/`queries.rs`.
 - Bug finding and code review are the primary implemented workflows.
 - Review replay prototypes were added for synthetic QA and intent debugging, including `/qa-replay` and `/intent-debugger` routes.
 - Risk-tiered specialist review is implemented in the CLI review path: trivial single pass, lite product/agent passes, full sensitive reviews with security/product/agent passes plus coordinator/dedupe metadata.

--- a/apps/desktop/src-tauri/src/commands/history.rs
+++ b/apps/desktop/src-tauri/src/commands/history.rs
@@ -310,6 +310,23 @@ pub async fn trigger_index(app: AppHandle) -> Result<Value, String> {
 }
 
 /// Shared implementation for the full indexer.
+/// Whether the indexer can skip a session file without re-parsing it: it has
+/// messages and the byte cursor has consumed *exactly* the file's current size,
+/// so nothing has been appended.
+///
+/// This keys on byte offset, NOT the file mtime. The old skip compared stored
+/// vs freshly-recomputed mtime strings, but their sub-microsecond nanoseconds
+/// drift between reads of the same unchanged inode — so the skip silently failed
+/// and hundreds of large sessions were fully re-parsed (and their archive rows
+/// DELETE+re-INSERTed) on every 5-minute pass, pegging one core. Byte offset is
+/// exact: equal ⇒ nothing new; smaller ⇒ file grew (parse the tail); larger ⇒
+/// file shrank/rotated (full re-parse).
+fn session_fully_indexed(meta: &queries::SessionMeta, file_size: i64) -> bool {
+    meta.message_count > 0
+        && meta.last_indexed_byte_offset > 0
+        && meta.last_indexed_byte_offset == file_size
+}
+
 fn full_index_impl(conn: &rusqlite::Connection) -> Result<(u64, u64, u64), String> {
     let all_bases = resolve_all_claude_projects_dirs();
     let index_started_at = chrono::Utc::now().to_rfc3339();
@@ -384,22 +401,18 @@ fn full_index_impl(conn: &rusqlite::Connection) -> Result<(u64, u64, u64), Strin
 
                 // ── Incremental check ────────────────────────────────
                 let file_meta = std::fs::metadata(jsonl_path).ok();
-                let file_mtime_str = file_meta
-                    .as_ref()
-                    .and_then(|m| m.modified().ok())
-                    .map(|t| chrono::DateTime::<chrono::Utc>::from(t).to_rfc3339());
+                let file_size = file_meta.as_ref().map(|m| m.len() as i64).unwrap_or(0);
 
                 let existing = queries::get_session_by_jsonl_path(&conn, &jsonl_path_str)
                     .map_err(|e| e.to_string())?;
 
-                // If the file mtime is unchanged AND the session already has
-                // messages, skip it.  Sessions with 0 messages (from the quick
-                // startup index) always need a full parse.
+                // Skip when the indexer has already consumed the whole file: the
+                // cursor reached EOF (offset == current size) and the file has
+                // not grown. Byte offset is an EXACT signal — the old mtime-string
+                // check silently failed because stored vs recomputed nanoseconds
+                // drift, re-parsing 100s of MB every pass and pegging the CPU.
                 if let Some(ref meta) = existing {
-                    if meta.file_mtime.as_deref() == file_mtime_str.as_deref()
-                        && meta.message_count > 0
-                        && meta.archived_message_count > 0
-                    {
+                    if session_fully_indexed(meta, file_size) {
                         skipped_sessions += 1;
                         continue;
                     }
@@ -474,20 +487,16 @@ fn full_index_impl(conn: &rusqlite::Connection) -> Result<(u64, u64, u64), Strin
             let jsonl_path_str = jsonl_path.to_string_lossy().to_string();
 
             // ── Incremental check ────────────────────────────
+            // Skip fully-consumed unchanged files via exact byte offset (see the
+            // Claude phase above for why mtime strings are unreliable).
             let file_meta = std::fs::metadata(jsonl_path).ok();
-            let file_mtime_str = file_meta
-                .as_ref()
-                .and_then(|m| m.modified().ok())
-                .map(|t| chrono::DateTime::<chrono::Utc>::from(t).to_rfc3339());
+            let file_size = file_meta.as_ref().map(|m| m.len() as i64).unwrap_or(0);
 
             let existing = queries::get_session_by_jsonl_path(&conn, &jsonl_path_str)
                 .map_err(|e| e.to_string())?;
 
             if let Some(ref meta) = existing {
-                if meta.file_mtime.as_deref() == file_mtime_str.as_deref()
-                    && meta.message_count > 0
-                    && meta.archived_message_count > 0
-                {
+                if session_fully_indexed(meta, file_size) {
                     skipped_sessions += 1;
                     continue;
                 }
@@ -2799,5 +2808,121 @@ mod tests {
         );
         // Non-encoded input is returned unchanged.
         assert_eq!(percent_decode_path("plain-name"), "plain-name");
+    }
+
+    // Diagnostic (not a CI eval): runs the real indexer against a COPY of the
+    // live DB twice. Pass 2 is steady state — it must skip ~everything and be
+    // fast. Run with: cargo test --bin codevetter-desktop diag_live_index -- --ignored --nocapture
+    #[test]
+    #[ignore]
+    fn diag_mtime_skip_mismatch() {
+        // For every session in the live copy, compare the STORED file_mtime with
+        // what the indexer recomputes from the file on disk. Any mismatch on an
+        // unchanged file means the mtime-skip can never fire → perpetual reparse.
+        let path = "/tmp/cv_live_copy.db";
+        if !std::path::Path::new(path).exists() {
+            eprintln!("SKIP: {path} not present");
+            return;
+        }
+        let conn = Connection::open(path).expect("open");
+        let mut stmt = conn
+            .prepare("SELECT jsonl_path, file_mtime FROM cc_sessions WHERE jsonl_path IS NOT NULL AND file_mtime IS NOT NULL")
+            .unwrap();
+        let rows: Vec<(String, String)> = stmt
+            .query_map([], |r| Ok((r.get(0)?, r.get(1)?)))
+            .unwrap()
+            .filter_map(|r| r.ok())
+            .collect();
+        let mut checked = 0;
+        let mut mismatch = 0;
+        let mut shown = 0;
+        for (p, stored) in &rows {
+            let meta = match std::fs::metadata(p) {
+                Ok(m) => m,
+                Err(_) => continue,
+            };
+            let recomputed = meta
+                .modified()
+                .ok()
+                .map(|t| chrono::DateTime::<chrono::Utc>::from(t).to_rfc3339());
+            checked += 1;
+            if recomputed.as_deref() != Some(stored.as_str()) {
+                mismatch += 1;
+                if shown < 8 {
+                    eprintln!("MISMATCH stored={stored:?} recomputed={recomputed:?}");
+                    shown += 1;
+                }
+            }
+        }
+        eprintln!("checked={checked} mismatch={mismatch}");
+    }
+
+    #[test]
+    #[ignore]
+    fn diag_live_index_steady_state() {
+        let path = "/tmp/cv_live_copy.db";
+        if !std::path::Path::new(path).exists() {
+            eprintln!("SKIP: {path} not present");
+            return;
+        }
+        let conn = Connection::open(path).expect("open live copy");
+        schema::run_migrations(&conn).expect("migrate");
+
+        for pass in 1..=2 {
+            let t0 = std::time::Instant::now();
+            let s = run_full_index_summary_with_conn(&conn).expect("index pass");
+            let dt = t0.elapsed();
+            eprintln!(
+                "PASS {pass}: {:?} in {:.1}s — indexed={} skipped={} msgs={} fts_rows={}",
+                "ok",
+                dt.as_secs_f64(),
+                s.indexed_sessions,
+                s.skipped_sessions,
+                s.indexed_messages,
+                s.archive_search_rows_indexed,
+            );
+        }
+    }
+
+    #[test]
+    fn eval_skip_keys_on_byte_offset_not_mtime() {
+        // The index-skip decision must depend ONLY on byte offset vs file size —
+        // never on the file mtime string (whose nanoseconds drift between reads
+        // and silently disabled the old skip, re-parsing 100s of MB every pass).
+        let meta = |msgs: i64, offset: i64| queries::SessionMeta {
+            id: "s".to_string(),
+            // A deliberately "stale"/garbage mtime: it must not affect the result.
+            file_mtime: Some("1999-01-01T00:00:00.000000001+00:00".to_string()),
+            message_count: msgs,
+            archived_message_count: 0, // some sessions legitimately archive nothing
+            total_input_tokens: 0,
+            last_indexed_byte_offset: offset,
+        };
+
+        // Cursor at EOF → SKIP, regardless of the mismatched mtime or zero archive.
+        assert!(session_fully_indexed(&meta(5, 1000), 1000));
+        // File grew (size > offset) → must re-index the appended tail.
+        assert!(!session_fully_indexed(&meta(5, 1000), 2000));
+        // Never cursored (offset 0) → must index once.
+        assert!(!session_fully_indexed(&meta(5, 0), 0));
+        // File shrank/rotated (size < offset) → must re-parse.
+        assert!(!session_fully_indexed(&meta(5, 1000), 500));
+        // No messages yet (quick-startup stub) → must do a full parse.
+        assert!(!session_fully_indexed(&meta(0, 1000), 1000));
+    }
+
+    #[test]
+    fn eval_estimate_cost_uses_current_prices() {
+        let near = |a: f64, b: f64| (a - b).abs() < 1e-6;
+        // Opus 4.6+ is $5/$25 per 1M — NOT the old $15/$75. This guards against
+        // a stale price table inflating the headline $ (the "$49K Claude" bug).
+        assert!(near(estimate_cost("claude-opus-4-8", 1_000_000, 0, 0, 0), 5.0));
+        assert!(near(estimate_cost("claude-opus-4-8", 0, 1_000_000, 0, 0), 25.0));
+        // Cache reads bill at 0.1× input ($0.50/1M for Opus).
+        assert!(near(estimate_cost("claude-opus-4-8", 1_000_000, 0, 1_000_000, 0), 0.50));
+        // Haiku 4.5 is $1/$5 (not the old $0.25/$1.25).
+        assert!(near(estimate_cost("claude-haiku-4-5-20251001", 1_000_000, 0, 0, 0), 1.0));
+        // OpenAI o3 (codex) is $2/$8.
+        assert!(near(estimate_cost("o3", 1_000_000, 0, 0, 0), 2.0));
     }
 }

--- a/apps/desktop/src-tauri/src/commands/session_adapters.rs
+++ b/apps/desktop/src-tauri/src/commands/session_adapters.rs
@@ -281,6 +281,14 @@ impl SessionSourceAdapter for ClaudeCodeAdapter {
 
     fn parse_raw(&self, source_ref: &str, raw: &str) -> RawSessionAdapterSummary {
         let mut summary = empty_summary(self.adapter_id(), self.agent_type(), source_ref);
+        // Subagent/sidechain transcripts (one file per Task sub-run, under
+        // `<session>/subagents/`) carry the PARENT session's `sessionId`. Keyed
+        // by that, every sidechain of a session collapses onto one DB row whose
+        // path is the parent's — so the per-file path never matches on lookup and
+        // the indexer full-reparses + DELETE/re-INSERTs their archive on EVERY
+        // pass (profiled to ~95% of a core). Track it and key sidechains by their
+        // own path below so each indexes once and is then skipped.
+        let mut is_sidechain = false;
 
         for (idx, line) in raw.lines().enumerate() {
             let line = line.trim();
@@ -326,6 +334,13 @@ impl SessionSourceAdapter for ClaudeCodeAdapter {
                 summary.compaction_count += 1;
             }
 
+            if parsed
+                .get("isSidechain")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false)
+            {
+                is_sidechain = true;
+            }
             if summary.stable_id.is_none() {
                 summary.stable_id = value_string(Some(&parsed), "sessionId");
             }
@@ -399,6 +414,14 @@ impl SessionSourceAdapter for ClaudeCodeAdapter {
             }
 
             summary.message_count += 1;
+        }
+
+        // Sidechains: replace the parent-shared sessionId with a path-unique id so
+        // each subagent transcript is its own session row (found by path on the
+        // next pass → skipped, not re-parsed). Deterministic, so re-indexing the
+        // same file is stable.
+        if is_sidechain {
+            summary.stable_id = Some(format!("sidechain::{source_ref}"));
         }
 
         if summary.stable_id.is_none() {

--- a/apps/desktop/src-tauri/src/db/queries.rs
+++ b/apps/desktop/src-tauri/src/db/queries.rs
@@ -353,6 +353,10 @@ pub struct SessionMeta {
     pub message_count: i64,
     pub archived_message_count: i64,
     pub total_input_tokens: i64,
+    /// Byte offset the indexer has consumed up to. When this equals the file's
+    /// current size the file is fully indexed and can be skipped — an exact,
+    /// precision-free signal (unlike mtime strings, whose nanoseconds drift).
+    pub last_indexed_byte_offset: i64,
 }
 
 #[derive(Debug, Clone)]
@@ -382,7 +386,7 @@ pub fn get_session_by_jsonl_path(
     conn.query_row(
         "SELECT id, file_mtime, message_count,
                 (SELECT COUNT(*) FROM session_message_archive a WHERE a.session_id = cc_sessions.id),
-                total_input_tokens
+                total_input_tokens, last_indexed_byte_offset
          FROM cc_sessions
          WHERE jsonl_path = ?1",
         params![jsonl_path],
@@ -393,6 +397,7 @@ pub fn get_session_by_jsonl_path(
                 message_count: row.get(2)?,
                 archived_message_count: row.get(3)?,
                 total_input_tokens: row.get(4)?,
+                last_indexed_byte_offset: row.get(5)?,
             })
         },
     )
@@ -980,13 +985,15 @@ pub fn sync_session_message_archive_fts(conn: &Connection) -> Result<i64, rusqli
         return Ok(0);
     }
 
-    // Incremental sync. The old code DELETE'd and re-INSERT'd the ENTIRE FTS
-    // table on any count change — with 300k+ archive rows that's a multi-second
-    // CPU burn on every index pass that adds a single message (and the backfill
-    // pass re-triggered it constantly). Instead insert only rows past the FTS
-    // high-water mark (archive ids are monotonic) — O(new rows). Fall back to a
-    // full rebuild only when FTS has *more* rows than the archive (rows were
-    // deleted / a session re-indexed), so stale FTS entries get cleared.
+    // Repair sync. FTS is normally kept in step with the base table inside the
+    // same transaction (see `insert_archive_rows`), so the equal-count early
+    // return above is the steady-state path and this body almost never runs.
+    // The old code DELETE'd and re-INSERT'd the ENTIRE FTS table on any count
+    // mismatch — with 300k+ rows that's a multi-second CPU burn, and the
+    // backfill pass used to re-trigger it constantly.
+    //
+    // Only fall back to a full rebuild when FTS has *more* rows than the archive
+    // (rows were deleted / a session re-indexed), so stale FTS entries clear.
     if fts_count > archive_count {
         conn.execute("DELETE FROM session_message_archive_fts", [])?;
         return conn
@@ -1003,11 +1010,10 @@ pub fn sync_session_message_archive_fts(conn: &Connection) -> Result<i64, rusqli
             .map(|rows| rows as i64);
     }
 
-    let max_fts_id: i64 = conn.query_row(
-        "SELECT COALESCE(MAX(archive_id), 0) FROM session_message_archive_fts",
-        [],
-        |row| row.get(0),
-    )?;
+    // Archive ids are random UUIDs (TEXT), NOT a monotonic sequence, so a numeric
+    // high-water mark is wrong — `MAX(archive_id)` read as an int errors on a real
+    // UUID, and `a.id > <int>` compares TEXT against INTEGER. Insert exactly the
+    // archive rows that are missing from FTS instead (set difference on id).
     conn.execute(
         "INSERT INTO session_message_archive_fts (
             archive_id, session_id, adapter_id, agent_type, role, kind,
@@ -1016,8 +1022,10 @@ pub fn sync_session_message_archive_fts(conn: &Connection) -> Result<i64, rusqli
          SELECT a.id, a.session_id, a.adapter_id, a.agent_type, a.role, a.kind,
                 a.content_text, a.tool_name, a.source_ref
          FROM session_message_archive a
-         WHERE a.id > ?1",
-        params![max_fts_id],
+         WHERE NOT EXISTS (
+             SELECT 1 FROM session_message_archive_fts f WHERE f.archive_id = a.id
+         )",
+        [],
     )
     .map(|rows| rows as i64)
 }
@@ -2780,5 +2788,162 @@ mod tests {
             search_session_message_archive(&conn, "checkout local", Some("codex"), None, 10)
                 .expect("search rebuilt");
         assert_eq!(rebuilt_rows.len(), 1);
+    }
+
+    // ─── Indexer-CPU regression evals ────────────────────────────────────
+    // These pin the "steady-state does no work" guarantees. The ~90% CPU bug
+    // was the indexer re-doing O(everything) work on every 5-min pass: a full
+    // FTS rebuild on any change, and re-reading sessions that yield no archive
+    // rows forever. If either guarantee regresses, these fail.
+
+    fn eval_seed_session(conn: &Connection, id: &str, msgs: i64) {
+        upsert_project(
+            conn,
+            &ProjectInput {
+                id: "eval-p".to_string(),
+                display_name: "Eval".to_string(),
+                dir_path: "/eval".to_string(),
+                session_count: None,
+                last_activity: None,
+                created_at: "2026-01-01T00:00:00Z".to_string(),
+            },
+        )
+        .ok();
+        upsert_session(
+            conn,
+            &SessionInput {
+                id: id.to_string(),
+                project_id: "eval-p".to_string(),
+                agent_type: Some("claude-code".to_string()),
+                jsonl_path: Some(format!("/eval/{id}.jsonl")),
+                git_branch: None,
+                cwd: None,
+                cli_version: None,
+                first_message: None,
+                last_message: Some("2026-06-20T00:00:00Z".to_string()),
+                message_count: Some(msgs),
+                total_input_tokens: Some(1000),
+                total_output_tokens: Some(100),
+                model_used: Some("claude-opus-4-8".to_string()),
+                slug: None,
+                file_size_bytes: Some(1000),
+                indexed_at: None,
+                file_mtime: Some("2026-06-20T00:00:00Z".to_string()),
+                cache_read_tokens: Some(0),
+                cache_creation_tokens: Some(0),
+                compaction_count: Some(0),
+                estimated_cost_usd: Some(0.0),
+            },
+        )
+        .expect("eval seed session");
+    }
+
+    fn eval_archive_row(idx: i64, text: &str) -> SessionMessageArchiveInput {
+        SessionMessageArchiveInput {
+            adapter_id: "claude-code".to_string(),
+            agent_type: "claude-code".to_string(),
+            source_ref: "/eval/a.jsonl".to_string(),
+            source_line: Some(idx),
+            message_index: idx,
+            role: Some("user".to_string()),
+            kind: "message".to_string(),
+            timestamp: Some("2026-06-20T00:00:00Z".to_string()),
+            content_text: Some(text.to_string()),
+            tool_name: None,
+            tool_call_id: None,
+            raw_type: Some("message".to_string()),
+        }
+    }
+
+    #[test]
+    fn eval_fts_sync_is_noop_in_steady_state_and_repairs_correctly() {
+        // FTS is mirrored at write-time, so once archived a sync must do ZERO
+        // work (the anti-CPU-loop guarantee). When FTS *does* drift, the repair
+        // must touch only the diff — and must work with TEXT/UUID archive ids
+        // (an earlier numeric high-water-mark repair errored on real UUIDs).
+        let conn = Connection::open_in_memory().expect("memory db");
+        schema::run_migrations(&conn).expect("schema");
+
+        eval_seed_session(&conn, "s1", 2);
+        replace_session_message_archive(
+            &conn,
+            "s1",
+            &[eval_archive_row(0, "alpha"), eval_archive_row(1, "beta")],
+        )
+        .expect("archive s1");
+
+        // Write-time mirroring means the table is already in sync: a sync is a
+        // pure no-op. This is the path that runs on every 5-min index pass.
+        assert_eq!(
+            sync_session_message_archive_fts(&conn).expect("steady-state sync"),
+            0,
+            "a steady-state FTS sync must do no work"
+        );
+
+        // Simulate drift: one FTS row goes missing (archive=2, fts=1). The
+        // repair must re-insert exactly the one missing row — not rebuild both,
+        // and not error on the UUID id.
+        conn.execute(
+            "DELETE FROM session_message_archive_fts
+             WHERE archive_id IN (SELECT archive_id FROM session_message_archive_fts LIMIT 1)",
+            [],
+        )
+        .expect("drop one fts row");
+        assert_eq!(
+            sync_session_message_archive_fts(&conn).expect("repair sync"),
+            1,
+            "repair must re-index exactly the missing row (UUID-id safe)"
+        );
+        assert_eq!(sync_session_message_archive_fts(&conn).expect("settled"), 0);
+
+        // Stale FTS rows (fts > archive) trigger a clean full rebuild.
+        conn.execute(
+            "INSERT INTO session_message_archive_fts
+                (archive_id, session_id, adapter_id, agent_type, role, kind,
+                 content_text, tool_name, source_ref)
+             VALUES ('stale-id','s1','claude-code','claude-code','user','message',
+                     'orphan',NULL,'/eval/a.jsonl')",
+            [],
+        )
+        .expect("inject stale fts row");
+        assert_eq!(
+            sync_session_message_archive_fts(&conn).expect("rebuild sync"),
+            2,
+            "an over-full FTS must be rebuilt to match the archive exactly"
+        );
+        assert_eq!(sync_session_message_archive_fts(&conn).expect("settled2"), 0);
+    }
+
+    #[test]
+    fn eval_backfill_never_re_reads_cursored_or_archived_sessions() {
+        // The backfill must target ONLY never-cursored, zero-archive sessions.
+        // A session the indexer has already read (cursor set) — even one that
+        // yields no archive rows — must never re-qualify, or it gets its whole
+        // JSONL re-read every pass forever.
+        let conn = Connection::open_in_memory().expect("memory db");
+        schema::run_migrations(&conn).expect("schema");
+
+        // Un-cursored + no archive → genuinely needs one backfill.
+        eval_seed_session(&conn, "fresh", 5);
+        let needy = list_sessions_needing_archive_backfill(&conn, 100).expect("list");
+        assert!(
+            needy.iter().any(|c| c.id == "fresh"),
+            "un-cursored zero-archive session should need a backfill"
+        );
+
+        // Once cursored, it must drop out even though it has no archive rows.
+        set_session_index_cursor(&conn, "fresh", 4096, 5).expect("cursor");
+        let after = list_sessions_needing_archive_backfill(&conn, 100).expect("list2");
+        assert!(
+            !after.iter().any(|c| c.id == "fresh"),
+            "a cursored session must NOT be re-read (this was the ~90% CPU bug)"
+        );
+
+        // A session that already has archive rows is excluded too.
+        eval_seed_session(&conn, "done", 2);
+        replace_session_message_archive(&conn, "done", &[eval_archive_row(0, "x")])
+            .expect("archive done");
+        let final_list = list_sessions_needing_archive_backfill(&conn, 100).expect("list3");
+        assert!(!final_list.iter().any(|c| c.id == "done"));
     }
 }

--- a/apps/desktop/src-tauri/src/db/schema.rs
+++ b/apps/desktop/src-tauri/src/db/schema.rs
@@ -52,6 +52,25 @@ pub fn run_migrations(conn: &Connection) -> Result<(), rusqlite::Error> {
         [],
     );
 
+    // v1.1.98: the same CPU bug bit ALREADY-archived sessions too. The index
+    // skip used to compare stored vs recomputed file mtime *strings*, whose
+    // sub-microsecond nanoseconds drift between reads of the very same inode —
+    // so the skip silently failed and ~800 sessions got fully re-parsed and
+    // their archive DELETE+re-INSERTed every pass (profiled to replace_archive
+    // _messages → sqlite3_step at ~95% of one core). The skip now keys on exact
+    // byte offset == file size, so give every already-indexed session a cursor
+    // at its current size. Idempotent; a grown file (size > offset) re-engages
+    // the incremental tail parser next pass.
+    let _ = conn.execute(
+        "UPDATE cc_sessions
+         SET last_indexed_byte_offset = file_size_bytes,
+             last_indexed_line_count = message_count
+         WHERE message_count > 0
+           AND last_indexed_byte_offset = 0
+           AND file_size_bytes > 0",
+        [],
+    );
+
     // T-Rex: discovery_method tags findings as 'inspection' (the default,
     // legacy LLM review pass) vs 'execution' (the sandbox runner caught it).
     let _ = conn.execute(

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-utils/schema.json",
   "identifier": "com.codevetter.desktop",
   "productName": "CodeVetter",
-  "version": "1.1.97",
+  "version": "1.1.98",
   "build": {
     "beforeDevCommand": "npm run dev",
     "beforeBuildCommand": "npm run build",


### PR DESCRIPTION
## Problem
The background session indexer sat at a sustained ~95% of a CPU core (felt across 1.1.91–1.1.97). The shipped 1.1.97 QoS build did **not** fix it — wrong code path.

## Root cause (profiled, not guessed)
Found by `sample`-ing the live process and replaying the indexer over a copy of the real DB (steady-state pass **87s → 1.9s** after the fix):

1. **Subagent/sidechain collapse (dominant).** `<session>/subagents/agent-*.jsonl` transcripts carry the *parent* session's `sessionId`. The Claude adapter keyed sessions by `sessionId`, so ~550 subagent files collapsed onto their parents' DB rows, were never found by their own path on lookup, and got full-reparsed + archive DELETE/re-INSERTed **every pass** (519 MB of churn).
2. **Nanosecond mtime-skip.** The skip compared file-mtime *strings* whose sub-microsecond nanoseconds drift between reads of the same inode → silently failed.

## Fix
- Key sidechains by a unique per-file `stable_id` (`sidechain::<path>`) so each indexes once then skips.
- Skip on exact `byte offset == file size` via new `session_fully_indexed()` (precision-free); add `SessionMeta.last_indexed_byte_offset`.
- Migration cursors the offset=0 backlog so it drains instantly.
- FTS repair sync no longer uses a numeric high-water mark on UUID archive ids.

## Verification
- Replay over real DB: steady-state pass **87s → 1.9s**.
- Installed build watched live: steady-state CPU **~95% → ~0%**.
- 193 Rust tests pass, incl. 4 new evals guarding these invariants.

## Note
Subagent transcripts now count as their own sessions (more accurate totals; possibly higher). Can be hidden from the dashboard as a follow-up if noisy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)