### PR TITLE
feat: qualify agent task corpus samples

### DIFF
--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -38,13 +38,16 @@ Internal (fleet):
 
 ## Timeline
 
-- **2026-07-31 — Agent-task corpus contract foundation:** added six closed,
-  versioned machine contracts plus deterministic, dependency-free validation
-  for task/index identities, safe bounded artifacts, provenance, licenses,
-  qualification evidence, and strict corpus breadth. The owned one-task sample
-  is structurally valid but intentionally reports zero qualified tasks and
-  fails publishable readiness; no task checks, agents, model calls, or scorer
-  projections run in this slice.
+- **2026-07-31 — Agent-task corpus qualification foundation:** added closed,
+  versioned fixture, acceptance, exact known-good, check-result, qualification,
+  adapter, and runner contracts plus deterministic dependency-free validation.
+  Qualification now creates fresh public-input-only workspaces, applies exact
+  known-good replacements without a shell, executes immutable timeout-bounded
+  checks, preserves explicit failure/cleanup taxonomy, and emits v2 receipts.
+  The owned one-task sample repeats its intended baseline failure and
+  known-good success, so it reports one qualified task while strict readiness
+  remains closed on count and breadth. No agent, model, network, scorer, or
+  production path runs in this slice.
 - **2026-07-31 — T-Rex MCP and CLI artifact qualification:** fixed the future
   agent-triggered verification boundary as a separate, explicitly enabled MCP
   process so the existing history MCP remains read-only. Pull-request CI now
@@ -197,10 +200,11 @@ Internal (fleet):
 
 ### Benchmarks
 - Catch-rate benchmark harness (`benchmarks/agent-prs`): per-case or combined fixtures, `bench:new-case` starter, `bench:curation` readiness report, strict fixture validation, named CodeVetter / CodeRabbit free-tier / Claude Code comparator slots, false-positive and redundant-match counts, precision/F1, baseline deltas, severity-specific gates, JSON/Markdown report output.
-- Agent-task corpus foundation (`benchmarks/agent-tasks`): six closed JSON
-  contracts, two-level SHA-256 task identity, fail-closed local validation,
-  distinct non-strict/readiness commands, and an explicitly unqualified sample
-  for issue #53.
+- Agent-task corpus foundation (`benchmarks/agent-tasks`): ten closed JSON
+  schemas, two-level SHA-256 task identity, fail-closed local validation,
+  deterministic repeated baseline/known-good qualification, distinct
+  validate/qualify/readiness commands, and one qualified owned sample that
+  remains explicitly non-publishable for issue #53.
 - `--evidence-comparison=with:without` mode compares stored outputs with and without deterministic evidence search.
 - 27 hand-labeled public benchmark cases (`benchmark/cases/`) covering 7 languages and 15+ vulnerability types; `pnpm bench:public` scores catch-rate/precision/F1.
 

--- a/benchmarks/agent-tasks/contracts/acceptance-contract.schema.json
+++ b/benchmarks/agent-tasks/contracts/acceptance-contract.schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://codevetter.com/schemas/agent-task/acceptance-contract-v1.json",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "task_id",
+    "task_defining_failures",
+    "required_checks",
+    "regression_checks",
+    "driver",
+    "repetitions"
+  ],
+  "properties": {
+    "schema_version": { "const": "codevetter.agent-task-acceptance.v1" },
+    "task_id": { "$ref": "./common.schema.json#/$defs/id" },
+    "task_defining_failures": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 100,
+      "uniqueItems": true,
+      "items": { "$ref": "./common.schema.json#/$defs/id" }
+    },
+    "required_checks": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 100,
+      "items": { "$ref": "#/$defs/check" }
+    },
+    "regression_checks": {
+      "type": "array",
+      "maxItems": 100,
+      "items": { "$ref": "#/$defs/check" }
+    },
+    "driver": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "sha256", "timeout_ms"],
+      "properties": {
+        "path": { "$ref": "./common.schema.json#/$defs/relativePath" },
+        "sha256": { "$ref": "./common.schema.json#/$defs/sha256" },
+        "timeout_ms": { "type": "integer", "minimum": 10, "maximum": 60000 }
+      }
+    },
+    "repetitions": { "type": "integer", "minimum": 2, "maximum": 5 }
+  },
+  "$defs": {
+    "check": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "label"],
+      "properties": {
+        "id": { "$ref": "./common.schema.json#/$defs/id" },
+        "label": { "type": "string", "minLength": 1, "maxLength": 160 }
+      }
+    }
+  }
+}

--- a/benchmarks/agent-tasks/contracts/fixture-bundle.schema.json
+++ b/benchmarks/agent-tasks/contracts/fixture-bundle.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://codevetter.com/schemas/agent-task/fixture-bundle-v1.json",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "files"],
+  "properties": {
+    "schema_version": { "const": "codevetter.agent-task-fixture.v1" },
+    "files": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 100,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["path", "content_base64", "sha256"],
+        "properties": {
+          "path": { "$ref": "./common.schema.json#/$defs/relativePath" },
+          "content_base64": { "type": "string", "minLength": 4, "maxLength": 1398104 },
+          "sha256": { "$ref": "./common.schema.json#/$defs/sha256" }
+        }
+      }
+    }
+  }
+}

--- a/benchmarks/agent-tasks/contracts/known-good-change.schema.json
+++ b/benchmarks/agent-tasks/contracts/known-good-change.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://codevetter.com/schemas/agent-task/known-good-change-v1.json",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "task_id", "files"],
+  "properties": {
+    "schema_version": { "const": "codevetter.agent-task-known-good.v1" },
+    "task_id": { "$ref": "./common.schema.json#/$defs/id" },
+    "files": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 100,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["path", "before_sha256", "after_base64", "after_sha256"],
+        "properties": {
+          "path": { "$ref": "./common.schema.json#/$defs/relativePath" },
+          "before_sha256": { "$ref": "./common.schema.json#/$defs/sha256" },
+          "after_base64": { "type": "string", "minLength": 4, "maxLength": 1398104 },
+          "after_sha256": { "$ref": "./common.schema.json#/$defs/sha256" }
+        }
+      }
+    }
+  }
+}

--- a/benchmarks/agent-tasks/contracts/qualification-receipt-v2.schema.json
+++ b/benchmarks/agent-tasks/contracts/qualification-receipt-v2.schema.json
@@ -1,0 +1,99 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://codevetter.com/schemas/agent-task/qualification-receipt-v2.json",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "task_id",
+    "manifest_sha256",
+    "fixture_sha256",
+    "acceptance_contract_sha256",
+    "known_good_sha256",
+    "workspace_policy",
+    "qualified",
+    "baseline",
+    "known_good",
+    "cleanup",
+    "limitations"
+  ],
+  "properties": {
+    "schema_version": { "const": "codevetter.agent-task-qualification.v2" },
+    "task_id": { "$ref": "./common.schema.json#/$defs/id" },
+    "manifest_sha256": { "$ref": "./common.schema.json#/$defs/sha256" },
+    "fixture_sha256": { "$ref": "./common.schema.json#/$defs/sha256" },
+    "acceptance_contract_sha256": { "$ref": "./common.schema.json#/$defs/sha256" },
+    "known_good_sha256": { "$ref": "./common.schema.json#/$defs/sha256" },
+    "workspace_policy": { "const": "public_fixture_and_task_packet_v1" },
+    "qualified": { "type": "boolean" },
+    "baseline": { "$ref": "#/$defs/phase" },
+    "known_good": { "$ref": "#/$defs/phase" },
+    "cleanup": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status"],
+      "properties": { "status": { "enum": ["complete", "failed"] } }
+    },
+    "limitations": {
+      "type": "array",
+      "maxItems": 50,
+      "items": { "type": "string", "minLength": 1, "maxLength": 500 }
+    }
+  },
+  "$defs": {
+    "phase": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "attempts"],
+      "properties": {
+        "status": {
+          "enum": [
+            "intended_failure",
+            "wrong_failure",
+            "pass",
+            "patch_failure",
+            "check_failure",
+            "regression",
+            "setup_failure",
+            "timeout",
+            "incomplete_checks",
+            "check_error",
+            "flaky",
+            "cleanup_failure"
+          ]
+        },
+        "attempts": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 5,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["attempt", "outcome", "result_sha256"],
+            "properties": {
+              "attempt": { "type": "integer", "minimum": 1, "maximum": 5 },
+              "outcome": {
+                "enum": [
+                  "intended_failure",
+                  "wrong_failure",
+                  "pass",
+                  "patch_failure",
+                  "check_failure",
+                  "regression",
+                  "setup_failure",
+                  "timeout",
+                  "incomplete_checks",
+                  "check_error",
+                  "cleanup_failure"
+                ]
+              },
+              "result_sha256": {
+                "anyOf": [{ "$ref": "./common.schema.json#/$defs/sha256" }, { "type": "null" }]
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/benchmarks/agent-tasks/sample/corpus.json
+++ b/benchmarks/agent-tasks/sample/corpus.json
@@ -7,7 +7,11 @@
       "task_id": "preserve-explicit-false",
       "manifest": {
         "path": "tasks/preserve-explicit-false/task.json",
-        "sha256": "c00c443a2a58383497d8adb4bbd21989c412892f561273debe7a34d4b6a76c6f"
+        "sha256": "650229cec888569d5a0d6823b7dc1619f7f214bde8b66d4f9695d5fcb6844b08"
+      },
+      "qualification": {
+        "path": "qualification.json",
+        "sha256": "80c12293033d3e24023c885e164a7df4b24d5c4dd3604ded98cabe091a1b2ac2"
       }
     }
   ]

--- a/benchmarks/agent-tasks/sample/qualification.json
+++ b/benchmarks/agent-tasks/sample/qualification.json
@@ -1,0 +1,46 @@
+{
+  "schema_version": "codevetter.agent-task-qualification.v2",
+  "task_id": "preserve-explicit-false",
+  "manifest_sha256": "650229cec888569d5a0d6823b7dc1619f7f214bde8b66d4f9695d5fcb6844b08",
+  "fixture_sha256": "7573b5ca83bdc7286cf35693f070d12c6b6bddd99f1f7ef0659986f91d13fa0a",
+  "acceptance_contract_sha256": "ad86ac07ef32973d4df25a25b45721b3b32d717466fe5d61f7fe43396da51b81",
+  "known_good_sha256": "27a1390fa4048248c610afa469dbf0871c9dd80730116fd5ab9ec8679e2d8b62",
+  "workspace_policy": "public_fixture_and_task_packet_v1",
+  "qualified": true,
+  "baseline": {
+    "status": "intended_failure",
+    "attempts": [
+      {
+        "attempt": 1,
+        "outcome": "intended_failure",
+        "result_sha256": "b4439564103e9f775e797030835b2c80dce120585b43053302e0c8082023251c"
+      },
+      {
+        "attempt": 2,
+        "outcome": "intended_failure",
+        "result_sha256": "b4439564103e9f775e797030835b2c80dce120585b43053302e0c8082023251c"
+      }
+    ]
+  },
+  "known_good": {
+    "status": "pass",
+    "attempts": [
+      {
+        "attempt": 1,
+        "outcome": "pass",
+        "result_sha256": "96868924a4e7e7f02a16e93248ba89ff479df05fbf73e6dfa8726a12e56c9a20"
+      },
+      {
+        "attempt": 2,
+        "outcome": "pass",
+        "result_sha256": "96868924a4e7e7f02a16e93248ba89ff479df05fbf73e6dfa8726a12e56c9a20"
+      }
+    ]
+  },
+  "cleanup": {
+    "status": "complete"
+  },
+  "limitations": [
+    "Qualification executes trusted corpus check code without an operating-system sandbox."
+  ]
+}

--- a/benchmarks/agent-tasks/sample/tasks/preserve-explicit-false/acceptance-contract.json
+++ b/benchmarks/agent-tasks/sample/tasks/preserve-explicit-false/acceptance-contract.json
@@ -1,6 +1,27 @@
 {
   "schema_version": "codevetter.agent-task-acceptance.v1",
   "task_id": "preserve-explicit-false",
-  "required_checks": ["explicit-false-preserved"],
-  "regression_checks": ["label-preserved"]
+  "task_defining_failures": ["explicit-false-preserved"],
+  "required_checks": [
+    {
+      "id": "explicit-false-preserved",
+      "label": "An explicit false value is preserved"
+    }
+  ],
+  "regression_checks": [
+    {
+      "id": "label-preserved",
+      "label": "The caller-provided label is preserved"
+    },
+    {
+      "id": "public-inputs-only",
+      "label": "The workspace contains only fixture files and the public task packet"
+    }
+  ],
+  "driver": {
+    "path": "checks.mjs",
+    "sha256": "87a15682466972ddcabf040b32bc7a51d27ae25fb026b5dc6982decb8c59151b",
+    "timeout_ms": 5000
+  },
+  "repetitions": 2
 }

--- a/benchmarks/agent-tasks/sample/tasks/preserve-explicit-false/checks.mjs
+++ b/benchmarks/agent-tasks/sample/tasks/preserve-explicit-false/checks.mjs
@@ -1,0 +1,50 @@
+import { readdir } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const [workspace, taskId, acceptanceSha256, phase, attempt] = process.argv.slice(2);
+
+async function listFiles(root, directory = root) {
+  const files = [];
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await listFiles(root, path)));
+    } else if (entry.isFile()) {
+      files.push(relative(root, path));
+    }
+  }
+  return files.sort();
+}
+
+const moduleUrl = pathToFileURL(join(workspace, 'transformer.mjs'));
+moduleUrl.searchParams.set('qualification', `${phase}-${attempt}`);
+const { transform } = await import(moduleUrl.href);
+const input = { enabled: false, label: 'Keep the explicit false value' };
+const output = transform(input);
+const files = await listFiles(workspace);
+
+process.stdout.write(
+  JSON.stringify({
+    schema_version: 'codevetter.agent-task-check-result.v1',
+    task_id: taskId,
+    acceptance_contract_sha256: acceptanceSha256,
+    results: [
+      {
+        id: 'explicit-false-preserved',
+        status: output.enabled === false ? 'pass' : 'fail',
+      },
+      {
+        id: 'label-preserved',
+        status: output.label === input.label ? 'pass' : 'fail',
+      },
+      {
+        id: 'public-inputs-only',
+        status:
+          JSON.stringify(files) === JSON.stringify(['TASK.md', 'transformer.mjs'])
+            ? 'pass'
+            : 'fail',
+      },
+    ],
+  })
+);

