### PR TITLE
Qualify T-Rex CLI artifacts and design MCP projection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,11 @@ jobs:
       - name: Prepare CLI sidecar
         working-directory: apps/desktop
         run: pnpm run prepare:cli-sidecar
+      - name: Qualify CLI artifact
+        working-directory: apps/desktop
+        run: |
+          pnpm run test:cli-qualification
+          pnpm run qualify:cli
       - name: Desktop build
         working-directory: apps/desktop
         run: pnpm run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,6 +121,8 @@ jobs:
         run: |
           test -x apps/desktop/src-tauri/target/aarch64-apple-darwin/release/bundle/macos/CodeVetter.app/Contents/MacOS/codevetter
           test -x apps/desktop/src-tauri/target/aarch64-apple-darwin/release/bundle/macos/CodeVetter.app/Contents/MacOS/codevetter-mcp
+          pnpm --dir apps/desktop run qualify:cli --binary \
+            src-tauri/target/aarch64-apple-darwin/release/bundle/macos/CodeVetter.app/Contents/MacOS/codevetter
 
       - name: Qualify Agent Island app and updater payload
         working-directory: apps/desktop

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -38,6 +38,13 @@ Internal (fleet):
 
 ## Timeline
 
+- **2026-07-31 — T-Rex MCP and CLI artifact qualification:** fixed the future
+  agent-triggered verification boundary as a separate, explicitly enabled MCP
+  process so the existing history MCP remains read-only. Pull-request CI now
+  executes the prepared CLI's version/help/bundle contract, and the release
+  workflow repeats that check against the final binary inside the macOS app.
+  No verification MCP binary, live preview smoke, version bump, or release was
+  performed.
 - **2026-07-29 — Owned product changelog:** added a same-origin
   `/changelog` that turns verified shipped milestones into concise,
   user-visible outcomes. Public navigation now exposes the page, routes
@@ -218,6 +225,10 @@ Internal (fleet):
 
 ### Automation readiness
 - Privacy-safe product, release, reliability, and Foundry evidence contracts documented in `docs/operations/automation-contract.md` (surface inventory, funnel, N/A decisions, release + canary + Foundry contracts, baseline evidence).
+- The prepared and final bundled T-Rex CLI artifacts are executable
+  qualification targets for exact version/help and Tauri bundle contracts; a
+  future verification MCP has a separate fixed-scope authorization design and
+  is not exposed by the read-only history sidecar.
 - `scripts/verify-release-manifest.mjs` validates the live `latest.json` updater manifest references a resolvable asset with a present signature, without publishing a release; wired as a post-upload step in `release.yml`.
 - `scripts/emit-foundry-receipt.mjs` emits a closed-schema sanitized aggregate Foundry receipt (project slug, git revision, desktop version, CI/canary/release/landing/manifest status); `scripts/emit-foundry-receipt.test.mjs` proves sensitive payloads (code, repo, prompt, finding, path, key, email) cannot enter the receipt.
 - `weekly.yml` now records source revision and emits a `canary-evidence.json` artifact (90-day retention) with bounds, timeout, declared cron, freshness window, and conclusion; job summary table exposes the same.

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -11,6 +11,8 @@
     "prepare:mcp-sidecar:release": "node scripts/prepare-mcp-sidecar.mjs --release",
     "prepare:cli-sidecar": "node scripts/prepare-cli-sidecar.mjs",
     "prepare:cli-sidecar:release": "node scripts/prepare-cli-sidecar.mjs --release",
+    "qualify:cli": "node scripts/verify-cli-release.mjs",
+    "test:cli-qualification": "node --test scripts/verify-cli-release.test.mjs",
     "prepare:agent-island": "node scripts/prepare-agent-island.mjs",
     "prepare:agent-island:release": "node scripts/prepare-agent-island.mjs --release",
     "test:agent-island": "swift run --package-path native/AgentIsland codevetter-agent-island --self-test",

