### PR TITLE
fix(release): prepare MCP sidecar before qualification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,12 @@ jobs:
         working-directory: apps/desktop
         run: pnpm exec playwright install chromium
 
+      - name: Prepare release MCP sidecar
+        working-directory: apps/desktop
+        env:
+          TAURI_ENV_TARGET_TRIPLE: aarch64-apple-darwin
+        run: pnpm run prepare:mcp-sidecar:release
+
       - name: Qualify canonical graph and MCP performance
         working-directory: apps/desktop
         env:
@@ -69,12 +75,6 @@ jobs:
           pnpm qualify:graph
           pnpm qualify:graph:browser
           pnpm bench:mcp
-
-      - name: Prepare release MCP sidecar
-        working-directory: apps/desktop
-        env:
-          TAURI_ENV_TARGET_TRIPLE: aarch64-apple-darwin
-        run: pnpm run prepare:mcp-sidecar:release
 
       - name: Build Tauri app
         id: tauri


### PR DESCRIPTION
## Root cause
The release qualification invokes Cargo before the external MCP sidecar exists, so the Tauri build script rejects the missing configured binary.

## Fix
Move the existing release-sidecar preparation step ahead of graph/MCP qualification. The later Tauri build still validates and bundles the prepared binary.

## Validation
- workflow diff check is clean
- change only reorders the existing prerequisite step

After merge, re-dispatch release.yml for the existing v1.2.21 tag.