### PR TITLE
seo: include docs in landing sitemap

### DIFF
--- a/apps/landing-page-astro/astro.config.mjs
+++ b/apps/landing-page-astro/astro.config.mjs
@@ -24,7 +24,7 @@ export default defineConfig({
     format: 'directory',
     inlineStylesheets: 'always',
   },
-  integrations: [sitemap()],
+  integrations: [sitemap({ customPages: ['https://codevetter.com/docs/'] })],
   vite: {
     plugins: [tailwind()],
     css: { transformer: 'lightningcss' },


### PR DESCRIPTION
Add the canonical Blume docs root to the generated landing sitemap so search engines discover the docs surface as well as the docs-owned sitemap.