--- a/benchmarks/agent-tasks/sample/tasks/preserve-explicit-false/fixture.json
+++ b/benchmarks/agent-tasks/sample/tasks/preserve-explicit-false/fixture.json
@@ -1,10 +1,10 @@
 {
-  "input": {
-    "enabled": false,
-    "label": "Keep the explicit false value"
-  },
-  "current_output": {
-    "enabled": true,
-    "label": "Keep the explicit false value"
-  }
+  "schema_version": "codevetter.agent-task-fixture.v1",
+  "files": [
+    {
+      "path": "transformer.mjs",
+      "content_base64": "ZXhwb3J0IGZ1bmN0aW9uIHRyYW5zZm9ybShpbnB1dCkgewogIHJldHVybiB7CiAgICBlbmFibGVkOiBpbnB1dC5lbmFibGVkIHx8IHRydWUsCiAgICBsYWJlbDogaW5wdXQubGFiZWwgPz8gJ0RlZmF1bHQnLAogIH07Cn0K",
+      "sha256": "a735f90ea072eb1402af13969aeeff834018b30e0a49c4c43b6a3a36a6a022d5"
+    }
+  ]
 }

--- a/benchmarks/agent-tasks/sample/tasks/preserve-explicit-false/known-good.json
+++ b/benchmarks/agent-tasks/sample/tasks/preserve-explicit-false/known-good.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "codevetter.agent-task-known-good.v1",
+  "task_id": "preserve-explicit-false",
+  "files": [
+    {
+      "path": "transformer.mjs",
+      "before_sha256": "a735f90ea072eb1402af13969aeeff834018b30e0a49c4c43b6a3a36a6a022d5",
+      "after_base64": "ZXhwb3J0IGZ1bmN0aW9uIHRyYW5zZm9ybShpbnB1dCkgewogIHJldHVybiB7CiAgICBlbmFibGVkOiBpbnB1dC5lbmFibGVkID8/IHRydWUsCiAgICBsYWJlbDogaW5wdXQubGFiZWwgPz8gJ0RlZmF1bHQnLAogIH07Cn0K",
+      "after_sha256": "ffbc8c47cf78435dcfa6f5dcc79f29d65dc2fd785eea4d35569a74e3d85c3444"
+    }
+  ]
+}

--- a/benchmarks/agent-tasks/sample/tasks/preserve-explicit-false/known-good.patch
+++ b/benchmarks/agent-tasks/sample/tasks/preserve-explicit-false/known-good.patch
@@ -1,5 +1,0 @@
---- a/transformer.mjs
-+++ b/transformer.mjs
-@@
--  enabled: input.enabled || true,
-+  enabled: input.enabled ?? true,

--- a/benchmarks/agent-tasks/sample/tasks/preserve-explicit-false/task.json
+++ b/benchmarks/agent-tasks/sample/tasks/preserve-explicit-false/task.json
@@ -9,7 +9,7 @@
   "artifacts": {
     "fixture": {
       "path": "fixture.json",
-      "sha256": "0cdbb8dfcf729ee3bc0b0e8123521a1f37edacdac42e87e729f1fc6dcd33a785"
+      "sha256": "7573b5ca83bdc7286cf35693f070d12c6b6bddd99f1f7ef0659986f91d13fa0a"
     },
     "task_packet": {
       "path": "task.md",
@@ -17,15 +17,15 @@
     },
     "acceptance_contract": {
       "path": "acceptance-contract.json",
-      "sha256": "b1f3c7157677f0b87406aca4aa814cfe6e1d080763bd6ebafd212cf717765dd9"
+      "sha256": "ad86ac07ef32973d4df25a25b45721b3b32d717466fe5d61f7fe43396da51b81"
     },
     "known_good_patch": {
-      "path": "known-good.patch",
-      "sha256": "cabe7b1fed6be3a29089ac4377b64583574004d7cce07152af351386fe6c6563"
+      "path": "known-good.json",
+      "sha256": "27a1390fa4048248c610afa469dbf0871c9dd80730116fd5ab9ec8679e2d8b62"
     }
   },
   "required_checks": ["explicit-false-preserved"],