--- a/apps/desktop/scripts/verify-cli-release.mjs
+++ b/apps/desktop/scripts/verify-cli-release.mjs
@@ -1,0 +1,135 @@
+import { execFileSync } from 'node:child_process';
+import { constants, accessSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const desktopRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const requiredHelpFragments = [
+  'codevetter trex (--pr <url> | --range <base..head>) --preview <url>',
+  '--pr <url>',
+  '--range <range>',
+  '--preview <url>',
+  '--repo <path>',
+  '--json',
+];
+
+export function qualifyCli({
+  binaryPath = resolvePreparedBinary(),
+  projectRoot = desktopRoot,
+} = {}) {
+  const resolvedBinary = resolve(binaryPath);
+  const stats = statSync(resolvedBinary);
+  if (!stats.isFile() || stats.size === 0) {
+    throw new Error(`CLI artifact is missing or empty: ${resolvedBinary}`);
+  }
+  accessSync(resolvedBinary, constants.X_OK);
+
+  const tauriConfigPath = join(projectRoot, 'src-tauri', 'tauri.conf.json');
+  const macosConfigPath = join(projectRoot, 'src-tauri', 'tauri.macos.conf.json');
+  const tauriConfig = readJson(tauriConfigPath);
+  const macosConfig = readJson(macosConfigPath);
+  const expectedBundleEntry = 'binaries/codevetter';
+  assertBundleEntry(tauriConfig, tauriConfigPath, expectedBundleEntry);
+  assertBundleEntry(macosConfig, macosConfigPath, expectedBundleEntry);
+
+  const expectedVersion = tauriConfig.version;
+  if (typeof expectedVersion !== 'string' || expectedVersion.length === 0) {
+    throw new Error(`Tauri version is missing: ${tauriConfigPath}`);
+  }
+
+  const versionOutput = runBinary(resolvedBinary, ['--version']).trim();
+  const expectedVersionOutput = `codevetter ${expectedVersion}`;
+  if (versionOutput !== expectedVersionOutput) {
+    throw new Error(
+      `CLI version mismatch: expected "${expectedVersionOutput}", received "${versionOutput}"`
+    );
+  }
+
+  const helpOutput = runBinary(resolvedBinary, ['--help']);
+  for (const fragment of requiredHelpFragments) {
+    if (!helpOutput.includes(fragment)) {
+      throw new Error(`CLI help is missing required contract: ${fragment}`);
+    }
+  }
+
+  return {
+    binary: resolvedBinary,
+    bytes: stats.size,
+    version: expectedVersion,
+    bundleEntry: expectedBundleEntry,
+    helpContracts: requiredHelpFragments.length,
+  };
+}
+
+export function resolvePreparedBinary() {
+  const target = rustHostTarget();
+  return join(
+    desktopRoot,
+    'src-tauri',
+    'binaries',
+    `codevetter-${target}${process.platform === 'win32' ? '.exe' : ''}`
+  );
+}
+
+function assertBundleEntry(config, path, expected) {
+  const entries = config?.bundle?.externalBin;
+  if (!Array.isArray(entries) || !entries.includes(expected)) {
+    throw new Error(`${path} does not declare ${expected}`);
+  }
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function runBinary(binary, args) {
+  return execFileSync(binary, args, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+function rustHostTarget() {
+  const target = execFileSync('rustc', ['-vV'], { encoding: 'utf8' })
+    .split('\n')
+    .find((line) => line.startsWith('host: '))
+    ?.slice('host: '.length);
+  if (!target) {
+    throw new Error('Could not determine the Rust host target');
+  }
+  return target;
+}
+
+function parseArgs(args) {
+  let binaryPath;
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    if (argument !== '--binary') {
+      throw new Error(`Unknown argument: ${argument}`);
+    }
+    const value = args[index + 1];
+    if (!value || value.startsWith('--')) {
+      throw new Error('--binary requires a path');
+    }
+    binaryPath = value;
+    index += 1;
+  }
+  return { binaryPath };
+}
+
+const isMain =
+  process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+
+if (isMain) {
+  try {
+    const result = qualifyCli(parseArgs(process.argv.slice(2)));
+    process.stdout.write(
+      `T-Rex CLI qualification passed: ${result.version}, ${result.bytes} bytes, ${result.helpContracts} help contracts\n`
+    );
+  } catch (error) {
+    process.stderr.write(
+      `T-Rex CLI qualification failed: ${error instanceof Error ? error.message : String(error)}\n`
+    );
+    process.exitCode = 1;
+  }
+}

--- a/apps/desktop/scripts/verify-cli-release.test.mjs
+++ b/apps/desktop/scripts/verify-cli-release.test.mjs
@@ -1,0 +1,108 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import { qualifyCli } from './verify-cli-release.mjs';
+
+const TRACKED_VERSION = JSON.parse(
+  readFileSync(new URL('../src-tauri/tauri.conf.json', import.meta.url), 'utf8')
+).version;
+const HELP = `CodeVetter execution-backed verification
+
+Usage:
+  codevetter trex (--pr <url> | --range <base..head>) --preview <url> [--repo <path>] [--json]
+
+Options:
+  --pr <url>
+  --range <range>
+  --preview <url>
+  --repo <path>
+  --json
+`;
+
+async function fakeCli(directory, { version = TRACKED_VERSION, help = HELP } = {}) {
+  const path = join(directory, 'codevetter');
+  await writeFile(
+    path,
+    `#!/usr/bin/env node
+const argument = process.argv[2];
+if (argument === '--version') process.stdout.write('codevetter ${version}\\n');
+else if (argument === '--help') process.stdout.write(${JSON.stringify(help)});
+else process.exitCode = 2;
+`
+  );
+  await chmod(path, 0o755);
+  return path;
+}
+
+test('qualifies the tracked version, help surface, and bundle declarations', async (t) => {
+  const directory = await mkdtemp(join(tmpdir(), 'codevetter-cli-'));
+  t.after(() => rm(directory, { recursive: true, force: true }));
+  const binaryPath = await fakeCli(directory);
+
+  const result = qualifyCli({ binaryPath });
+
+  assert.equal(result.version, TRACKED_VERSION);
+  assert.equal(result.bundleEntry, 'binaries/codevetter');
+  assert.equal(result.helpContracts, 6);
+  assert.ok(result.bytes > 0);
+});
+
+test('fails on version drift', async (t) => {
+  const directory = await mkdtemp(join(tmpdir(), 'codevetter-cli-'));
+  t.after(() => rm(directory, { recursive: true, force: true }));
+  const binaryPath = await fakeCli(directory, { version: '0.0.0-drift' });
+
+  assert.throws(
+    () => qualifyCli({ binaryPath }),
+    (error) => {
+      assert.match(error.message, /CLI version mismatch/);
+      assert.match(
+        error.message,
+        new RegExp(`codevetter ${TRACKED_VERSION.replaceAll('.', '\\.')}`)
+      );
+      assert.match(error.message, /codevetter 0\.0\.0-drift/);
+      return true;
+    }
+  );
+});
+
+test('fails when a documented T-Rex flag disappears', async (t) => {
+  const directory = await mkdtemp(join(tmpdir(), 'codevetter-cli-'));
+  t.after(() => rm(directory, { recursive: true, force: true }));
+  const binaryPath = await fakeCli(directory, {
+    help: HELP.replaceAll('--json', '--machine'),
+  });
+
+  assert.throws(() => qualifyCli({ binaryPath }), /CLI help is missing required contract: --json/);
+});
+
+test('fails when either Tauri bundle declaration drops the CLI', async (t) => {
+  const directory = await mkdtemp(join(tmpdir(), 'codevetter-cli-'));
+  t.after(() => rm(directory, { recursive: true, force: true }));
+  const binaryPath = await fakeCli(directory);
+  const projectRoot = join(directory, 'desktop');
+  const tauriRoot = join(projectRoot, 'src-tauri');
+  await mkdir(tauriRoot, { recursive: true });
+  await writeFile(
+    join(tauriRoot, 'tauri.conf.json'),
+    JSON.stringify({
+      version: TRACKED_VERSION,
+      bundle: { externalBin: ['binaries/codevetter'] },
+    })
+  );
+  await writeFile(
+    join(tauriRoot, 'tauri.macos.conf.json'),
+    JSON.stringify({
+      bundle: { externalBin: ['binaries/codevetter-mcp'] },
+    })
+  );
+
+  assert.throws(
+    () => qualifyCli({ binaryPath, projectRoot }),
+    /tauri\.macos\.conf\.json does not declare binaries\/codevetter/
+  );
+});

--- a/docs/architecture/trex-mcp-projection.md
+++ b/docs/architecture/trex-mcp-projection.md
@@ -1,0 +1,164 @@
+---
+title: T-Rex MCP projection
+description: The authorization and receipt contract for a future agent-triggered change-preview verifier.
+sidebar:
+  order: 8
+---
+
+# T-Rex MCP projection
+
+This document fixes the architecture for exposing the direct T-Rex
+change-preview workflow to an MCP client. It is a design contract, not a claim
+that the execution tool ships today.
+
+The current [`codevetter-mcp`](./mcp-sidecar.md) server remains a strictly
+read-only history and graph interface. It does not run T-Rex, launch a browser,
+or write a verification receipt.
+
+## Why the boundary is separate
+
+The three existing product paths do not have identical authority:
+
+| Surface | May execute verification | May write local receipt | May mutate target |
+| --- | --- | --- | --- |
+| Desktop T-Rex | Yes | Yes | No |
+| `codevetter trex` CLI | Yes | Yes | No |
+| `codevetter-mcp` | No | No | No |
+
+Calling the current MCP server "read-only" while adding a tool that launches a
+browser and persists a receipt would make its contract misleading. A future
+verification projection therefore uses a separate process and permission.
+
+## Process identity
+
+The planned binary is `codevetter-verify-mcp`. It will not replace or extend
+`codevetter-mcp`.
+
+Starting the process will require an owner-controlled, explicit verification
+enablement for one repository. Enabling history MCP access alone will never
+authorize verification execution.
+
+The process receives one canonical repository scope at startup. The tool does
+not accept arbitrary repository paths, clone repositories, or switch scope
+between calls.
+
+## Tool contract
+
+The first tool is planned as:
+
+```text
+verify_change_preview
+```
+
+Its closed input shape is:
+
+```json
+{
+  "source": {
+    "kind": "pull_request",
+    "value": "https://github.com/acme/widget/pull/42"
+  },
+  "preview_url": "https://widget-pr-42.example.com"
+}
+```
+
+`source.kind` is exactly `pull_request` or `range`. The value is exactly one
+canonical PR URL or bounded two-dot/three-dot Git range. `preview_url` is one
+credential-free HTTP(S) URL.
+
+The tool does not accept:
+
+- a repository path;
+- a shell command, test command, or dependency installer;
+- cookies, credentials, headers, or browser storage;
+- a model, prompt, route, click plan, or mutation request;
+- a second source or preview.
+
+## Shared execution authority
+
+The MCP adapter will call the same `execute_trex_preview` service used by Tauri
+and the CLI. It must not reimplement source resolution, preview identity,
+route selection, browser execution, aggregation, persistence, or verdicts.
+
+The shared service retains the current guarantees:
+
+- source resolution is exact, bounded, shell-free, and checkout-read-only;
+- preview identity is verified, claimed, or mismatched from headers;
+- routes are deterministic and bounded;
+- browser work is unauthenticated navigation and observation only;
+- no model chooses actions or verdicts;
+- the canonical receipt remains authoritative.
+
+## Output contract
+
+A completed tool call returns the versioned `TrexPreviewReceipt` without an
+MCP-specific verdict overlay. The receipt preserves:
+
+- exact base/head identities and changed paths;
+- preview URL and identity evidence;
+- selected routes and reasons;
+- journey evidence and artifacts;
+- limitations, duration, and run time;
+- `passed_with_limits`, `failed`, or `no_confidence`.
+
+Invalid input, preview mismatch, incomplete evidence, persistence failure, and
+cleanup failure remain `no_confidence`. The MCP adapter must not translate an
+operationally incomplete run into a successful result because the protocol
+call itself completed.
+
+Protocol/framing errors may use MCP errors. Verification outcomes must use the
+canonical receipt shape so CLI, desktop, and MCP consumers do not diverge.
+
+## Write boundary
+
+T-Rex is read-only toward the target repository and preview. It does write one
+local canonical receipt to CodeVetter's application data.
+
+The future settings copy and MCP tool metadata must say "local verification
+execution," not simply "read-only." The process will record bounded access
+metadata without prompt, profile, credential, or page content.
+
+## Authorization lifecycle
+
+Before implementation, the feature must define:
+
+1. a separate per-repository verification enablement;
+2. how a client discovers and launches the dedicated binary;
+3. how enablement is revoked while a process is running;
+4. bounded concurrent-run ownership and cancellation;
+5. receipt/audit retention;
+6. protocol and end-to-end tests proving the history MCP cannot execute it.
+
+No verification MCP binary should be bundled until those lifecycle behaviors
+are implemented and qualified.
+
+## Explicit exclusions
+
+The projection does not authorize:
+
+- authenticated or state-mutating journeys;
+- repository cloning or dependency installation;
+- local application startup or arbitrary command execution;
+- base-versus-head preview comparison;
+- observability, logs, or Sentry ingestion;
+- SARIF as the authoritative receipt;
+- autonomous scheduling or repeated background verification.
+
+Those require separate evidence and product decisions.
+
+## Qualification before shipping
+
+Implementation must prove all of the following:
+
+- tool schema rejects unknown fields and ambiguous source selectors;
+- repository scope cannot be changed by tool input;
+- the target checkout remains unchanged;
+- preview credentials and non-HTTP(S) URLs fail before execution;
+- completed results round-trip through the canonical receipt;
+- failures remain explicit and schema-valid;
+- disabling verification revokes new runs;
+- `codevetter-mcp` still exposes no execution tool;
+- packaged protocol tests pass without the desktop UI.
+
+Until then, the supported machine interface is
+[`codevetter trex --json`](../product/trex-change-preview.md#command-line).

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,6 +33,8 @@ is only the presentation and search layer.
 - [graph-and-history.md](./architecture/graph-and-history.md) — canonical structural graph + release history workbench.
 - [repo-unpacked.md](./architecture/repo-unpacked.md) — evidence-backed repo briefs.
 - [mcp-sidecar.md](./architecture/mcp-sidecar.md) — opt-in local MCP server.
+- [trex-mcp-projection.md](./architecture/trex-mcp-projection.md) — future
+  agent-triggered verification boundary without weakening the read-only MCP.
 - [history-evidence-import.md](./architecture/history-evidence-import.md) — importing provider-side outcomes.
 - [native-agent-island.md](./architecture/native-agent-island.md) — supervised Swift status, speech, and provider-action boundary.
 - [verification-workbench.md](./architecture/verification-workbench.md) — additive evidence identities, retention, managed-run, intent, and performance records.

--- a/docs/operations/ci.md
+++ b/docs/operations/ci.md
@@ -26,10 +26,13 @@ Steps, in order (a failure stops the job):
    in `release.yml` as a post-upload check, not here)
 10. **MCP sidecar build smoke** — `pnpm run prepare:mcp-sidecar`
 11. **CLI sidecar build smoke** — `pnpm run prepare:cli-sidecar`
-12. **Desktop build** — `pnpm run build` (Vite production build)
-13. **MCP protocol and safety tests** — Rust library, binary, and stdio integration tests
-14. **T-Rex CLI contract tests** — browser-feature parser, output, and exit-code tests
-15. **MCP and history browser tests** — Settings and Repo Unpack Playwright coverage
+12. **CLI artifact qualification** — focused script tests plus
+    `pnpm run qualify:cli` execute the prepared binary and verify its exact
+    version/help surface and both Tauri bundle declarations
+13. **Desktop build** — `pnpm run build` (Vite production build)
+14. **MCP protocol and safety tests** — Rust library, binary, and stdio integration tests
+15. **T-Rex CLI contract tests** — browser-feature parser, output, and exit-code tests
+16. **MCP and history browser tests** — Settings and Repo Unpack Playwright coverage
 
 ## Other workflows
 

--- a/docs/operations/release-pipeline.md
+++ b/docs/operations/release-pipeline.md
@@ -30,6 +30,7 @@ release.yml  (on release.created OR workflow_dispatch with tag)
    ├─ prepare:mcp-sidecar:release + prepare:cli-sidecar:release
    │  + universal Agent Island helper + vite build
    ├─ tauri build (macos-latest) → DMG + signed updater archive
+   ├─ execute the final bundled CLI qualification
    ├─ upload assets to the release
    └─ upload latest.json manifest (consumed by the updater)
         │
@@ -70,8 +71,9 @@ graph + MCP budget qualification runs before the build (see
 The optional [Native Agent Island](../architecture/native-agent-island.md) is
 bundled as a nested universal sidecar. Release verification checks arm64 and
 x86_64 slices plus its nested code signature before assets are uploaded.
-The same release verifies executable `codevetter` and `codevetter-mcp`
-sidecars inside the final app bundle.
+The same release executes the final bundled `codevetter` binary to verify its
+version/help contract and confirms executable `codevetter-mcp` remains in the
+app bundle.
 
 ## Auto-updater
 
@@ -86,6 +88,7 @@ sidecars inside the final app bundle.
 - `apps/desktop/src-tauri/tauri.conf.json` (version + updater config)
 - `apps/desktop/src-tauri/tauri.macos.conf.json` (macOS-only Agent Island sidecar)
 - `apps/desktop/scripts/prepare-mcp-sidecar.mjs` (sidecar bundling)
+- `apps/desktop/scripts/verify-cli-release.mjs` (prepared/final CLI contract)
 - `apps/desktop/scripts/prepare-agent-island.mjs` (universal native helper)
 - `scripts/verify-release-manifest.mjs` (post-upload manifest linkage check;
   see [automation-contract.md](./automation-contract.md#updater-manifest-validation))

--- a/docs/product/trex-change-preview.md
+++ b/docs/product/trex-change-preview.md
@@ -166,9 +166,13 @@ The following remain deferred:
 - dependency installation and application boot orchestration;
 - authenticated or state-mutating browser journeys;
 - base-preview versus head-preview comparison;
-- MCP entrypoints for the direct-run workflow;
 - model-authored or richer autonomous journeys;
 - observability and Sentry-log correlation.
 
 Those capabilities can build on the same source, preview-identity, journey, and
 receipt contracts after the direct path proves reliable.
+
+An MCP execution projection is designed but not implemented. It deliberately
+uses a future, separately enabled process because the existing history MCP must
+remain strictly read-only. See
+[T-Rex MCP projection](../architecture/trex-mcp-projection.md).

--- a/openspec/changes/archive/2026-07-31-add-trex-mcp-release-qualification/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-31-add-trex-mcp-release-qualification/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-31

--- a/openspec/changes/archive/2026-07-31-add-trex-mcp-release-qualification/design.md
+++ b/openspec/changes/archive/2026-07-31-add-trex-mcp-release-qualification/design.md
@@ -1,0 +1,80 @@
+## Context
+
+CodeVetter currently ships two native sidecars with intentionally different
+contracts:
+
+- `codevetter` executes T-Rex verification and persists the canonical receipt.
+- `codevetter-mcp` exposes repository-scoped history and graph reads and is
+  forbidden from running commands or writing product data.
+
+Putting T-Rex directly into `codevetter-mcp` would make its advertised
+read-only boundary false. The release workflow also checks that the CLI file is
+present in the app bundle, but it does not execute that final binary to prove
+its version/help surface.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Preserve the current history MCP's strict read-only contract.
+- Specify a future equivalent MCP execution entrypoint precisely enough to
+  implement without inventing scope later.
+- Qualify the actual prepared and bundled CLI binaries automatically.
+- Keep all checks shell-free inside the qualification script.
+
+**Non-Goals:**
+
+- Implement or bundle the future verification MCP server now.
+- Publish a release or claim a real preview smoke happened.
+- Add SARIF, authenticated journeys, repository cloning, dependency
+  installation, or target mutations.
+
+## Decisions
+
+### Keep verification MCP separate
+
+A future `codevetter-verify-mcp` process will own one explicit
+`verify_change_preview` tool. It will not be added to `codevetter-mcp`.
+
+The process will start with one fixed, canonical repository scope supplied by
+an owner-controlled configuration. Tool input will accept exactly one
+canonical PR URL or bounded Git range plus one credential-free HTTP(S) preview
+URL. It will call the same T-Rex execution service as Tauri and the CLI.
+
+The output will be the canonical receipt on every completed run. Invalid
+input, operational failure, or incomplete evidence will remain a schema-valid
+`no_confidence` result rather than an MCP-only success shape.
+
+### Name the local write honestly
+
+The verification process is read-only toward the target repository and
+preview, but it writes a local canonical receipt. Its future enablement must
+therefore be separate from history-MCP access and clearly labeled as local
+verification execution. Enabling history reads alone can never authorize it.
+
+### Qualify binaries, not source claims
+
+`verify-cli-release.mjs` accepts an optional explicit binary path. Without one,
+it resolves the host-target sidecar prepared by the existing build script. It
+checks:
+
+- non-empty executable file;
+- exact `codevetter <tauri-version>` output;
+- documented `trex` usage and required flags in `--help`;
+- both Tauri bundle configs still declare `binaries/codevetter`.
+
+CI runs the check after preparing the debug sidecar. The release workflow runs
+it after Tauri builds the final `.app`, pointing at the bundled executable.
+
+## Risks / Trade-offs
+
+- The new automated gate does not prove a live preview journey. Issue #52 must
+  retain that operator-owned release qualification item.
+- A future second MCP binary increases packaging cost. No binary is added until
+  the execution authorization, protocol tests, and receipt failure envelope
+  are implemented.
+
+## Migration Plan
+
+No data migration. The script and workflow checks are additive. Removing the
+new checks reverts qualification behavior without changing runtime artifacts.

--- a/openspec/changes/archive/2026-07-31-add-trex-mcp-release-qualification/proposal.md
+++ b/openspec/changes/archive/2026-07-31-add-trex-mcp-release-qualification/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+The direct T-Rex CLI is implemented and bundled, but issue #52 still lacks two
+delivery contracts: an explicit answer for how agent clients may eventually
+invoke the same workflow without weakening the read-only history MCP, and one
+automated release check that proves the shipped CLI binary matches its
+documented/versioned surface.
+
+## What Changes
+
+- Define the future T-Rex verification MCP as a separate, explicitly enabled
+  execution capability instead of adding a write-producing tool to the
+  existing read-only history MCP sidecar.
+- Document its fixed repository scope, exact input/output contract,
+  target-read-only boundary, local receipt write, and fail-closed states.
+- Add a reusable CLI qualification script that validates a prepared or bundled
+  binary, exact version/help contract, executable state, and Tauri bundle
+  declarations.
+- Run that qualification in pull-request CI and against the final macOS app
+  bundle in the release workflow.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `automatic-change-verification`: adds the MCP projection boundary and
+  automated CLI release-artifact qualification.
+
+## Impact
+
+- Changes docs, one Node qualification script, package scripts, CI, and release
+  workflow checks.
+- Does not expose a new MCP tool, run a preview, publish a release, mutate a
+  target repository, or change the canonical T-Rex receipt.
+- The real external preview smoke and an actual release remain operator-owned
+  follow-ups on issue #52.

--- a/openspec/changes/archive/2026-07-31-add-trex-mcp-release-qualification/specs/automatic-change-verification/spec.md
+++ b/openspec/changes/archive/2026-07-31-add-trex-mcp-release-qualification/specs/automatic-change-verification/spec.md
@@ -1,0 +1,46 @@
+## ADDED Requirements
+
+### Requirement: Verification MCP does not weaken history MCP
+
+CodeVetter SHALL keep future agent-triggered T-Rex execution separate from the
+existing repository history MCP. Enabling read-only history MCP access MUST NOT
+authorize preview execution or local receipt writes.
+
+#### Scenario: History MCP is enabled
+
+- **WHEN** an MCP client can read an explicitly enabled repository's history
+- **THEN** it cannot start T-Rex, write a receipt, or obtain a verification
+  execution capability from that server
+
+#### Scenario: Verification MCP is designed
+
+- **WHEN** CodeVetter exposes T-Rex through MCP in a future change
+- **THEN** a separate explicitly enabled process fixes one repository scope,
+  accepts exactly one PR or range plus one credential-free preview URL, calls
+  the canonical T-Rex service, and returns its versioned receipt
+
+### Requirement: Prepared and bundled CLI artifacts are contract-qualified
+
+CodeVetter SHALL automatically execute a qualification check against the
+prepared CLI in pull-request CI and the final bundled CLI during macOS release
+builds. The check SHALL fail if the artifact is missing, empty, non-executable,
+version-mismatched, missing its documented T-Rex flags, or absent from either
+Tauri bundle declaration.
+
+#### Scenario: Pull request prepares the CLI
+
+- **WHEN** CI builds the host-target CLI sidecar
+- **THEN** the qualification script executes that binary and verifies its
+  exact version, help surface, and bundle declarations
+
+#### Scenario: Release app is bundled
+
+- **WHEN** Tauri produces the final macOS application bundle
+- **THEN** release qualification executes the CLI inside that bundle before
+  artifact publication continues
+
+#### Scenario: CLI contract drifts
+
+- **WHEN** the binary version/help output or bundle declarations no longer
+  match the tracked contract
+- **THEN** qualification fails with the exact missing or mismatched evidence

--- a/openspec/changes/archive/2026-07-31-add-trex-mcp-release-qualification/tasks.md
+++ b/openspec/changes/archive/2026-07-31-add-trex-mcp-release-qualification/tasks.md
@@ -1,0 +1,23 @@
+## 1. Verification MCP design
+
+- [x] 1.1 Document the separate verification MCP process, fixed repository
+  scope, exact tool inputs, canonical receipt output, and local-write boundary.
+- [x] 1.2 Update T-Rex product docs so the current read-only MCP and future
+  execution projection are not conflated.
+
+## 2. CLI artifact qualification
+
+- [x] 2.1 Add a reusable shell-free script that validates prepared or bundled
+  CLI executables, version/help contracts, and Tauri bundle declarations.
+- [x] 2.2 Run the check after CLI preparation in CI and against the final
+  macOS app bundle during release qualification.
+- [x] 2.3 Add focused script tests for success and contract drift.
+
+## 3. Delivery
+
+- [x] 3.1 Update project status and issue #52 with the completed design and
+  automated qualification boundary.
+- [x] 3.2 Run focused tests, lint, typecheck, docs, workflow checks, and strict
+  OpenSpec validation.
+- [x] 3.3 Archive the change and deliver the scoped progress through a linked
+  pull request without claiming the operator-owned release/live smoke.

--- a/openspec/specs/automatic-change-verification/spec.md
+++ b/openspec/specs/automatic-change-verification/spec.md
@@ -4,9 +4,7 @@
 Define the bounded, read-only T-Rex workflow that verifies one exact repository
 change against one existing preview and exposes the same evidence through the
 desktop application and CLI.
-
 ## Requirements
-
 ### Requirement: T-Rex starts from one change and one preview
 For an already selected repository, T-Rex SHALL accept either a canonical
 GitHub PR URL or one local Git range plus one HTTP(S) preview URL as the complete
@@ -172,3 +170,48 @@ access.
 #### Scenario: The app is running from a development target
 - **WHEN** the executable is not inside an installed `.app/Contents/MacOS`
 - **THEN** automatic CLI registration is skipped
+
+### Requirement: Verification MCP does not weaken history MCP
+
+CodeVetter SHALL keep future agent-triggered T-Rex execution separate from the
+existing repository history MCP. Enabling read-only history MCP access MUST NOT
+authorize preview execution or local receipt writes.
+
+#### Scenario: History MCP is enabled
+
+- **WHEN** an MCP client can read an explicitly enabled repository's history
+- **THEN** it cannot start T-Rex, write a receipt, or obtain a verification
+  execution capability from that server
+
+#### Scenario: Verification MCP is designed
+
+- **WHEN** CodeVetter exposes T-Rex through MCP in a future change
+- **THEN** a separate explicitly enabled process fixes one repository scope,
+  accepts exactly one PR or range plus one credential-free preview URL, calls
+  the canonical T-Rex service, and returns its versioned receipt
+
+### Requirement: Prepared and bundled CLI artifacts are contract-qualified
+
+CodeVetter SHALL automatically execute a qualification check against the
+prepared CLI in pull-request CI and the final bundled CLI during macOS release
+builds. The check SHALL fail if the artifact is missing, empty, non-executable,
+version-mismatched, missing its documented T-Rex flags, or absent from either
+Tauri bundle declaration.
+
+#### Scenario: Pull request prepares the CLI
+
+- **WHEN** CI builds the host-target CLI sidecar
+- **THEN** the qualification script executes that binary and verifies its
+  exact version, help surface, and bundle declarations
+
+#### Scenario: Release app is bundled
+
+- **WHEN** Tauri produces the final macOS application bundle
+- **THEN** release qualification executes the CLI inside that bundle before
+  artifact publication continues
+
+#### Scenario: CLI contract drifts
+
+- **WHEN** the binary version/help output or bundle declarations no longer
+  match the tracked contract
+- **THEN** qualification fails with the exact missing or mismatched evidence


### PR DESCRIPTION
## Summary
- add a shell-free qualifier for prepared and bundled T-Rex CLI artifacts
- run the qualifier in pull-request CI and against the final macOS app bundle in release builds
- document a separate, fixed-scope future verification MCP without changing the existing read-only history MCP
- archive the validated OpenSpec and update product/operations status

## Validation
- `pnpm --dir apps/desktop run test:cli-qualification` (4/4)
- `pnpm --dir apps/desktop run qualify:cli` (actual prepared CLI: 1.7.0, 51,202,888 bytes, 6 help contracts)
- `pnpm --dir apps/desktop run lint`
- `pnpm --dir apps/desktop exec tsc --noEmit`
- `pnpm --dir apps/desktop run build`
- `TAURI_CONFIG={"bundle":{"externalBin":[]}} cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml --features browser-agent --bin codevetter` (3/3)
- `node scripts/check-docs.mjs`
- workflow YAML parse
- strict OpenSpec validation (37/37)
- `git diff --check`

## Boundary
This is scoped progress on #52. It does not implement a verification MCP binary, publish a release, or perform the operator-owned real external preview smoke.

Refs #52