### PR TITLE
docs: link landing page to canonical docs

### DIFF
--- a/apps/landing-page-astro/src/components/Footer.astro
+++ b/apps/landing-page-astro/src/components/Footer.astro
@@ -16,7 +16,7 @@ const cols = [
   {
     label: 'Resources',
     items: [
-      { l: 'Documentation', h: 'https://github.com/Codevetter/codevetter#readme' },
+      { l: 'Documentation', h: '/docs/' },
       { l: 'FAQ', h: '/faq' },
       { l: 'Benchmark', h: '/benchmark' },
       { l: 'Privacy', h: '/privacy' },


### PR DESCRIPTION
Point the visible Documentation footer link at /docs/ so visitors reach the canonical Blume docs surface instead of the repository README.