### PR TITLE
perf(ci): qualify only the graph library target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,8 @@ jobs:
           # qualification here; absolute graph ceilings run on the named machine.
           CV_GRAPH_BUDGET_MODE: report-only
         run: |
-          pnpm qualify:graph
+          CV_ENFORCE_GRAPH_BUDGETS=1 cargo test --release --manifest-path src-tauri/Cargo.toml --lib perf_bench::bench_structural_graph_real_repo -- --ignored --nocapture --test-threads=1
+          pnpm bench:history-ui
           pnpm qualify:graph:browser
           pnpm bench:mcp
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -39,7 +39,7 @@
     "qualify:archaeology:correctness": "node --test scripts/archaeology-reviewer-effort.test.mjs && node scripts/archaeology-correctness-report.mjs",
     "qualify:archaeology:reviewer": "node scripts/archaeology-reviewer-effort.mjs",
     "bench:rust": "cargo test --release --manifest-path src-tauri/Cargo.toml perf_bench -- --ignored --nocapture --test-threads=1",
-    "qualify:graph": "CV_ENFORCE_GRAPH_BUDGETS=1 cargo test --release --manifest-path src-tauri/Cargo.toml perf_bench::bench_structural_graph_real_repo -- --ignored --nocapture --test-threads=1 && pnpm bench:history-ui",
+    "qualify:graph": "CV_ENFORCE_GRAPH_BUDGETS=1 cargo test --release --manifest-path src-tauri/Cargo.toml --lib perf_bench::bench_structural_graph_real_repo -- --ignored --nocapture --test-threads=1 && pnpm bench:history-ui",
     "qualify:graph:browser": "CV_ENFORCE_GRAPH_BROWSER_BUDGETS=1 playwright test tests/e2e/repo-unpacked.spec.ts --grep 'history slider stays frame-responsive'",
     "bench": "npm run build && npm run bench:bundle && npm run bench:rust"
   },


### PR DESCRIPTION
## Root cause
The graph benchmark is a library test, but the qualification command built every Cargo target. On a clean release runner that needlessly compiled the Tauri UI binary and failed because frontendDist had not been produced yet.

## Fix
Pass --lib to Cargo so qualification builds and runs only the target that owns the benchmark.

## Validation
- exact report-only library benchmark passed locally
- 81,341 nodes / 143,928 edges
- 1 test passed; 823 filtered out
- package JSON and diff checks clean