-  "regression_checks": ["label-preserved"],
+  "regression_checks": ["label-preserved", "public-inputs-only"],
   "provenance": {
     "kind": "owned",
     "repository": "Codevetter/codevetter",

--- a/docs/development/agent-task-corpus.md
+++ b/docs/development/agent-task-corpus.md
@@ -7,13 +7,14 @@ sidebar:
 
 # Agent-task corpus contracts
 
-This is the contract foundation for
+This is the contract and qualification foundation for
 [GitHub issue #53](https://github.com/Codevetter/codevetter/issues/53). It makes
-task packages inspectable and immutable before CodeVetter gains authority to
-qualify tasks or launch an agent.
+task packages inspectable and immutable, then proves their baseline failure and
+known-good success without launching an agent.
 
-The current sample is deliberately small and unqualified. It proves structural
-validation only; it is not benchmark evidence.
+The current owned sample is qualified through the real local path. It proves
+the machinery, not product value: one synthetic task remains far below corpus
+readiness.
 
 ## Commands
 
@@ -23,6 +24,9 @@ Run from the repository root:
 pnpm corpus:validate
 pnpm corpus:validate --json
 pnpm corpus:validate --root benchmarks/agent-tasks/sample --json
+pnpm corpus:qualify --task preserve-explicit-false
+pnpm corpus:qualify --task preserve-explicit-false --json
+pnpm corpus:qualify --task preserve-explicit-false --out /tmp/qualification.json
 pnpm corpus:readiness
 pnpm corpus:readiness --json
 pnpm test:corpus-contracts
@@ -43,6 +47,13 @@ strict gates pass:
 Both commands support deterministic human and JSON output. Invalid input always
 exits non-zero.
 
+`corpus:qualify` creates two fresh baseline workspaces and two fresh known-good
+workspaces by default, runs the immutable task check driver without a shell,
+and emits a deterministic v2 receipt. It exits `0` only when the task-defining
+failure repeats at baseline, every check repeats successfully after the
+known-good replacement, and every workspace is removed. `--out` writes the
+receipt atomically.
+
 ## Layout
 
 ```text
@@ -51,23 +62,30 @@ benchmarks/agent-tasks/
 │   ├── common.schema.json
 │   ├── corpus-index.schema.json
 │   ├── task-manifest.schema.json
+│   ├── fixture-bundle.schema.json
+│   ├── acceptance-contract.schema.json
+│   ├── known-good-change.schema.json
 │   ├── check-result.schema.json
 │   ├── qualification-receipt.schema.json
+│   ├── qualification-receipt-v2.schema.json
 │   ├── agent-adapter.schema.json
 │   └── run-receipt.schema.json
 └── sample/
     ├── corpus.json
+    ├── qualification.json
     └── tasks/<task-id>/
         ├── task.json
         ├── fixture.json
         ├── task.md
         ├── acceptance-contract.json
-        └── known-good.patch
+        ├── checks.mjs
+        └── known-good.json
 ```
 
-The sample uses small regular files for contract proof. Later realistic tasks
-may use bounded owned fixture archives, but the manifest still treats each
-archive as one immutable artifact.
+The fixture is a closed, bounded bundle of sorted base64 files. The known-good
+change is a sorted list of exact file replacements with before/after SHA-256
+identities. Qualification does not invoke `tar`, `patch`, a package manager, or
+the network.
 
 ## Identity chain
 
@@ -92,6 +110,24 @@ task definition. Strict readiness counts a task only when the receipt:
 - records repeated known-good success; and
 - derives `qualified: true` from those exact states.
 
+V1 receipts remain readable. V2 additionally binds the fixture, acceptance
+contract, known-good change, public-input workspace policy, ordered attempt
+outcomes/result identities, and cleanup result.
+
+## Qualification boundary
+
+Every attempt starts from a new temporary directory containing only decoded
+fixture files and `TASK.md`. The acceptance contract, known-good data, and
+check driver stay outside that workspace. Known-good qualification performs
+only declared exact replacements after checking the before hash.
+
+The driver runs under Node with `shell: false`, a declared timeout, bounded
+stdout/stderr, and a minimal environment. Its stdout must be one closed
+check-result document with the exact required and regression inventory.
+Qualification distinguishes wrong baseline failure, incomplete checks,
+timeouts, check errors, flakiness, patch drift, regression, and cleanup failure.
+Receipts omit temporary paths, timing, environment values, and raw output.
+
 ## Authoring rules
 
 - Keep task IDs, category IDs, failure modes, and check IDs lowercase
@@ -113,17 +149,17 @@ shortfalls with sorted path-specific errors.
 
 ## Current authority boundary
 
-Validation and readiness only read local files and compute hashes. They do not:
+Validation and readiness only read local files and compute hashes.
+Qualification may create bounded temporary workspaces and execute the trusted
+repository-owned check driver. These paths do not:
 
-- execute fixture setup or task checks;
-- apply the known-good patch;
-- create a qualification receipt;
 - launch an agent or subprocess adapter;
 - read credentials or environment values;
 - make network requests;
 - project receipts into the structural-context evaluator; or
 - mutate corpus content.
 
-Those capabilities remain later, separately reviewed slices on issue #53.
-Until qualification exists, the sample must continue to report `0 qualified`
-and `publishable: false`.
+Agent execution and evaluator projection remain later, separately reviewed
+slices on issue #53. The sample reports `1 qualified` and
+`publishable: false`; task count, browser-lane, TypeScript-runtime, and category
+breadth gates remain closed.

--- a/docs/operations/ci.md
+++ b/docs/operations/ci.md
@@ -23,8 +23,9 @@ Steps, in order (a failure stops the job):
 8. **Unit tests** — `pnpm run test:unit` in `apps/desktop`
 9. **Automation readiness tests** — `pnpm run test:automation` and
    `pnpm run test:corpus-contracts` at root (hermetic Foundry receipt
-   sanitization plus agent-task contract/readiness tests; the live manifest
-   verifier runs in `release.yml` as a post-upload check, not here)
+   sanitization plus agent-task contract, qualification, timeout, cleanup, and
+   readiness tests; the live manifest verifier runs in `release.yml` as a
+   post-upload check, not here)
 10. **MCP sidecar build smoke** — `pnpm run prepare:mcp-sidecar`
 11. **CLI sidecar build smoke** — `pnpm run prepare:cli-sidecar`
 12. **CLI artifact qualification** — focused script tests plus

--- a/openspec/changes/archive/2026-07-31-add-agent-task-qualification/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-31-add-agent-task-qualification/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-31

--- a/openspec/changes/archive/2026-07-31-add-agent-task-qualification/design.md
+++ b/openspec/changes/archive/2026-07-31-add-agent-task-qualification/design.md
@@ -1,0 +1,103 @@
+## Context
+
+The contract foundation on `main` validates task/index identities and can count
+qualification receipts, but it deliberately has no authority to create them.
+The current sample artifacts are descriptive placeholders rather than an
+executable owned fixture. This slice must establish qualification without
+crossing into agent execution or adding a package dependency.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Prove one real owned task through the same repeated qualification path later
+  corpus tasks will use.
+- Keep public task inputs, withheld checks, and known-good material physically
+  distinct during every attempt.
+- Preserve exact failure taxonomy in a deterministic machine receipt.
+- Make cleanup and timeout behavior testable without leaking temporary paths
+  into the receipt.
+
+**Non-Goals:**
+
+- Provide adversarial host isolation from a malicious check driver.
+- Launch an agent adapter or dry-run an agent plan.
+- Support arbitrary archive formats, package installation, or network setup.
+- Count the one-task sample as a publishable corpus.
+
+## Decisions
+
+### Represent the fixture and known-good change as closed data bundles
+
+The fixture bundle contains a sorted list of bounded POSIX-relative files with
+base64 content and exact decoded SHA-256. The known-good change contains sorted
+exact file replacements with before/after identities and bounded base64
+content.
+
+This avoids shelling out to `tar`, `patch`, or package managers and makes path,
+content, and mutation bounds inspectable. It is intentionally narrower than a
+general patch engine; later realistic tasks can store a bounded owned archive
+only after an explicit format proposal.
+
+### Keep the acceptance contract and driver outside the workspace
+
+The acceptance contract declares the task-defining failure IDs, exact required
+and regression inventories, repetition count, and one immutable driver path,
+hash, and timeout. Qualification executes the driver with Node, `shell: false`,
+and passes only workspace, task, acceptance identity, and attempt metadata.
+
+The driver is procedural withheld evidence, not an agent-visible file. This is
+not a sandbox claim: the receipt calls the policy
+`public_fixture_and_task_packet_v1`, and the driver is trusted corpus code.
+
+### Use a version-2 qualification receipt
+
+The already-published v1 contract remains readable. Qualification emits v2,
+which adds immutable fixture/acceptance/known-good identities, the workspace
+policy, ordered per-attempt outcome/result identities, and cleanup status.
+Corpus validation accepts both versions but the new sample uses v2.
+
+This preserves compatibility instead of silently changing v1 while giving
+failure taxonomy enough structure for later runner composition.
+
+### Run fresh baseline and known-good attempts
+
+Each attempt creates a new temporary directory, materializes only public input,
+optionally applies the known-good replacements, executes the driver once, and
+removes the directory in a `finally` boundary. The default repetition count is
+two and the contract bounds it to two through five.
+
+Phase status is derived after all attempts. Any cleanup failure is retained as
+`cleanup_failure`; check-status disagreement becomes `flaky`; no later success
+can overwrite those states.
+
+### Hash results, do not retain workspace-local details
+
+Each attempt retains its ordinal, derived outcome, and canonical check-result
+SHA-256. The aggregate receipt contains no temporary path, stdout/stderr,
+environment value, timestamp, or duration. Diagnostic command output can name
+the stable task/check IDs only.
+
+This makes deterministic requalification possible and keeps the receipt
+bounded. Future runner receipts can preserve bounded runtime diagnostics under
+their separate contract.
+
+## Risks / Trade-offs
+
+- **A trusted driver reads outside the workspace** → State the procedural
+  boundary honestly; stronger sandboxing belongs to the agent-runner slice.
+- **Base64 fixture bundles are verbose** → Bound them to small owned seed
+  fixtures; introduce archives only with explicit traversal-safe extraction.
+- **Cleanup failure is difficult to reproduce naturally** → Inject the owned
+  workspace remover in focused tests while the CLI uses the real remover.
+- **Check output includes noisy text** → Capture bounded stdout/stderr and parse
+  only the closed JSON stdout document; never place raw output in receipts.
+
+## Migration Plan
+
+Convert the one-task sample to the executable v1 fixture/acceptance/change
+contracts, generate its deterministic v2 qualification receipt, and reference
+that receipt from the corpus index. Strict readiness remains closed because the
+corpus is below 30 tasks and lacks lane/category breadth. Rollback removes the
+qualification command/receipt and restores the unqualified sample reference;
+no production state changes.

--- a/openspec/changes/archive/2026-07-31-add-agent-task-qualification/proposal.md
+++ b/openspec/changes/archive/2026-07-31-add-agent-task-qualification/proposal.md
@@ -1,0 +1,48 @@
+## Why
+
+CodeVetter can now prove that task packages are structurally valid, but it
+cannot prove that a baseline fails for the intended reason or that the
+known-good change passes without regressions. Issue #53 needs that qualification
+authority before any task can count toward corpus readiness or any agent is
+launched.
+
+## What Changes
+
+- Add closed fixture-bundle, acceptance-contract, and known-good change
+  contracts that extend the existing immutable task identity chain.
+- Prepare fresh owned temporary workspaces containing only bounded public
+  fixture files and the public task packet.
+- Run an exact shell-free check driver outside the workspace under timeout and
+  require one closed result for every declared required and regression check.
+- Repeat clean baseline checks and require at least one declared task-defining
+  failure while preserving wrong failure, check error, incomplete inventory,
+  timeout, and flaky outcomes distinctly.
+- Apply the exact known-good change in fresh workspaces and require repeated
+  complete acceptance and regression success.
+- Emit a deterministic qualification receipt, qualify the owned sample through
+  the real path, and keep strict corpus readiness closed below its breadth gate.
+- Add no agent/model launch, provider adapter execution, scorer projection,
+  network access, desktop route, or production behavior.
+
+## Capabilities
+
+### New Capabilities
+
+- `agent-task-qualification`: Defines safe public-input workspace preparation,
+  closed check execution, repeated baseline/known-good proof, exact outcome
+  classification, cleanup, and deterministic qualification receipts.
+
+### Modified Capabilities
+
+- `agent-task-corpus-contracts`: Extends the closed contract surface and task
+  artifact validation to the fixture, acceptance, and known-good change
+  documents consumed by qualification.
+
+## Impact
+
+- Extends `benchmarks/agent-tasks/contracts/` and the owned sample task.
+- Adds qualification implementation and tests under
+  `scripts/agent-task-corpus/`, plus one root `pnpm` command.
+- Updates corpus authoring/CI documentation and durable project status.
+- Adds no package dependency, Tauri/SQLite/API change, credential access,
+  deployment, release, or production configuration.

--- a/openspec/changes/archive/2026-07-31-add-agent-task-qualification/specs/agent-task-corpus-contracts/spec.md
+++ b/openspec/changes/archive/2026-07-31-add-agent-task-qualification/specs/agent-task-corpus-contracts/spec.md
@@ -1,0 +1,20 @@
+## MODIFIED Requirements
+
+### Requirement: Corpus documents use closed versioned contracts
+
+The system SHALL define closed versioned contracts for corpus indexes, task
+manifests, fixture bundles, acceptance contracts, known-good changes, check
+results, qualification receipts, agent adapters, and run receipts. Every
+contract MUST reject unknown fields, missing required fields, invalid enum
+values, duplicate identifiers, and values outside declared bounds.
+
+#### Scenario: A contract document is valid
+
+- **WHEN** a document contains exactly the required and optional fields for its
+  declared schema version and every value is within bounds
+- **THEN** contract validation accepts it without adding inferred values
+
+#### Scenario: An unknown field appears
+
+- **WHEN** any contract object contains a field not declared by its schema
+- **THEN** validation rejects the document and identifies the exact field path

--- a/openspec/changes/archive/2026-07-31-add-agent-task-qualification/specs/agent-task-qualification/spec.md
+++ b/openspec/changes/archive/2026-07-31-add-agent-task-qualification/specs/agent-task-qualification/spec.md
@@ -1,0 +1,117 @@
+## Purpose
+
+Defines deterministic proof that an immutable agent task has the intended
+baseline failure and a complete regression-free known-good solution.
+
+## ADDED Requirements
+
+### Requirement: Qualification workspaces expose only public task inputs
+
+Each qualification attempt SHALL use a fresh owned temporary workspace
+containing only bounded regular files declared by the fixture bundle and one
+copy of the public task packet. The workspace MUST NOT contain the acceptance
+contract, check driver, known-good change, qualification receipt, corpus index,
+or paths that identify those withheld artifacts.
+
+#### Scenario: A baseline workspace is prepared
+
+- **WHEN** qualification begins one clean baseline attempt
+- **THEN** the workspace contains exactly the public fixture files and task
+  packet declared by the immutable task package
+
+#### Scenario: A fixture path is unsafe
+
+- **WHEN** a fixture file is absolute, traverses a parent, is duplicated, has a
+  mismatched identity, or exceeds a bound
+- **THEN** setup fails before any check driver runs
+
+### Requirement: Check execution is closed, exact, and bounded
+
+Qualification SHALL launch the immutable declared check driver without a shell,
+outside the task workspace, with an explicit timeout. The driver MUST emit one
+schema-valid result for every declared required and regression check, with no
+unknown or duplicate result. Process status and result contents MUST agree.
+
+#### Scenario: The driver returns the exact inventory
+
+- **WHEN** the driver exits successfully with one valid result for every
+  declared check
+- **THEN** qualification classifies the attempt from those exact results
+
+#### Scenario: The driver times out or omits a result
+
+- **WHEN** the driver exceeds its timeout or returns an incomplete inventory
+- **THEN** the attempt records `timeout` or `incomplete_checks` distinctly and
+  cannot qualify the task
+
+### Requirement: Baseline failure is repeated and task-defining
+
+Qualification SHALL run at least two fresh baseline attempts. Every attempt
+MUST fail at least one declared task-defining required check, MUST preserve the
+same exact check statuses across repetitions, and MUST keep regression checks
+passing. Wrong failure, check error, timeout, incomplete inventory, flakiness,
+and cleanup failure SHALL remain distinct outcomes.
+
+#### Scenario: The baseline fails as intended twice
+
+- **WHEN** every clean baseline attempt has the same declared task-defining
+  failure and every regression check passes
+- **THEN** the baseline phase records `intended_failure`
+
+#### Scenario: Baseline repetitions disagree
+
+- **WHEN** otherwise valid baseline attempts produce different check statuses
+- **THEN** the baseline phase records `flaky` and the task remains unqualified
+
+### Requirement: Known-good success is repeated and regression-free
+
+Qualification SHALL apply only the immutable declared known-good file changes
+after verifying every before identity. It SHALL run at least two fresh
+known-good attempts and require every required and regression check to pass
+with identical inventories. Patch failure, check failure, regression, timeout,
+incomplete inventory, check error, flakiness, and cleanup failure SHALL remain
+distinct outcomes.
+
+#### Scenario: The known-good change passes twice
+
+- **WHEN** every before identity matches, every declared change is applied, and
+  all repeated required and regression checks pass
+- **THEN** the known-good phase records `pass`
+
+#### Scenario: The known-good change regresses existing behavior
+
+- **WHEN** required checks pass but any regression check fails
+- **THEN** the known-good phase records `regression` and the task remains
+  unqualified
+
+### Requirement: Qualification receipts are deterministic and fail closed
+
+Qualification SHALL emit a bounded versioned receipt tied to the exact task,
+manifest, acceptance contract, fixture, known-good change, per-attempt result
+identities, workspace policy, phase outcomes, cleanup state, and limitations.
+`qualified` MUST be true only when all baseline attempts record
+`intended_failure`, all known-good attempts record `pass`, and cleanup succeeds.
+
+#### Scenario: Unchanged qualification is repeated
+
+- **WHEN** unchanged task bytes and deterministic checks are qualified again
+- **THEN** the semantic receipt and its SHA-256 identity are identical
+
+#### Scenario: Any phase is not authoritative
+
+- **WHEN** setup, patching, checks, repetition, or cleanup does not meet its
+  exact contract
+- **THEN** a diagnostic receipt is still returned, `qualified` is false, and
+  the command exits non-zero
+
+### Requirement: Qualification does not launch an agent
+
+Task qualification MAY execute the declared fixture check driver but MUST NOT
+launch an agent adapter, call a model/provider, read credential values, make a
+network request, or project a run into the structural-context evaluator.
+
+#### Scenario: An operator qualifies a task
+
+- **WHEN** the qualification command completes or fails
+- **THEN** its receipt records check evidence only and contains no fabricated
+  agent, model, token, cost, tool, or scorer data

--- a/openspec/changes/archive/2026-07-31-add-agent-task-qualification/tasks.md
+++ b/openspec/changes/archive/2026-07-31-add-agent-task-qualification/tasks.md
@@ -1,0 +1,45 @@
+## 1. Qualification Contracts
+
+- [x] 1.1 Add closed fixture-bundle, acceptance-contract, known-good change,
+  and v2 qualification-receipt schemas plus semantic validators.
+- [x] 1.2 Extend corpus validation to inspect the three nested task contracts,
+  immutable check-driver identity, and v1/v2 qualification evidence.
+
+## 2. Workspace and Check Execution
+
+- [x] 2.1 Implement bounded fresh workspace materialization containing only
+  declared fixture files and the public task packet.
+- [x] 2.2 Implement exact known-good file replacement with before/after
+  identities and no shell.
+- [x] 2.3 Implement timeout-bounded shell-free check-driver execution, closed
+  result parsing, exact inventory enforcement, and bounded diagnostics.
+- [x] 2.4 Guarantee workspace cleanup in every attempt and preserve cleanup
+  failure as an explicit outcome.
+
+## 3. Qualification and Receipt
+
+- [x] 3.1 Implement repeated baseline classification for intended failure,
+  wrong failure, timeout, incomplete checks, check error, flakiness, and
+  cleanup failure.
+- [x] 3.2 Implement repeated known-good classification for pass, patch failure,
+  check failure, regression, timeout, incomplete checks, check error,
+  flakiness, and cleanup failure.
+- [x] 3.3 Emit deterministic v2 qualification receipts and a root CLI command
+  with human/JSON output plus optional atomic receipt output.
+
+## 4. Owned Proof and Tests
+
+- [x] 4.1 Convert the owned sample into an executable fixture, acceptance
+  driver, and known-good change; generate and index its real qualification
+  receipt while strict corpus readiness remains closed.
+- [x] 4.2 Add focused tests for public-input isolation, deterministic success,
+  wrong failure, incomplete inventory, timeout, flakiness, known-good
+  regression, patch drift, and cleanup failure.
+- [x] 4.3 Update corpus authoring, CI, and project-status documentation.
+
+## 5. Delivery
+
+- [x] 5.1 Run focused tests, sample qualification, corpus validation/readiness,
+  lint, docs, workflow YAML, strict OpenSpec validation, and diff checks.
+- [x] 5.2 Archive the change and deliver it through a pull request linked to
+  issue #53 without claiming agent execution or corpus readiness.

--- a/openspec/specs/agent-task-corpus-contracts/spec.md
+++ b/openspec/specs/agent-task-corpus-contracts/spec.md
@@ -7,10 +7,10 @@ build a reproducible coding-agent task corpus without launching an agent.
 ### Requirement: Corpus documents use closed versioned contracts
 
 The system SHALL define closed versioned contracts for corpus indexes, task
-manifests, check results, qualification receipts, agent adapters, and run
-receipts. Every contract MUST reject unknown fields, missing required fields,
-invalid enum values, duplicate identifiers, and values outside declared
-bounds.
+manifests, fixture bundles, acceptance contracts, known-good changes, check
+results, qualification receipts, agent adapters, and run receipts. Every
+contract MUST reject unknown fields, missing required fields, invalid enum
+values, duplicate identifiers, and values outside declared bounds.
 
 #### Scenario: A contract document is valid
 

--- a/openspec/specs/agent-task-qualification/spec.md
+++ b/openspec/specs/agent-task-qualification/spec.md
@@ -1,0 +1,119 @@
+# agent-task-qualification Specification
+
+## Purpose
+
+Defines deterministic proof that an immutable agent task has the intended
+baseline failure and a complete regression-free known-good solution.
+
+## Requirements
+
+### Requirement: Qualification workspaces expose only public task inputs
+
+Each qualification attempt SHALL use a fresh owned temporary workspace
+containing only bounded regular files declared by the fixture bundle and one
+copy of the public task packet. The workspace MUST NOT contain the acceptance
+contract, check driver, known-good change, qualification receipt, corpus index,
+or paths that identify those withheld artifacts.
+
+#### Scenario: A baseline workspace is prepared
+
+- **WHEN** qualification begins one clean baseline attempt
+- **THEN** the workspace contains exactly the public fixture files and task
+  packet declared by the immutable task package
+
+#### Scenario: A fixture path is unsafe
+
+- **WHEN** a fixture file is absolute, traverses a parent, is duplicated, has a
+  mismatched identity, or exceeds a bound
+- **THEN** setup fails before any check driver runs
+
+### Requirement: Check execution is closed, exact, and bounded
+
+Qualification SHALL launch the immutable declared check driver without a shell,
+outside the task workspace, with an explicit timeout. The driver MUST emit one
+schema-valid result for every declared required and regression check, with no
+unknown or duplicate result. Process status and result contents MUST agree.
+
+#### Scenario: The driver returns the exact inventory
+
+- **WHEN** the driver exits successfully with one valid result for every
+  declared check
+- **THEN** qualification classifies the attempt from those exact results
+
+#### Scenario: The driver times out or omits a result
+
+- **WHEN** the driver exceeds its timeout or returns an incomplete inventory
+- **THEN** the attempt records `timeout` or `incomplete_checks` distinctly and
+  cannot qualify the task
+
+### Requirement: Baseline failure is repeated and task-defining
+
+Qualification SHALL run at least two fresh baseline attempts. Every attempt
+MUST fail at least one declared task-defining required check, MUST preserve the
+same exact check statuses across repetitions, and MUST keep regression checks
+passing. Wrong failure, check error, timeout, incomplete inventory, flakiness,
+and cleanup failure SHALL remain distinct outcomes.
+
+#### Scenario: The baseline fails as intended twice
+
+- **WHEN** every clean baseline attempt has the same declared task-defining
+  failure and every regression check passes
+- **THEN** the baseline phase records `intended_failure`
+
+#### Scenario: Baseline repetitions disagree
+
+- **WHEN** otherwise valid baseline attempts produce different check statuses
+- **THEN** the baseline phase records `flaky` and the task remains unqualified
+
+### Requirement: Known-good success is repeated and regression-free
+
+Qualification SHALL apply only the immutable declared known-good file changes
+after verifying every before identity. It SHALL run at least two fresh
+known-good attempts and require every required and regression check to pass
+with identical inventories. Patch failure, check failure, regression, timeout,
+incomplete inventory, check error, flakiness, and cleanup failure SHALL remain
+distinct outcomes.
+
+#### Scenario: The known-good change passes twice
+
+- **WHEN** every before identity matches, every declared change is applied, and
+  all repeated required and regression checks pass
+- **THEN** the known-good phase records `pass`
+
+#### Scenario: The known-good change regresses existing behavior
+
+- **WHEN** required checks pass but any regression check fails
+- **THEN** the known-good phase records `regression` and the task remains
+  unqualified
+
+### Requirement: Qualification receipts are deterministic and fail closed
+
+Qualification SHALL emit a bounded versioned receipt tied to the exact task,
+manifest, acceptance contract, fixture, known-good change, per-attempt result
+identities, workspace policy, phase outcomes, cleanup state, and limitations.
+`qualified` MUST be true only when all baseline attempts record
+`intended_failure`, all known-good attempts record `pass`, and cleanup succeeds.
+
+#### Scenario: Unchanged qualification is repeated
+
+- **WHEN** unchanged task bytes and deterministic checks are qualified again
+- **THEN** the semantic receipt and its SHA-256 identity are identical
+
+#### Scenario: Any phase is not authoritative
+
+- **WHEN** setup, patching, checks, repetition, or cleanup does not meet its
+  exact contract
+- **THEN** a diagnostic receipt is still returned, `qualified` is false, and
+  the command exits non-zero
+
+### Requirement: Qualification does not launch an agent
+
+Task qualification MAY execute the declared fixture check driver but MUST NOT
+launch an agent adapter, call a model/provider, read credential values, make a
+network request, or project a run into the structural-context evaluator.
+
+#### Scenario: An operator qualifies a task
+
+- **WHEN** the qualification command completes or fails
+- **THEN** its receipt records check evidence only and contains no fabricated
+  agent, model, token, cost, tool, or scorer data

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "bench:curate-public": "node scripts/curate-public-agent-prs.mjs",
     "corpus:validate": "node scripts/agent-task-corpus/cli.mjs",
     "corpus:readiness": "node scripts/agent-task-corpus/cli.mjs --strict",
+    "corpus:qualify": "node scripts/agent-task-corpus/qualify-cli.mjs",
     "test:benchmark": "node --test scripts/run-catch-rate-benchmark.test.mjs scripts/run-structural-context-evaluation.test.mjs",
     "test:graph-context": "node --test scripts/run-structural-context-evaluation.test.mjs",
     "test:corpus-contracts": "node --test scripts/agent-task-corpus/*.test.mjs",

--- a/scripts/agent-task-corpus/contracts.mjs
+++ b/scripts/agent-task-corpus/contracts.mjs
@@ -2,10 +2,14 @@ import { createHash } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 
 export const CONTRACT_SCHEMA_VERSIONS = Object.freeze({
+  'acceptance-contract': 'codevetter.agent-task-acceptance.v1',
   'agent-adapter': 'codevetter.agent-task-adapter.v1',
   'check-result': 'codevetter.agent-task-check-result.v1',
   'corpus-index': 'codevetter.agent-task-corpus.v1',
+  'fixture-bundle': 'codevetter.agent-task-fixture.v1',
+  'known-good-change': 'codevetter.agent-task-known-good.v1',
   'qualification-receipt': 'codevetter.agent-task-qualification.v1',
+  'qualification-receipt-v2': 'codevetter.agent-task-qualification.v2',
   'run-receipt': 'codevetter.agent-task-run.v1',
   'task-manifest': 'codevetter.agent-task.v1',
 });
@@ -196,6 +200,14 @@ function validateCheckResult(value, path, errors) {
 }
 
 function validateQualificationReceipt(value, path, errors) {
+  if (value?.schema_version === CONTRACT_SCHEMA_VERSIONS['qualification-receipt-v2']) {
+    validateQualificationReceiptV2(value, path, errors);
+    return;
+  }
+  validateQualificationReceiptV1(value, path, errors);
+}
+
+function validateQualificationReceiptV1(value, path, errors) {
   const fields = [
     'schema_version',
     'task_id',
@@ -234,6 +246,182 @@ function validateQualificationReceipt(value, path, errors) {
       value.baseline?.status === 'intended_failure' && value.known_good?.status === 'pass';
     if (value.qualified !== derived) {
       errors.push(`${path}.qualified: must equal the baseline and known-good qualification result`);
+    }
+  }
+}
+
+function validateFixtureBundle(value, path, errors) {
+  if (
+    !closedObject(value, path, ['schema_version', 'files'], ['schema_version', 'files'], errors)
+  ) {
+    return;
+  }
+  exact(
+    value.schema_version,
+    CONTRACT_SCHEMA_VERSIONS['fixture-bundle'],
+    `${path}.schema_version`,
+    errors
+  );
+  fileBundle(value.files, `${path}.files`, 'content_base64', errors);
+  if (value.files?.some((file) => file?.path === 'TASK.md')) {
+    errors.push(`${path}.files: TASK.md is reserved for the public task packet`);
+  }
+}
+
+function validateAcceptanceContract(value, path, errors) {
+  const fields = [
+    'schema_version',
+    'task_id',
+    'task_defining_failures',
+    'required_checks',
+    'regression_checks',
+    'driver',
+    'repetitions',
+  ];
+  if (!closedObject(value, path, fields, fields, errors)) return;
+  exact(
+    value.schema_version,
+    CONTRACT_SCHEMA_VERSIONS['acceptance-contract'],
+    `${path}.schema_version`,
+    errors
+  );
+  id(value.task_id, `${path}.task_id`, errors);
+  checkIdArray(value.task_defining_failures, `${path}.task_defining_failures`, errors, {
+    min: 1,
+  });
+  const required = describedCheckArray(value.required_checks, `${path}.required_checks`, errors, 1);
+  const regression = describedCheckArray(
+    value.regression_checks,
+    `${path}.regression_checks`,
+    errors,
+    0
+  );
+  const requiredIds = new Set(required);
+  for (const checkId of value.task_defining_failures ?? []) {
+    if (!requiredIds.has(checkId)) {
+      errors.push(`${path}.task_defining_failures: check "${checkId}" is not required`);
+    }
+  }
+  for (const checkId of regression) {
+    if (requiredIds.has(checkId)) {
+      errors.push(`${path}.regression_checks: check "${checkId}" is also required`);
+    }
+  }
+  if (
+    closedObject(
+      value.driver,
+      `${path}.driver`,
+      ['path', 'sha256', 'timeout_ms'],
+      ['path', 'sha256', 'timeout_ms'],
+      errors
+    )
+  ) {
+    relativePath(value.driver.path, `${path}.driver.path`, errors);
+    sha256(value.driver.sha256, `${path}.driver.sha256`, errors);
+    integer(value.driver.timeout_ms, `${path}.driver.timeout_ms`, errors, 10, 60_000);
+  }
+  integer(value.repetitions, `${path}.repetitions`, errors, 2, 5);
+}
+
+function validateKnownGoodChange(value, path, errors) {
+  if (
+    !closedObject(
+      value,
+      path,
+      ['schema_version', 'task_id', 'files'],
+      ['schema_version', 'task_id', 'files'],
+      errors
+    )
+  ) {
+    return;
+  }
+  exact(
+    value.schema_version,
+    CONTRACT_SCHEMA_VERSIONS['known-good-change'],
+    `${path}.schema_version`,
+    errors
+  );
+  id(value.task_id, `${path}.task_id`, errors);
+  array(value.files, `${path}.files`, errors, { min: 1, max: 100 });
+  if (!Array.isArray(value.files)) return;
+  const paths = [];
+  for (const [index, file] of value.files.entries()) {
+    const filePath = `${path}.files[${index}]`;
+    if (
+      !closedObject(
+        file,
+        filePath,
+        ['path', 'before_sha256', 'after_base64', 'after_sha256'],
+        ['path', 'before_sha256', 'after_base64', 'after_sha256'],
+        errors
+      )
+    ) {
+      continue;
+    }
+    relativePath(file.path, `${filePath}.path`, errors);
+    sha256(file.before_sha256, `${filePath}.before_sha256`, errors);
+    validateBase64(file.after_base64, file.after_sha256, `${filePath}.after_base64`, errors);
+    sha256(file.after_sha256, `${filePath}.after_sha256`, errors);
+    if (file.before_sha256 === file.after_sha256) {
+      errors.push(`${filePath}: before and after SHA-256 must differ`);
+    }
+    if (typeof file.path === 'string') paths.push(file.path);
+  }
+  unique(paths, `${path}.files path`, errors);
+  sorted(paths, `${path}.files`, errors);
+}
+
+function validateQualificationReceiptV2(value, path, errors) {
+  const fields = [
+    'schema_version',
+    'task_id',
+    'manifest_sha256',
+    'fixture_sha256',
+    'acceptance_contract_sha256',
+    'known_good_sha256',
+    'workspace_policy',
+    'qualified',
+    'baseline',
+    'known_good',
+    'cleanup',
+    'limitations',
+  ];
+  if (!closedObject(value, path, fields, fields, errors)) return;
+  exact(
+    value.schema_version,
+    CONTRACT_SCHEMA_VERSIONS['qualification-receipt-v2'],
+    `${path}.schema_version`,
+    errors
+  );
+  id(value.task_id, `${path}.task_id`, errors);
+  for (const field of [
+    'manifest_sha256',
+    'fixture_sha256',
+    'acceptance_contract_sha256',
+    'known_good_sha256',
+  ]) {
+    sha256(value[field], `${path}.${field}`, errors);
+  }
+  exact(
+    value.workspace_policy,
+    'public_fixture_and_task_packet_v1',
+    `${path}.workspace_policy`,
+    errors
+  );
+  boolean(value.qualified, `${path}.qualified`, errors);
+  qualificationPhaseV2(value.baseline, `${path}.baseline`, 'baseline', errors);
+  qualificationPhaseV2(value.known_good, `${path}.known_good`, 'known_good', errors);
+  if (closedObject(value.cleanup, `${path}.cleanup`, ['status'], ['status'], errors)) {
+    oneOf(value.cleanup.status, ['complete', 'failed'], `${path}.cleanup.status`, errors);
+  }
+  stringArray(value.limitations, `${path}.limitations`, errors, { max: 50, itemMax: 500 });
+  if (typeof value.qualified === 'boolean') {
+    const derived =
+      value.baseline?.status === 'intended_failure' &&
+      value.known_good?.status === 'pass' &&
+      value.cleanup?.status === 'complete';
+    if (value.qualified !== derived) {
+      errors.push(`${path}.qualified: must equal the v2 qualification result`);
     }
   }
 }
@@ -424,6 +612,129 @@ function qualificationPhase(value, path, statuses, errors) {
   oneOf(value.status, statuses, `${path}.status`, errors);
 }
 
+function qualificationPhaseV2(value, path, phase, errors) {
+  const baselineStatuses = [
+    'intended_failure',
+    'wrong_failure',
+    'setup_failure',
+    'timeout',
+    'incomplete_checks',
+    'check_error',
+    'flaky',
+    'cleanup_failure',
+  ];
+  const knownGoodStatuses = [
+    'pass',
+    'patch_failure',
+    'check_failure',
+    'regression',
+    'setup_failure',
+    'timeout',
+    'incomplete_checks',
+    'check_error',
+    'flaky',
+    'cleanup_failure',
+  ];
+  const statuses = phase === 'baseline' ? baselineStatuses : knownGoodStatuses;
+  if (!closedObject(value, path, ['status', 'attempts'], ['status', 'attempts'], errors)) return;
+  oneOf(value.status, statuses, `${path}.status`, errors);
+  array(value.attempts, `${path}.attempts`, errors, { min: 2, max: 5 });
+  if (!Array.isArray(value.attempts)) return;
+  const outcomes = [];
+  const identities = [];
+  for (const [index, attempt] of value.attempts.entries()) {
+    const attemptPath = `${path}.attempts[${index}]`;
+    if (
+      !closedObject(
+        attempt,
+        attemptPath,
+        ['attempt', 'outcome', 'result_sha256'],
+        ['attempt', 'outcome', 'result_sha256'],
+        errors
+      )
+    ) {
+      continue;
+    }
+    integer(attempt.attempt, `${attemptPath}.attempt`, errors, 1, 5);
+    if (attempt.attempt !== index + 1) {
+      errors.push(`${attemptPath}.attempt: attempts must be ordered from 1`);
+    }
+    oneOf(
+      attempt.outcome,
+      statuses.filter((status) => status !== 'flaky'),
+      `${attemptPath}.outcome`,
+      errors
+    );
+    if (attempt.result_sha256 !== null) {
+      sha256(attempt.result_sha256, `${attemptPath}.result_sha256`, errors);
+    }
+    if (typeof attempt.outcome === 'string') outcomes.push(attempt.outcome);
+    identities.push(attempt.result_sha256);
+  }
+  const stable =
+    new Set(outcomes).size <= 1 &&
+    new Set(identities.map((identity) => String(identity))).size <= 1;
+  if (value.status === 'flaky' && stable) {
+    errors.push(`${path}.status: flaky requires differing repeated outcomes or results`);
+  }
+  if (value.status !== 'flaky' && outcomes.some((outcome) => outcome !== value.status)) {
+    errors.push(`${path}.status: must match every stable attempt outcome`);
+  }
+}
+
+function fileBundle(value, path, contentField, errors) {
+  array(value, path, errors, { min: 1, max: 100 });
+  if (!Array.isArray(value)) return;
+  const paths = [];
+  for (const [index, file] of value.entries()) {
+    const filePath = `${path}[${index}]`;
+    const allowed = ['path', contentField, 'sha256'];
+    if (!closedObject(file, filePath, allowed, allowed, errors)) continue;
+    relativePath(file.path, `${filePath}.path`, errors);
+    validateBase64(file[contentField], file.sha256, `${filePath}.${contentField}`, errors);
+    sha256(file.sha256, `${filePath}.sha256`, errors);
+    if (typeof file.path === 'string') paths.push(file.path);
+  }
+  unique(paths, `${path} path`, errors);
+  sorted(paths, path, errors);
+}
+
+function validateBase64(value, expectedSha256, path, errors) {
+  boundedString(value, path, errors, 4, 1_398_104);
+  if (typeof value !== 'string') return;
+  if (
+    value.length % 4 !== 0 ||
+    !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(value)
+  ) {
+    errors.push(`${path}: expected canonical base64`);
+    return;
+  }
+  const bytes = Buffer.from(value, 'base64');
+  if (bytes.length === 0 || bytes.length > CORPUS_LIMITS.maxArtifactBytes) {
+    errors.push(`${path}: decoded content must be 1-${CORPUS_LIMITS.maxArtifactBytes} bytes`);
+    return;
+  }
+  if (SHA256_PATTERN.test(String(expectedSha256)) && sha256Bytes(bytes) !== expectedSha256) {
+    errors.push(`${path}: decoded SHA-256 does not match`);
+  }
+}
+
+function describedCheckArray(value, path, errors, min) {
+  array(value, path, errors, { min, max: CORPUS_LIMITS.maxChecks });
+  if (!Array.isArray(value)) return [];
+  const ids = [];
+  for (const [index, check] of value.entries()) {
+    const checkPath = `${path}[${index}]`;
+    if (!closedObject(check, checkPath, ['id', 'label'], ['id', 'label'], errors)) continue;
+    id(check.id, `${checkPath}.id`, errors);
+    boundedString(check.label, `${checkPath}.label`, errors, 1, 160);
+    if (typeof check.id === 'string') ids.push(check.id);
+  }
+  unique(ids, `${path} id`, errors);
+  sorted(ids, path, errors);
+  return ids;
+}
+
 function checkArray(value, path, errors) {
   array(value, path, errors, { max: 200 });
   if (!Array.isArray(value)) return;
@@ -582,9 +893,12 @@ function sortJson(value) {
 }
 
 const validators = Object.freeze({
+  'acceptance-contract': validateAcceptanceContract,
   'agent-adapter': validateAgentAdapter,
   'check-result': validateCheckResult,
   'corpus-index': validateCorpusIndex,
+  'fixture-bundle': validateFixtureBundle,
+  'known-good-change': validateKnownGoodChange,
   'qualification-receipt': validateQualificationReceipt,
   'run-receipt': validateRunReceipt,
   'task-manifest': validateTaskManifest,

--- a/scripts/agent-task-corpus/contracts.test.mjs
+++ b/scripts/agent-task-corpus/contracts.test.mjs
@@ -3,17 +3,32 @@ import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import test from 'node:test';
 
-import { CONTRACT_SCHEMA_VERSIONS, canonicalJson, validateContract } from './contracts.mjs';
+import {
+  CONTRACT_SCHEMA_VERSIONS,
+  canonicalJson,
+  sha256Bytes,
+  validateContract,
+} from './contracts.mjs';
 
 const DIGEST = 'a'.repeat(64);
 const REVISION = 'b'.repeat(40);
+const FIXTURE_BYTES = Buffer.from('fixture\n');
+const FIXTURE_BASE64 = FIXTURE_BYTES.toString('base64');
+const FIXTURE_SHA256 = sha256Bytes(FIXTURE_BYTES);
+const AFTER_BYTES = Buffer.from('fixed\n');
+const AFTER_BASE64 = AFTER_BYTES.toString('base64');
+const AFTER_SHA256 = sha256Bytes(AFTER_BYTES);
 
 test('all public contract schemas are closed and parseable', async () => {
   const names = [
+    'acceptance-contract',
     'agent-adapter',
     'check-result',
     'corpus-index',
+    'fixture-bundle',
+    'known-good-change',
     'qualification-receipt',
+    'qualification-receipt-v2',
     'run-receipt',
     'task-manifest',
   ];
@@ -25,8 +40,17 @@ test('all public contract schemas are closed and parseable', async () => {
   }
 });
 
-test('accepts representative documents for all six contracts', () => {
+test('accepts representative documents for all qualification and runner contracts', () => {
   const documents = {
+    'acceptance-contract': {
+      schema_version: CONTRACT_SCHEMA_VERSIONS['acceptance-contract'],
+      task_id: 'preserve-explicit-false',
+      task_defining_failures: ['explicit-false-preserved'],
+      required_checks: [{ id: 'explicit-false-preserved', label: 'Explicit false is preserved' }],
+      regression_checks: [{ id: 'label-preserved', label: 'Label is preserved' }],
+      driver: { path: 'checks.mjs', sha256: DIGEST, timeout_ms: 5_000 },
+      repetitions: 2,
+    },
     'agent-adapter': {
       schema_version: CONTRACT_SCHEMA_VERSIONS['agent-adapter'],
       adapter_id: 'fixture-agent',
@@ -55,6 +79,28 @@ test('accepts representative documents for all six contracts', () => {
         },
       ],
     },
+    'fixture-bundle': {
+      schema_version: CONTRACT_SCHEMA_VERSIONS['fixture-bundle'],
+      files: [
+        {
+          path: 'fixture.txt',
+          content_base64: FIXTURE_BASE64,
+          sha256: FIXTURE_SHA256,
+        },
+      ],
+    },
+    'known-good-change': {
+      schema_version: CONTRACT_SCHEMA_VERSIONS['known-good-change'],
+      task_id: 'preserve-explicit-false',
+      files: [
+        {
+          path: 'fixture.txt',
+          before_sha256: FIXTURE_SHA256,
+          after_base64: AFTER_BASE64,
+          after_sha256: AFTER_SHA256,
+        },
+      ],
+    },
     'qualification-receipt': {
       schema_version: CONTRACT_SCHEMA_VERSIONS['qualification-receipt'],
       task_id: 'preserve-explicit-false',
@@ -62,6 +108,32 @@ test('accepts representative documents for all six contracts', () => {
       qualified: true,
       baseline: { runs: 2, result_sha256: DIGEST, status: 'intended_failure' },
       known_good: { runs: 2, result_sha256: DIGEST, status: 'pass' },
+      limitations: [],
+    },
+    'qualification-receipt-v2': {
+      schema_version: CONTRACT_SCHEMA_VERSIONS['qualification-receipt-v2'],
+      task_id: 'preserve-explicit-false',
+      manifest_sha256: DIGEST,
+      fixture_sha256: DIGEST,
+      acceptance_contract_sha256: DIGEST,
+      known_good_sha256: DIGEST,
+      workspace_policy: 'public_fixture_and_task_packet_v1',
+      qualified: true,
+      baseline: {
+        status: 'intended_failure',
+        attempts: [
+          { attempt: 1, outcome: 'intended_failure', result_sha256: DIGEST },
+          { attempt: 2, outcome: 'intended_failure', result_sha256: DIGEST },
+        ],
+      },
+      known_good: {
+        status: 'pass',
+        attempts: [
+          { attempt: 1, outcome: 'pass', result_sha256: DIGEST },
+          { attempt: 2, outcome: 'pass', result_sha256: DIGEST },
+        ],
+      },
+      cleanup: { status: 'complete' },
       limitations: [],
     },
     'run-receipt': {
@@ -104,8 +176,9 @@ test('accepts representative documents for all six contracts', () => {
     },
   };
 
-  for (const [kind, document] of Object.entries(documents)) {
-    assert.deepEqual(validateContract(kind, document), [], kind);
+  for (const [name, document] of Object.entries(documents)) {
+    const kind = name === 'qualification-receipt-v2' ? 'qualification-receipt' : name;
+    assert.deepEqual(validateContract(kind, document), [], name);
   }
 });
 

--- a/scripts/agent-task-corpus/qualify-cli.mjs
+++ b/scripts/agent-task-corpus/qualify-cli.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+
+import { pathToFileURL } from 'node:url';
+
+import { qualifyTask, writeQualificationReceipt } from './qualify-task.mjs';
+
+export async function runQualificationCli(args = process.argv.slice(2)) {
+  const wantsJson = args.includes('--json');
+  try {
+    const options = parseArgs(args);
+    const receipt = await qualifyTask({ root: options.root, taskId: options.taskId });
+    if (options.out) await writeQualificationReceipt(options.out, receipt);
+    const output = options.json
+      ? `${JSON.stringify(receipt)}\n`
+      : humanOutput(receipt, options.out);
+    return { exitCode: receipt.qualified ? 0 : 1, output, receipt };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      exitCode: 2,
+      output: wantsJson
+        ? `${JSON.stringify({ error: message })}\n`
+        : `Agent-task qualification failed: ${message}\n`,
+      receipt: null,
+    };
+  }
+}
+
+function parseArgs(args) {
+  const options = { root: undefined, taskId: undefined, out: undefined, json: false };
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    if (argument === '--json') {
+      options.json = true;
+      continue;
+    }
+    if (['--root', '--task', '--out'].includes(argument)) {
+      const value = args[index + 1];
+      if (!value || value.startsWith('--')) throw new Error(`${argument} requires a value`);
+      index += 1;
+      if (argument === '--root') options.root = value;
+      if (argument === '--task') options.taskId = value;
+      if (argument === '--out') options.out = value;
+      continue;
+    }
+    throw new Error(`unknown argument: ${argument}`);
+  }
+  if (!options.taskId) throw new Error('--task is required');
+  return options;
+}
+
+function humanOutput(receipt, outputPath) {
+  const lines = [
+    `Task: ${receipt.task_id}`,
+    `Qualified: ${receipt.qualified ? 'yes' : 'no'}`,
+    `Baseline: ${receipt.baseline.status} (${receipt.baseline.attempts.length} attempts)`,
+    `Known good: ${receipt.known_good.status} (${receipt.known_good.attempts.length} attempts)`,
+    `Cleanup: ${receipt.cleanup.status}`,
+  ];
+  if (outputPath) lines.push(`Receipt: ${outputPath}`);
+  return `${lines.join('\n')}\n`;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  let result;
+  try {
+    result = await runQualificationCli();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    result = { exitCode: 2, output: `Agent-task qualification failed: ${message}\n` };
+  }
+  process.stdout.write(result.output);
+  process.exitCode = result.exitCode;
+}

--- a/scripts/agent-task-corpus/qualify-task.mjs
+++ b/scripts/agent-task-corpus/qualify-task.mjs
@@ -1,0 +1,340 @@
+import { execFile as execFileCallback } from 'node:child_process';
+import { lstat, mkdir, mkdtemp, readFile, rename, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
+import { promisify } from 'node:util';
+
+import {
+  CONTRACT_SCHEMA_VERSIONS,
+  CORPUS_LIMITS,
+  canonicalJson,
+  sha256Bytes,
+  validateContract,
+} from './contracts.mjs';
+import { DEFAULT_CORPUS_ROOT, resolveArtifact, validateCorpus } from './validate-corpus.mjs';
+
+const execFile = promisify(execFileCallback);
+const WORKSPACE_POLICY = 'public_fixture_and_task_packet_v1';
+const MAX_DRIVER_OUTPUT_BYTES = 256 * 1024;
+const LIMITATIONS = Object.freeze([
+  'Qualification executes trusted corpus check code without an operating-system sandbox.',
+]);
+
+export async function qualifyTask({
+  root = DEFAULT_CORPUS_ROOT,
+  taskId,
+  executeDriver = executeCheckDriver,
+  removeWorkspace = removeQualificationWorkspace,
+  temporaryRoot = tmpdir(),
+} = {}) {
+  if (typeof taskId !== 'string' || taskId.length === 0) {
+    throw new Error('taskId is required');
+  }
+  const task = await loadTaskPackage(root, taskId);
+  const phaseOptions = { executeDriver, removeWorkspace, temporaryRoot, task };
+  const baseline = await qualifyPhase('baseline', phaseOptions);
+  const knownGood = await qualifyPhase('known_good', phaseOptions);
+  const cleanupStatus = [...baseline.attempts, ...knownGood.attempts].some(
+    (attempt) => attempt.outcome === 'cleanup_failure'
+  )
+    ? 'failed'
+    : 'complete';
+  const qualified =
+    baseline.status === 'intended_failure' &&
+    knownGood.status === 'pass' &&
+    cleanupStatus === 'complete';
+
+  const receipt = {
+    schema_version: CONTRACT_SCHEMA_VERSIONS['qualification-receipt-v2'],
+    task_id: taskId,
+    manifest_sha256: task.identities.manifest,
+    fixture_sha256: task.identities.fixture,
+    acceptance_contract_sha256: task.identities.acceptance,
+    known_good_sha256: task.identities.knownGood,
+    workspace_policy: WORKSPACE_POLICY,
+    qualified,
+    baseline,
+    known_good: knownGood,
+    cleanup: { status: cleanupStatus },
+    limitations: [...LIMITATIONS],
+  };
+  const errors = validateContract('qualification-receipt', receipt);
+  if (errors.length > 0) {
+    throw new Error(`qualification produced an invalid receipt:\n${errors.join('\n')}`);
+  }
+  return receipt;
+}
+
+export async function writeQualificationReceipt(path, receipt) {
+  const destination = resolve(path);
+  await mkdir(dirname(destination), { recursive: true });
+  const temporary = `${destination}.tmp-${process.pid}`;
+  await writeFile(temporary, `${JSON.stringify(receipt, null, 2)}\n`, { flag: 'wx' });
+  await rename(temporary, destination);
+}
+
+async function loadTaskPackage(root, taskId) {
+  const corpusRoot = resolve(root);
+  const validation = validateCorpus({ root: corpusRoot, ignoreQualification: true });
+  if (!validation.valid) {
+    throw new Error(`corpus validation failed:\n${validation.errors.join('\n')}`);
+  }
+  const indexPath = resolveArtifact(corpusRoot, 'corpus.json', CORPUS_LIMITS.maxDocumentBytes);
+  const index = JSON.parse(await readFile(indexPath, 'utf8'));
+  const entry = index.tasks.find((candidate) => candidate.task_id === taskId);
+  if (!entry) throw new Error(`task "${taskId}" is not in the corpus`);
+
+  const manifestPath = resolveArtifact(
+    corpusRoot,
+    entry.manifest.path,
+    CORPUS_LIMITS.maxDocumentBytes
+  );
+  const manifestBytes = await readFile(manifestPath);
+  const manifest = JSON.parse(manifestBytes.toString('utf8'));
+  const taskRoot = dirname(manifestPath);
+  const fixture = await readJsonArtifact(taskRoot, manifest.artifacts.fixture, 'fixture-bundle');
+  const acceptance = await readJsonArtifact(
+    taskRoot,
+    manifest.artifacts.acceptance_contract,
+    'acceptance-contract'
+  );
+  const knownGood = await readJsonArtifact(
+    taskRoot,
+    manifest.artifacts.known_good_patch,
+    'known-good-change'
+  );
+  const taskPacketPath = resolveArtifact(
+    taskRoot,
+    manifest.artifacts.task_packet.path,
+    CORPUS_LIMITS.maxArtifactBytes
+  );
+  const taskPacket = await readFile(taskPacketPath);
+  const driverPath = resolveArtifact(
+    taskRoot,
+    acceptance.value.driver.path,
+    CORPUS_LIMITS.maxArtifactBytes
+  );
+  const driverBytes = await readFile(driverPath);
+  if (sha256Bytes(driverBytes) !== acceptance.value.driver.sha256) {
+    throw new Error('acceptance driver SHA-256 does not match its contract');
+  }
+
+  return {
+    taskId,
+    taskRoot,
+    fixture: fixture.value,
+    acceptance: acceptance.value,
+    knownGood: knownGood.value,
+    taskPacket,
+    driverPath,
+    identities: {
+      manifest: sha256Bytes(manifestBytes),
+      fixture: fixture.sha256,
+      acceptance: acceptance.sha256,
+      knownGood: knownGood.sha256,
+    },
+  };
+}
+
+async function readJsonArtifact(root, artifact, kind) {
+  const path = resolveArtifact(root, artifact.path, CORPUS_LIMITS.maxDocumentBytes);
+  const bytes = await readFile(path);
+  const sha256 = sha256Bytes(bytes);
+  if (sha256 !== artifact.sha256) throw new Error(`${kind} SHA-256 does not match the manifest`);
+  const value = JSON.parse(bytes.toString('utf8'));
+  const errors = validateContract(kind, value);
+  if (errors.length > 0) throw new Error(`invalid ${kind}:\n${errors.join('\n')}`);
+  return { value, sha256 };
+}
+
+async function qualifyPhase(phase, options) {
+  const attempts = [];
+  for (let attempt = 1; attempt <= options.task.acceptance.repetitions; attempt += 1) {
+    attempts.push(await runAttempt(phase, attempt, options));
+  }
+  const outcomes = new Set(attempts.map((item) => item.outcome));
+  const results = new Set(attempts.map((item) => String(item.result_sha256)));
+  const status = outcomes.size === 1 && results.size === 1 ? attempts[0].outcome : 'flaky';
+  return { status, attempts };
+}
+
+async function runAttempt(phase, attempt, { executeDriver, removeWorkspace, temporaryRoot, task }) {
+  let workspace = null;
+  let outcome = 'setup_failure';
+  let resultSha256 = null;
+  try {
+    workspace = await materializeWorkspace(task.fixture, task.taskPacket, temporaryRoot);
+    if (phase === 'known_good') {
+      try {
+        await applyKnownGoodChange(workspace, task.knownGood);
+      } catch {
+        outcome = 'patch_failure';
+      }
+    }
+    if (outcome !== 'patch_failure') {
+      try {
+        const execution = await executeDriver({
+          driverPath: task.driverPath,
+          workspace,
+          taskId: task.taskId,
+          acceptanceSha256: task.identities.acceptance,
+          phase,
+          attempt,
+          timeoutMs: task.acceptance.driver.timeout_ms,
+        });
+        if (execution.kind !== 'result') {
+          outcome = execution.kind;
+        } else {
+          resultSha256 = sha256Bytes(Buffer.from(canonicalJson(execution.result)));
+          outcome = classifyResult(phase, execution.result, task.acceptance);
+        }
+      } catch {
+        outcome = 'check_error';
+      }
+    }
+  } catch (error) {
+    outcome = error?.code === 'CODEVETTER_CLEANUP_FAILURE' ? 'cleanup_failure' : 'setup_failure';
+  } finally {
+    if (workspace !== null) {
+      try {
+        await removeWorkspace(workspace);
+      } catch {
+        outcome = 'cleanup_failure';
+      }
+    }
+  }
+  return { attempt, outcome, result_sha256: resultSha256 };
+}
+
+export async function materializeWorkspace(fixture, taskPacket, temporaryRoot = tmpdir()) {
+  const workspace = await mkdtemp(join(resolve(temporaryRoot), 'codevetter-agent-task-'));
+  try {
+    for (const file of fixture.files) {
+      const destination = safeWorkspacePath(workspace, file.path);
+      await mkdir(dirname(destination), { recursive: true });
+      await writeFile(destination, Buffer.from(file.content_base64, 'base64'), { flag: 'wx' });
+    }
+    await writeFile(join(workspace, 'TASK.md'), taskPacket, { flag: 'wx' });
+    return workspace;
+  } catch (error) {
+    try {
+      await rm(workspace, { force: true, recursive: true });
+    } catch {
+      const cleanupError = new Error('workspace cleanup failed after setup');
+      cleanupError.code = 'CODEVETTER_CLEANUP_FAILURE';
+      throw cleanupError;
+    }
+    throw error;
+  }
+}
+
+export async function applyKnownGoodChange(workspace, knownGood) {
+  for (const file of knownGood.files) {
+    const destination = safeWorkspacePath(workspace, file.path);
+    const linkStats = await lstat(destination);
+    if (linkStats.isSymbolicLink() || !linkStats.isFile()) {
+      throw new Error(`known-good target is not a regular file: ${file.path}`);
+    }
+    const before = await readFile(destination);
+    if (sha256Bytes(before) !== file.before_sha256) {
+      throw new Error(`known-good before SHA-256 mismatch: ${file.path}`);
+    }
+    const after = Buffer.from(file.after_base64, 'base64');
+    if (sha256Bytes(after) !== file.after_sha256) {
+      throw new Error(`known-good after SHA-256 mismatch: ${file.path}`);
+    }
+    await writeFile(destination, after);
+  }
+}
+
+export async function executeCheckDriver({
+  driverPath,
+  workspace,
+  taskId,
+  acceptanceSha256,
+  phase,
+  attempt,
+  timeoutMs,
+}) {
+  try {
+    const { stdout } = await execFile(
+      process.execPath,
+      [driverPath, workspace, taskId, acceptanceSha256, phase, String(attempt)],
+      {
+        cwd: dirname(driverPath),
+        encoding: 'utf8',
+        env: { PATH: process.env.PATH ?? '' },
+        maxBuffer: MAX_DRIVER_OUTPUT_BYTES,
+        shell: false,
+        timeout: timeoutMs,
+        windowsHide: true,
+      }
+    );
+    let result;
+    try {
+      result = JSON.parse(stdout);
+    } catch {
+      return { kind: 'check_error' };
+    }
+    const errors = validateContract('check-result', result);
+    if (
+      errors.length > 0 ||
+      result.task_id !== taskId ||
+      result.acceptance_contract_sha256 !== acceptanceSha256
+    ) {
+      return { kind: 'check_error' };
+    }
+    return { kind: 'result', result };
+  } catch (error) {
+    if (error?.killed || error?.signal === 'SIGTERM' || error?.code === 'ETIMEDOUT') {
+      return { kind: 'timeout' };
+    }
+    return { kind: 'check_error' };
+  }
+}
+
+function classifyResult(phase, result, acceptance) {
+  const required = acceptance.required_checks.map((check) => check.id);
+  const regression = acceptance.regression_checks.map((check) => check.id);
+  const expected = [...required, ...regression].sort();
+  const actual = result.results.map((check) => check.id).sort();
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) return 'incomplete_checks';
+  const byId = new Map(result.results.map((check) => [check.id, check.status]));
+  if (result.results.some((check) => check.status === 'error')) return 'check_error';
+  const failedRequired = required.filter((id) => byId.get(id) !== 'pass');
+  const failedRegression = regression.filter((id) => byId.get(id) !== 'pass');
+  if (phase === 'baseline') {
+    if (failedRegression.length > 0) return 'wrong_failure';
+    return failedRequired.some((id) => acceptance.task_defining_failures.includes(id))
+      ? 'intended_failure'
+      : 'wrong_failure';
+  }
+  if (failedRegression.length > 0) return 'regression';
+  if (failedRequired.length > 0) return 'check_failure';
+  return 'pass';
+}
+
+async function removeQualificationWorkspace(workspace) {
+  await rm(workspace, { force: true, recursive: true });
+}
+
+function safeWorkspacePath(workspace, declaredPath) {
+  if (
+    typeof declaredPath !== 'string' ||
+    declaredPath.length === 0 ||
+    declaredPath.length > 240 ||
+    isAbsolute(declaredPath) ||
+    /^[A-Za-z]:/.test(declaredPath) ||
+    declaredPath.includes('\\') ||
+    declaredPath.includes('\0') ||
+    declaredPath.split('/').includes('..')
+  ) {
+    throw new Error(`unsafe workspace path: ${String(declaredPath)}`);
+  }
+  const candidate = resolve(workspace, declaredPath);
+  const pathFromRoot = relative(workspace, candidate);
+  if (pathFromRoot === '..' || pathFromRoot.startsWith(`..${sep}`) || isAbsolute(pathFromRoot)) {
+    throw new Error(`workspace path escapes root: ${declaredPath}`);
+  }
+  return candidate;
+}

--- a/scripts/agent-task-corpus/qualify-task.test.mjs
+++ b/scripts/agent-task-corpus/qualify-task.test.mjs
@@ -1,0 +1,206 @@
+import assert from 'node:assert/strict';
+import { cp, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import test from 'node:test';
+
+import { runQualificationCli } from './qualify-cli.mjs';
+import {
+  applyKnownGoodChange,
+  executeCheckDriver,
+  materializeWorkspace,
+  qualifyTask,
+} from './qualify-task.mjs';
+
+const SAMPLE_ROOT = resolve('benchmarks/agent-tasks/sample');
+const TASK_ID = 'preserve-explicit-false';
+
+function checkResult(acceptanceSha256, statuses = {}) {
+  return {
+    schema_version: 'codevetter.agent-task-check-result.v1',
+    task_id: TASK_ID,
+    acceptance_contract_sha256: acceptanceSha256,
+    results: [
+      {
+        id: 'explicit-false-preserved',
+        status: statuses.required ?? 'pass',
+      },
+      { id: 'label-preserved', status: statuses.label ?? 'pass' },
+      { id: 'public-inputs-only', status: statuses.public ?? 'pass' },
+    ],
+  };
+}
+
+function fixtureDriver(overrides = {}) {
+  return async ({ acceptanceSha256, phase, attempt }) => {
+    const override = overrides[`${phase}:${attempt}`] ?? overrides[phase];
+    if (override?.kind) return override;
+    const defaults = phase === 'baseline' ? { required: 'fail' } : {};
+    return {
+      kind: 'result',
+      result: checkResult(acceptanceSha256, { ...defaults, ...(override ?? {}) }),
+    };
+  };
+}
+
+test('qualifies the owned sample deterministically through isolated public inputs', async () => {
+  const first = await qualifyTask({ root: SAMPLE_ROOT, taskId: TASK_ID });
+  const second = await qualifyTask({ root: SAMPLE_ROOT, taskId: TASK_ID });
+  const tracked = JSON.parse(await readFile(join(SAMPLE_ROOT, 'qualification.json'), 'utf8'));
+
+  assert.deepEqual(second, first);
+  assert.deepEqual(tracked, first);
+  assert.equal(first.qualified, true);
+  assert.equal(first.workspace_policy, 'public_fixture_and_task_packet_v1');
+  assert.equal(first.baseline.status, 'intended_failure');
+  assert.equal(first.known_good.status, 'pass');
+  assert.equal(first.cleanup.status, 'complete');
+});
+
+test('requalifies a valid task package when its prior receipt is stale', async (t) => {
+  const directory = await mkdtemp(join(tmpdir(), 'codevetter-stale-qualification-'));
+  t.after(() => rm(directory, { force: true, recursive: true }));
+  const root = join(directory, 'sample');
+  await cp(SAMPLE_ROOT, root, { recursive: true });
+  await writeFile(join(root, 'qualification.json'), '{}\n');
+
+  const receipt = await qualifyTask({ root, taskId: TASK_ID });
+
+  assert.equal(receipt.qualified, true);
+  assert.equal(receipt.baseline.status, 'intended_failure');
+  assert.equal(receipt.known_good.status, 'pass');
+});
+
+test('classifies wrong failure, incomplete inventory, timeout, and flakiness', async () => {
+  const wrong = await qualifyTask({
+    root: SAMPLE_ROOT,
+    taskId: TASK_ID,
+    executeDriver: fixtureDriver({ baseline: { required: 'pass' } }),
+  });
+  assert.equal(wrong.baseline.status, 'wrong_failure');
+
+  const incomplete = await qualifyTask({
+    root: SAMPLE_ROOT,
+    taskId: TASK_ID,
+    executeDriver: async ({ acceptanceSha256 }) => {
+      const result = checkResult(acceptanceSha256);
+      result.results.pop();
+      return { kind: 'result', result };
+    },
+  });
+  assert.equal(incomplete.baseline.status, 'incomplete_checks');
+  assert.equal(incomplete.known_good.status, 'incomplete_checks');
+
+  const timeout = await qualifyTask({
+    root: SAMPLE_ROOT,
+    taskId: TASK_ID,
+    executeDriver: fixtureDriver({ baseline: { kind: 'timeout' } }),
+  });
+  assert.equal(timeout.baseline.status, 'timeout');
+
+  const checkError = await qualifyTask({
+    root: SAMPLE_ROOT,
+    taskId: TASK_ID,
+    executeDriver: async () => {
+      throw new Error('injected driver failure');
+    },
+  });
+  assert.equal(checkError.baseline.status, 'check_error');
+  assert.equal(checkError.known_good.status, 'check_error');
+
+  const flaky = await qualifyTask({
+    root: SAMPLE_ROOT,
+    taskId: TASK_ID,
+    executeDriver: fixtureDriver({ 'baseline:2': { required: 'pass' } }),
+  });
+  assert.equal(flaky.baseline.status, 'flaky');
+});
+
+test('terminates a real check driver at its declared timeout', async (t) => {
+  const directory = await mkdtemp(join(tmpdir(), 'codevetter-driver-timeout-'));
+  t.after(() => rm(directory, { force: true, recursive: true }));
+  const driverPath = join(directory, 'slow-check.mjs');
+  await writeFile(driverPath, 'setTimeout(() => process.stdout.write("{}"), 1000);\n');
+
+  const result = await executeCheckDriver({
+    driverPath,
+    workspace: directory,
+    taskId: TASK_ID,
+    acceptanceSha256: 'a'.repeat(64),
+    phase: 'baseline',
+    attempt: 1,
+    timeoutMs: 10,
+  });
+
+  assert.deepEqual(result, { kind: 'timeout' });
+});
+
+test('classifies a known-good regression separately from task check failure', async () => {
+  const receipt = await qualifyTask({
+    root: SAMPLE_ROOT,
+    taskId: TASK_ID,
+    executeDriver: fixtureDriver({ known_good: { label: 'fail' } }),
+  });
+
+  assert.equal(receipt.baseline.status, 'intended_failure');
+  assert.equal(receipt.known_good.status, 'regression');
+  assert.equal(receipt.qualified, false);
+});
+
+test('rejects known-good patch drift before writing a replacement', async (t) => {
+  const directory = await mkdtemp(join(tmpdir(), 'codevetter-patch-drift-'));
+  t.after(() => rm(directory, { force: true, recursive: true }));
+  const fixture = JSON.parse(
+    await readFile(join(SAMPLE_ROOT, 'tasks/preserve-explicit-false/fixture.json'), 'utf8')
+  );
+  const knownGood = JSON.parse(
+    await readFile(join(SAMPLE_ROOT, 'tasks/preserve-explicit-false/known-good.json'), 'utf8')
+  );
+  knownGood.files[0].before_sha256 = 'f'.repeat(64);
+  const workspace = await materializeWorkspace(fixture, Buffer.from('# Task\n'), directory);
+
+  await assert.rejects(applyKnownGoodChange(workspace, knownGood), /before SHA-256 mismatch/);
+});
+
+test('retains cleanup failure as the terminal qualification outcome', async () => {
+  const receipt = await qualifyTask({
+    root: SAMPLE_ROOT,
+    taskId: TASK_ID,
+    executeDriver: fixtureDriver(),
+    removeWorkspace: async (workspace) => {
+      await rm(workspace, { force: true, recursive: true });
+      throw new Error('injected cleanup failure');
+    },
+  });
+
+  assert.equal(receipt.baseline.status, 'cleanup_failure');
+  assert.equal(receipt.known_good.status, 'cleanup_failure');
+  assert.equal(receipt.cleanup.status, 'failed');
+  assert.equal(receipt.qualified, false);
+});
+
+test('CLI writes the same deterministic receipt atomically', async (t) => {
+  const directory = await mkdtemp(join(tmpdir(), 'codevetter-qualification-cli-'));
+  t.after(() => rm(directory, { force: true, recursive: true }));
+  const outputPath = join(directory, 'qualification.json');
+  const result = await runQualificationCli([
+    '--root',
+    SAMPLE_ROOT,
+    '--task',
+    TASK_ID,
+    '--out',
+    outputPath,
+    '--json',
+  ]);
+
+  assert.equal(result.exitCode, 0);
+  assert.deepEqual(JSON.parse(await readFile(outputPath, 'utf8')), result.receipt);
+  assert.deepEqual(JSON.parse(result.output), result.receipt);
+});
+
+test('CLI reports argument errors through its selected output contract', async () => {
+  const result = await runQualificationCli(['--json']);
+
+  assert.equal(result.exitCode, 2);
+  assert.deepEqual(JSON.parse(result.output), { error: '--task is required' });
+});

--- a/scripts/agent-task-corpus/validate-corpus.mjs
+++ b/scripts/agent-task-corpus/validate-corpus.mjs
@@ -10,7 +10,7 @@ import {
 
 export const DEFAULT_CORPUS_ROOT = 'benchmarks/agent-tasks/sample';
 
-export function validateCorpus({ root = DEFAULT_CORPUS_ROOT } = {}) {
+export function validateCorpus({ root = DEFAULT_CORPUS_ROOT, ignoreQualification = false } = {}) {
   const corpusRoot = resolve(root);
   const indexPath = resolve(corpusRoot, 'corpus.json');
   const errors = [];
@@ -34,7 +34,7 @@ export function validateCorpus({ root = DEFAULT_CORPUS_ROOT } = {}) {
 
   const entries = Array.isArray(index?.tasks) ? index.tasks : [];
   for (const entry of entries) {
-    taskRows.push(validateTaskEntry(corpusRoot, entry, errors));
+    taskRows.push(validateTaskEntry(corpusRoot, entry, errors, ignoreQualification));
   }
   taskRows.sort((left, right) => left.task_id.localeCompare(right.task_id));
 
@@ -106,7 +106,7 @@ export function validateCorpus({ root = DEFAULT_CORPUS_ROOT } = {}) {
   };
 }
 
-function validateTaskEntry(corpusRoot, entry, errors) {
+function validateTaskEntry(corpusRoot, entry, errors, ignoreQualification) {
   const taskId = typeof entry?.task_id === 'string' ? entry.task_id : '(invalid-task-id)';
   const row = {
     task_id: taskId,
@@ -120,6 +120,7 @@ function validateTaskEntry(corpusRoot, entry, errors) {
   const entryErrors = [];
   let manifestDocument;
   let manifestPath;
+  let contractEvidence = null;
 
   try {
     manifestPath = resolveArtifact(
@@ -152,14 +153,16 @@ function validateTaskEntry(corpusRoot, entry, errors) {
     for (const [name, artifact] of Object.entries(manifestDocument.artifacts ?? {}).sort()) {
       validateArtifact(taskRoot, artifact, `artifact ${name}`, entryErrors);
     }
+    contractEvidence = validateNestedTaskContracts(taskRoot, manifestDocument, taskId, entryErrors);
   }
 
-  if (entry?.qualification !== undefined) {
+  if (entry?.qualification !== undefined && !ignoreQualification) {
     validateQualification(
       corpusRoot,
       entry.qualification,
       taskId,
       row.manifest_sha256,
+      contractEvidence,
       entryErrors
     );
     row.qualified = !entryErrors.some((error) => error.startsWith('qualification:'));
@@ -173,7 +176,14 @@ function validateTaskEntry(corpusRoot, entry, errors) {
   return row;
 }
 
-function validateQualification(corpusRoot, artifact, taskId, manifestSha256, errors) {
+function validateQualification(
+  corpusRoot,
+  artifact,
+  taskId,
+  manifestSha256,
+  contractEvidence,
+  errors
+) {
   let receipt;
   try {
     const path = resolveArtifact(corpusRoot, artifact?.path, CORPUS_LIMITS.maxDocumentBytes);
@@ -190,13 +200,107 @@ function validateQualification(corpusRoot, artifact, taskId, manifestSha256, err
   for (const error of validateContract('qualification-receipt', receipt)) {
     errors.push(`qualification: ${error}`);
   }
-  if (receipt?.schema_version !== CONTRACT_SCHEMA_VERSIONS['qualification-receipt']) return;
+  const knownVersion =
+    receipt?.schema_version === CONTRACT_SCHEMA_VERSIONS['qualification-receipt'] ||
+    receipt?.schema_version === CONTRACT_SCHEMA_VERSIONS['qualification-receipt-v2'];
+  if (!knownVersion) return;
   if (receipt.task_id !== taskId) errors.push(`qualification: $.task_id must equal "${taskId}"`);
   if (receipt.manifest_sha256 !== manifestSha256) {
     errors.push('qualification: $.manifest_sha256 does not match the task manifest');
   }
   if (receipt.qualified !== true)
     errors.push('qualification: $.qualified must be true for readiness');
+  if (receipt.schema_version === CONTRACT_SCHEMA_VERSIONS['qualification-receipt-v2']) {
+    for (const [field, expected] of Object.entries({
+      fixture_sha256: contractEvidence?.fixture_sha256,
+      acceptance_contract_sha256: contractEvidence?.acceptance_contract_sha256,
+      known_good_sha256: contractEvidence?.known_good_sha256,
+    })) {
+      if (receipt[field] !== expected) {
+        errors.push(`qualification: $.${field} does not match the task manifest`);
+      }
+    }
+    if (receipt.workspace_policy !== 'public_fixture_and_task_packet_v1') {
+      errors.push('qualification: $.workspace_policy is not the public-input policy');
+    }
+  }
+}
+
+function validateNestedTaskContracts(taskRoot, manifest, taskId, errors) {
+  const fixture = readContractArtifact(
+    taskRoot,
+    manifest.artifacts?.fixture,
+    'fixture-bundle',
+    'fixture contract',
+    errors
+  );
+  const acceptance = readContractArtifact(
+    taskRoot,
+    manifest.artifacts?.acceptance_contract,
+    'acceptance-contract',
+    'acceptance contract',
+    errors
+  );
+  const knownGood = readContractArtifact(
+    taskRoot,
+    manifest.artifacts?.known_good_patch,
+    'known-good-change',
+    'known-good change',
+    errors
+  );
+
+  if (acceptance?.value?.task_id !== taskId) {
+    errors.push(`acceptance contract: $.task_id must equal "${taskId}"`);
+  }
+  if (knownGood?.value?.task_id !== taskId) {
+    errors.push(`known-good change: $.task_id must equal "${taskId}"`);
+  }
+  const fixturePaths = new Set((fixture?.value?.files ?? []).map((file) => file?.path));
+  for (const file of knownGood?.value?.files ?? []) {
+    if (!fixturePaths.has(file?.path)) {
+      errors.push(`known-good change: target is not a declared fixture file: ${file?.path}`);
+    }
+  }
+  if (fixturePaths.has(acceptance?.value?.driver?.path)) {
+    errors.push('acceptance contract: driver must remain outside the public fixture bundle');
+  }
+
+  const acceptanceRequired = (acceptance?.value?.required_checks ?? []).map((check) => check?.id);
+  const acceptanceRegression = (acceptance?.value?.regression_checks ?? []).map(
+    (check) => check?.id
+  );
+  if (JSON.stringify(acceptanceRequired) !== JSON.stringify(manifest.required_checks)) {
+    errors.push('acceptance contract: required check inventory does not match the manifest');
+  }
+  if (JSON.stringify(acceptanceRegression) !== JSON.stringify(manifest.regression_checks)) {
+    errors.push('acceptance contract: regression check inventory does not match the manifest');
+  }
+
+  if (acceptance?.value?.driver) {
+    validateArtifact(taskRoot, acceptance.value.driver, 'acceptance contract driver', errors);
+  }
+
+  return {
+    fixture_sha256: fixture?.sha256 ?? null,
+    acceptance_contract_sha256: acceptance?.sha256 ?? null,
+    known_good_sha256: knownGood?.sha256 ?? null,
+  };
+}
+
+function readContractArtifact(taskRoot, artifact, kind, label, errors) {
+  try {
+    const path = resolveArtifact(taskRoot, artifact?.path, CORPUS_LIMITS.maxDocumentBytes);
+    const bytes = readFileSync(path);
+    const sha256 = sha256Bytes(bytes);
+    const value = parseJson(bytes, artifact?.path ?? label);
+    for (const error of validateContract(kind, value)) {
+      errors.push(`${label}: ${error}`);
+    }
+    return { path, bytes, sha256, value };
+  } catch (error) {
+    errors.push(`${label}: ${message(error)}`);
+    return null;
+  }
 }
 
 function validateArtifact(taskRoot, artifact, label, errors) {
@@ -212,7 +316,7 @@ function validateArtifact(taskRoot, artifact, label, errors) {
   }
 }
 
-function resolveArtifact(root, declaredPath, maxBytes) {
+export function resolveArtifact(root, declaredPath, maxBytes) {
   if (typeof declaredPath !== 'string' || !safeRelativePath(declaredPath)) {
     throw new Error(`unsafe relative path "${String(declaredPath)}"`);
   }

--- a/scripts/agent-task-corpus/validate-corpus.test.mjs
+++ b/scripts/agent-task-corpus/validate-corpus.test.mjs
@@ -33,13 +33,13 @@ test('the owned sample is valid, deterministic, and explicitly not publishable',
   assert.deepEqual(second, first);
   assert.equal(first.valid, true);
   assert.equal(first.publishable, false);
-  assert.deepEqual(first.counts, { categories: 1, qualified_tasks: 0, tasks: 1 });
+  assert.deepEqual(first.counts, { categories: 1, qualified_tasks: 1, tasks: 1 });
   assert.deepEqual(first.coverage.lanes, ['api']);
   assert.deepEqual(
     first.gates.map((gate) => [gate.id, gate.passed]),
     [
       ['task-count', false],
-      ['qualification-count', false],
+      ['qualification-count', true],
       ['lane-coverage', false],
       ['runtime-coverage', false],
       ['failure-category-count', false],


### PR DESCRIPTION
## Summary

- add closed fixture, acceptance, exact known-good, and v2 qualification receipt contracts
- qualify tasks in fresh public-input-only workspaces with shell-free bounded checks and explicit failure taxonomy
- convert the owned sample into executable proof with a deterministic tracked receipt while preserving strict readiness gates
- sync and archive the OpenSpec change

## Validation

- pnpm run test:corpus-contracts (19 tests)
- pnpm run test:automation
- pnpm run corpus:qualify --task preserve-explicit-false --json
- pnpm run corpus:validate --json
- pnpm run lint
- node scripts/check-docs.mjs
- workflow YAML parse
- openspec validate --all --strict (39 specs)
- git diff --check
- pnpm run corpus:readiness --json exits 1 as expected: the one-task sample remains below task, lane, runtime, and category breadth gates

No agent, model, network, scorer, deploy, or production path runs in this slice.

Refs #53