### PR TITLE
chore: update repository ownership references

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Give your coding agent this prompt:
 
 ```text
 Install CodeVetter from the latest GitHub release:
-https://github.com/sarthak-fleet/CodeVetter/releases/latest
+https://github.com/Codevetter/codevetter/releases/latest
 
 Detect this machine's OS and CPU architecture, download the matching CodeVetter app archive, verify the release asset hash when available, extract it, install CodeVetter.app into /Applications on macOS, remove the quarantine attribute if needed, and launch the app once to verify it starts.
 ```
@@ -63,7 +63,7 @@ Prefer the app archive over the DMG until the macOS bundle is Developer ID signe
 
 ```bash
 # Clone and install dependencies (uses npm workspaces)
-git clone https://github.com/sarthak-fleet/CodeVetter.git
+git clone https://github.com/Codevetter/codevetter.git
 cd CodeVetter
 npm install
 ```

--- a/apps/desktop/docs/RELEASING.md
+++ b/apps/desktop/docs/RELEASING.md
@@ -32,7 +32,7 @@
 
    Prefer the app archive for manual installs until the macOS bundle is Developer ID signed and notarized. Unsigned or ad-hoc signed DMGs fail Gatekeeper for new installs.
 
-4. Create a GitHub release at `sarthak-fleet/CodeVetter`:
+4. Create a GitHub release at `Codevetter/codevetter`:
    - Tag: `v{x.y.z}`
    - Upload all build artifacts including `latest.json`
 

--- a/apps/desktop/src-tauri/src/commands/saas_maker.rs
+++ b/apps/desktop/src-tauri/src/commands/saas_maker.rs
@@ -1042,40 +1042,40 @@ mod tests {
     #[test]
     fn normalizes_https_with_dot_git() {
         assert_eq!(
-            normalize_git_url("https://github.com/sarthak-fleet/CodeVetter.git"),
-            "github.com/sarthak-fleet/codevetter"
+            normalize_git_url("https://github.com/Codevetter/codevetter.git"),
+            "github.com/Codevetter/codevetter"
         );
     }
 
     #[test]
     fn normalizes_https_without_dot_git() {
         assert_eq!(
-            normalize_git_url("https://github.com/sarthak-fleet/CodeVetter"),
-            "github.com/sarthak-fleet/codevetter"
+            normalize_git_url("https://github.com/Codevetter/codevetter"),
+            "github.com/Codevetter/codevetter"
         );
     }
 
     #[test]
     fn normalizes_ssh_form() {
         assert_eq!(
-            normalize_git_url("git@github.com:sarthak-fleet/CodeVetter.git"),
-            "github.com/sarthak-fleet/codevetter"
+            normalize_git_url("git@github.com:Codevetter/codevetter.git"),
+            "github.com/Codevetter/codevetter"
         );
     }
 
     #[test]
     fn normalizes_ssh_form_with_user_and_port() {
         assert_eq!(
-            normalize_git_url("ssh://git@github.com/sarthak-fleet/CodeVetter.git"),
-            "github.com/sarthak-fleet/codevetter"
+            normalize_git_url("ssh://git@github.com/Codevetter/codevetter.git"),
+            "github.com/Codevetter/codevetter"
         );
     }
 
     #[test]
     fn normalizes_trailing_slash_and_casing() {
         assert_eq!(
-            normalize_git_url("https://GitHub.com/Sarthak-FLEET/CodeVetter/"),
-            "github.com/sarthak-fleet/codevetter"
+            normalize_git_url("https://GitHub.com/Codevetter/codevetter/"),
+            "github.com/Codevetter/codevetter"
         );
     }
 
@@ -1100,10 +1100,10 @@ mod tests {
                 name: "CodeVetter".into(),
                 slug: Some("codevetter".into()),
                 source: None,
-                git_url: Some("git@github.com:sarthak-fleet/CodeVetter.git".into()),
+                git_url: Some("git@github.com:Codevetter/codevetter.git".into()),
             },
         ];
-        let local = "https://github.com/sarthak-fleet/CodeVetter";
+        let local = "https://github.com/Codevetter/codevetter";
         let m = match_project_by_url(local, &projects);
         assert!(m.is_some());
         assert_eq!(m.unwrap().slug.as_deref(), Some("codevetter"));

