### PR TITLE
feat: retain synthetic QA performance evidence

### DIFF
--- a/apps/desktop/scripts/run-synthetic-qa.mjs
+++ b/apps/desktop/scripts/run-synthetic-qa.mjs
@@ -11,6 +11,7 @@
 import { chromium } from 'playwright';
 import fs from 'node:fs';
 import path from 'node:path';
+import { performance } from 'node:perf_hooks';
 
 const LOOPS = {
   'codevetter-review-shell': {
@@ -83,6 +84,7 @@ async function main() {
   fs.mkdirSync(artifactDir, { recursive: true });
 
   const started = Date.now();
+  const stageTimingsMs = {};
   const consoleErrors = [];
   let browser;
   let context;
@@ -99,13 +101,19 @@ async function main() {
       throw new Error(`unsupported auth mode: ${authMode}`);
     }
 
+    let stageStarted = performance.now();
     browser = await chromium.launch({ headless: true });
+    stageTimingsMs.browser_launch = performance.now() - stageStarted;
+    stageStarted = performance.now();
     context = await browser.newContext({
       viewport: { width: 1280, height: 800 },
       colorScheme: 'dark',
       ...(authMode === 'storage_state' ? { storageState } : {}),
     });
+    stageTimingsMs.context_create = performance.now() - stageStarted;
+    stageStarted = performance.now();
     const page = await context.newPage();
+    stageTimingsMs.page_create = performance.now() - stageStarted;
 
     page.on('console', (msg) => {
       if (msg.type() !== 'error') return;
@@ -114,8 +122,12 @@ async function main() {
       consoleErrors.push(text);
     });
 
+    stageStarted = performance.now();
     await page.goto(targetUrl, { waitUntil: 'domcontentloaded', timeout: 15_000 });
+    stageTimingsMs.navigation = performance.now() - stageStarted;
+    stageStarted = performance.now();
     await loop.assert(page);
+    stageTimingsMs.assertion = performance.now() - stageStarted;
 
     const pass = consoleErrors.length === 0;
     const assertionSummary =
@@ -139,6 +151,8 @@ async function main() {
         final_url: page.url(),
         page_title: await page.title(),
         console_errors: consoleErrors,
+        stage_timings_ms: stageTimingsMs,
+        runner_rss_bytes: process.memoryUsage().rss,
       },
       error: null,
     };
@@ -180,6 +194,8 @@ async function main() {
         final_url: targetUrl,
         page_title: '',
         console_errors: consoleErrors,
+        stage_timings_ms: stageTimingsMs,
+        runner_rss_bytes: process.memoryUsage().rss,
       },
       error: message,
     };

--- a/apps/desktop/src-tauri/src/commands/synthetic_qa.rs
+++ b/apps/desktop/src-tauri/src/commands/synthetic_qa.rs
@@ -1,6 +1,7 @@
 use crate::{db::queries, DbState};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::process::Command as StdCommand;
 use tauri::{Manager, State};
@@ -10,6 +11,10 @@ pub struct SyntheticQaTrace {
     pub final_url: String,
     pub page_title: String,
     pub console_errors: Vec<String>,
+    #[serde(default)]
+    pub stage_timings_ms: BTreeMap<String, f64>,
+    #[serde(default)]
+    pub runner_rss_bytes: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -829,6 +834,8 @@ pub async fn run_synthetic_qa(
                     final_url: base_url,
                     page_title: "repo_playwright".to_string(),
                     console_errors,
+                    stage_timings_ms: BTreeMap::new(),
+                    runner_rss_bytes: None,
                 },
                 error: if pass {
                     None
@@ -902,6 +909,21 @@ pub async fn run_synthetic_qa(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn preserves_optional_runner_performance_evidence() {
+        let trace: SyntheticQaTrace = serde_json::from_value(json!({
+            "final_url": "http://localhost:1420/review",
+            "page_title": "Review",
+            "console_errors": [],
+            "stage_timings_ms": { "navigation": 42.5 },
+            "runner_rss_bytes": 1048576
+        }))
+        .expect("trace should deserialize");
+
+        assert_eq!(trace.stage_timings_ms.get("navigation"), Some(&42.5));
+        assert_eq!(trace.runner_rss_bytes, Some(1_048_576));
+    }
 
     #[test]
     fn discovers_playwright_specs_and_skips_plain_unit_tests() {

--- a/apps/desktop/src/lib/synthetic-qa/types.ts
+++ b/apps/desktop/src/lib/synthetic-qa/types.ts
@@ -3,6 +3,10 @@ interface SyntheticQaTrace {
   final_url: string;
   page_title: string;
   console_errors: string[];
+  /** Wall-clock duration for bounded runner stages, keyed by stable stage name. */
+  stage_timings_ms?: Record<string, number>;
+  /** Resident memory observed in the runner process after the workflow. */
+  runner_rss_bytes?: number;
 }
 
 export interface SyntheticQaStepResult {


### PR DESCRIPTION
## Summary
- recover the still-useful synthetic QA stage timings and runner RSS from the reviewed stash
- carry those fields through the TypeScript and Rust contracts so they are not silently discarded
- leave obsolete GitNexus and superseded health-projection stash changes out

## Validation
- cargo fmt --check
- cargo test commands::synthetic_qa::tests::preserves_optional_runner_performance_evidence
- pnpm --dir apps/desktop exec tsc --noEmit