--- a/apps/desktop/src-tauri/src/commands/trex_watcher.rs
+++ b/apps/desktop/src-tauri/src/commands/trex_watcher.rs
@@ -737,11 +737,11 @@ mod tests {
     #[test]
     fn owner_repo_from_https() {
         assert_eq!(
-            parse_owner_repo("https://github.com/sarthak-fleet/CodeVetter.git"),
+            parse_owner_repo("https://github.com/Codevetter/codevetter.git"),
             Some(("sarthak-fleet".into(), "CodeVetter".into()))
         );
         assert_eq!(
-            parse_owner_repo("https://github.com/sarthak-fleet/CodeVetter"),
+            parse_owner_repo("https://github.com/Codevetter/codevetter"),
             Some(("sarthak-fleet".into(), "CodeVetter".into()))
         );
     }
@@ -749,7 +749,7 @@ mod tests {
     #[test]
     fn owner_repo_from_ssh() {
         assert_eq!(
-            parse_owner_repo("git@github.com:sarthak-fleet/CodeVetter.git"),
+            parse_owner_repo("git@github.com:Codevetter/codevetter.git"),
             Some(("sarthak-fleet".into(), "CodeVetter".into()))
         );
     }

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -29,7 +29,7 @@
     "updater": {
       "active": true,
       "endpoints": [
-        "https://github.com/sarthak-fleet/CodeVetter/releases/latest/download/latest.json"
+        "https://github.com/Codevetter/codevetter/releases/latest/download/latest.json"
       ],
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDI4Q0JDRTlBNDRCRkEzNTkKUldSWm83OUVtczdMS05wTzZHN0tWVEdJTzdyT3N1S2Q2aE43SUE0dHU5a2dSV05vU1NQRUdxdGsK",
       "dialog": false

--- a/apps/landing-page-astro/public/llms.txt
+++ b/apps/landing-page-astro/public/llms.txt
@@ -14,8 +14,8 @@ Open source (ISC). macOS desktop app with optional Claude, Codex, or Gemini CLI 
 
 ## Docs
 
-- [README](https://github.com/sarthak-fleet/CodeVetter#readme): Architecture, desktop app setup, and product direction
-- [Releases](https://github.com/sarthak-fleet/CodeVetter/releases): Changelog and binaries
+- [README](https://github.com/Codevetter/codevetter#readme): Architecture, desktop app setup, and product direction
+- [Releases](https://github.com/Codevetter/codevetter/releases): Changelog and binaries
 
 ## Optional
 

--- a/apps/landing-page-astro/src/components/CTA.astro
+++ b/apps/landing-page-astro/src/components/CTA.astro
@@ -31,7 +31,7 @@ import Icon from './Icon.astro';
 
         <div class="mt-12 flex flex-wrap items-center justify-center gap-4">
           <a
-            href="https://github.com/sarthak-fleet/CodeVetter/releases/latest"
+            href="https://github.com/Codevetter/codevetter/releases/latest"
             class="group inline-flex items-center gap-2 h-14 px-8 text-sm font-medium bg-white text-black hover:bg-gray-100 shadow-[0_0_20px_rgba(255,255,255,0.2)] hover:shadow-[0_0_30px_rgba(255,255,255,0.4)] transition-all duration-300 rounded-full"
           >
             <Icon name="apple" class="w-5 h-5" width={20} height={20} />
@@ -39,7 +39,7 @@ import Icon from './Icon.astro';
             <Icon name="arrow-right" class="w-4 h-4 transition-transform group-hover:translate-x-1" width={16} height={16} />
           </a>
           <a
-            href="https://github.com/sarthak-fleet/CodeVetter/releases/latest"
+            href="https://github.com/Codevetter/codevetter/releases/latest"
             class="group inline-flex items-center gap-2 h-14 px-8 text-sm font-medium bg-white/5 border border-white/10 text-white backdrop-blur-md hover:bg-white/10 hover:border-white/20 shadow-lg transition-all duration-300 rounded-full"
           >
             Other Platforms

--- a/apps/landing-page-astro/src/components/FAQ.astro
+++ b/apps/landing-page-astro/src/components/FAQ.astro
@@ -30,7 +30,7 @@ const faqs = [
   },
   {
     q: 'Is CodeVetter open source?',
-    a: 'The source is on GitHub at github.com/sarthak-fleet/CodeVetter. Releases are built via GitHub Actions with Tauri for macOS, Windows, and Linux.',
+    a: 'The source is on GitHub at github.com/Codevetter/codevetter. Releases are built via GitHub Actions with Tauri for macOS, Windows, and Linux.',
   },
 ];
 

--- a/apps/landing-page-astro/src/components/Footer.astro
+++ b/apps/landing-page-astro/src/components/Footer.astro
@@ -10,13 +10,13 @@ const cols = [
       { l: 'Features', h: '#features' },
       { l: 'How it works', h: '#how' },
       { l: 'Pricing', h: '#pricing' },
-      { l: 'Changelog', h: 'https://github.com/sarthak-fleet/CodeVetter/releases' },
+      { l: 'Changelog', h: 'https://github.com/Codevetter/codevetter/releases' },
     ],
   },
   {
     label: 'Resources',
     items: [
-      { l: 'Documentation', h: 'https://github.com/sarthak-fleet/CodeVetter#readme' },
+      { l: 'Documentation', h: 'https://github.com/Codevetter/codevetter#readme' },
       { l: 'Benchmark', h: '/benchmark' },
       { l: 'Privacy', h: '/privacy' },
       { l: 'Terms', h: '/terms' },
@@ -25,7 +25,7 @@ const cols = [
   {
     label: 'Connect',
     items: [
-      { l: 'GitHub', h: 'https://github.com/sarthak-fleet/CodeVetter', icon: 'github' },
+      { l: 'GitHub', h: 'https://github.com/Codevetter/codevetter', icon: 'github' },
       { l: 'Twitter', h: 'https://x.com/sarthakcodes', icon: 'twitter' },
       { l: 'Email', h: 'mailto:hello@codevetter.dev', icon: 'mail' },
     ],

--- a/apps/landing-page-astro/src/components/Nav.astro
+++ b/apps/landing-page-astro/src/components/Nav.astro
@@ -38,7 +38,7 @@ const links = [
 
     <div class="flex items-center gap-2">
       <a
-        href="https://github.com/sarthak-fleet/CodeVetter"
+        href="https://github.com/Codevetter/codevetter"
         class="group hidden sm:inline-flex items-center gap-2 h-9 px-4 text-xs font-medium text-gray-400 hover:text-white hover:bg-white/5 transition-all duration-300 rounded-full"
       >
         GitHub

--- a/apps/landing-page-astro/src/pages/benchmark.astro
+++ b/apps/landing-page-astro/src/pages/benchmark.astro
@@ -32,14 +32,14 @@ import Footer from '@/components/Footer.astro';
       <h2 class="mt-8 text-base font-semibold text-white">Contribute</h2>
       <p class="mt-2 text-sm">
         Have an agent PR with a known bug the reviewer missed?
-        <a href="https://github.com/sarthak-fleet/CodeVetter/issues" class="text-amber-400 hover:underline">Open an issue</a>
+        <a href="https://github.com/Codevetter/codevetter/issues" class="text-amber-400 hover:underline">Open an issue</a>
         with a link to the diff (no proprietary code required — sanitized excerpts welcome).
       </p>
 
       <h2 class="mt-8 text-base font-semibold text-white">Try CodeVetter</h2>
       <p class="mt-2 text-sm">
         <a href="/download" class="text-amber-400 hover:underline">Download for macOS</a>
-        · <a href="https://github.com/sarthak-fleet/CodeVetter" class="text-amber-400 hover:underline">GitHub</a>
+        · <a href="https://github.com/Codevetter/codevetter" class="text-amber-400 hover:underline">GitHub</a>
       </p>
     </article>
     <Footer />

--- a/apps/landing-page-astro/src/pages/download.astro
+++ b/apps/landing-page-astro/src/pages/download.astro
@@ -66,7 +66,7 @@ const PLATFORMS: Platform[] = [
       </p>
 
       <a
-        href="https://github.com/sarthak-fleet/CodeVetter/releases/latest"
+        href="https://github.com/Codevetter/codevetter/releases/latest"
         target="_blank"
         rel="noopener noreferrer"
         class="mt-6 inline-block rounded-md bg-amber-500 px-4 py-2 text-sm font-medium text-stone-950 hover:bg-amber-400"
@@ -89,7 +89,7 @@ const PLATFORMS: Platform[] = [
       <p class="mt-10 text-xs text-stone-500">
         Building from source? See the{' '}
         <a
-          href="https://github.com/sarthak-fleet/CodeVetter"
+          href="https://github.com/Codevetter/codevetter"
           target="_blank"
           rel="noopener noreferrer"
           class="underline hover:text-amber-400"

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -12,7 +12,7 @@
 ### Clone and install
 
 ```bash
-git clone https://github.com/sarthak-fleet/CodeVetter.git
+git clone https://github.com/Codevetter/codevetter.git
 cd CodeVetter
 npm install
 ```

--- a/openspec/changes/archive/2026-07-10-consolidate-taste-into-codevetter/transfer-inventory.md
+++ b/openspec/changes/archive/2026-07-10-consolidate-taste-into-codevetter/transfer-inventory.md
@@ -45,7 +45,7 @@ The original worktrees were dirty when consolidation began and were preserved un
 - Worker `taste-capture` does not exist.
 - R2 bucket `taste-captures` does not exist.
 - No taste/ShipRank queue exists.
-- GitHub `sarthak-fleet/taste` is public, on `main`, and not archived.
+- GitHub `sarthakagrawal927/taste` is public, on `main`, and not archived.
 - `shiprank.dev` is an unrelated Vercel-hosted leaderboard and is not attached to the Cloudflare Pages project; it must not be touched.
 
 No external resource was changed by this inventory. Exact proposed closure actions remain gated: export then delete D1, delete the Pages project, and archive rather than delete the GitHub repository.


### PR DESCRIPTION
## What changed

- replace stale `sarthak-fleet` repository links with canonical product-organization owners
- update release, landing, integration, and archived inventory references

## Why

CodeVetter and its related repositories moved into dedicated GitHub organizations. Canonical links should no longer depend on redirects from the retired fleet organization.

## Validation

- `git diff --check`
- tracked stale-owner reference scan