### PR TITLE
feat: add provider-neutral agent task runner

### DIFF
--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -38,6 +38,16 @@ Internal (fleet):
 
 ## Timeline
 
+- **2026-07-31 — Provider-neutral agent-task runner foundation:** added
+  deterministic non-executing plans with public-input size, conservative token
+  and cost bounds, environment-name availability, exact task/adapter identity,
+  and one-attempt approval. Approved adapters run without a shell in fresh
+  public-input-only workspaces with immutable executable artifacts, minimal
+  declared environment, bounded redacted output, process-group
+  timeout/cancellation, terminal-before-check ordering, and v2 lifecycle
+  receipts. A repository-owned synthetic adapter passes the qualified sample;
+  no real provider, model, paid run, network, evaluator projection, deploy, or
+  production path ran in this slice.
 - **2026-07-31 — Agent-task corpus qualification foundation:** added closed,
   versioned fixture, acceptance, exact known-good, check-result, qualification,
   adapter, and runner contracts plus deterministic dependency-free validation.
@@ -200,11 +210,11 @@ Internal (fleet):
 
 ### Benchmarks
 - Catch-rate benchmark harness (`benchmarks/agent-prs`): per-case or combined fixtures, `bench:new-case` starter, `bench:curation` readiness report, strict fixture validation, named CodeVetter / CodeRabbit free-tier / Claude Code comparator slots, false-positive and redundant-match counts, precision/F1, baseline deltas, severity-specific gates, JSON/Markdown report output.
-- Agent-task corpus foundation (`benchmarks/agent-tasks`): ten closed JSON
-  schemas, two-level SHA-256 task identity, fail-closed local validation,
-  deterministic repeated baseline/known-good qualification, distinct
-  validate/qualify/readiness commands, and one qualified owned sample that
-  remains explicitly non-publishable for issue #53.
+- Agent-task corpus foundation (`benchmarks/agent-tasks`): thirteen closed
+  versioned machine contracts, two-level SHA-256 task identity, fail-closed
+  validation, repeated baseline/known-good qualification, deterministic
+  dry-run planning, explicitly approved disposable adapter execution, and one
+  qualified synthetic sample that remains non-publishable for issue #53.
 - `--evidence-comparison=with:without` mode compares stored outputs with and without deterministic evidence search.
 - 27 hand-labeled public benchmark cases (`benchmark/cases/`) covering 7 languages and 15+ vulnerability types; `pnpm bench:public` scores catch-rate/precision/F1.
 

--- a/benchmarks/agent-tasks/contracts/agent-adapter-v2.schema.json
+++ b/benchmarks/agent-tasks/contracts/agent-adapter-v2.schema.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://codevetter.com/schemas/agent-task/agent-adapter-v2.json",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "adapter_id",
+    "agent",
+    "model",
+    "configuration",
+    "command",
+    "artifacts",
+    "environment_names",
+    "timeout_ms",
+    "cost_posture",
+    "planning"
+  ],
+  "properties": {
+    "schema_version": { "const": "codevetter.agent-task-adapter.v2" },
+    "adapter_id": { "$ref": "./common.schema.json#/$defs/id" },
+    "agent": { "type": "string", "minLength": 1, "maxLength": 120 },
+    "model": { "type": "string", "minLength": 1, "maxLength": 160 },
+    "configuration": { "type": "string", "minLength": 1, "maxLength": 160 },
+    "command": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 50,
+      "items": { "type": "string", "minLength": 1, "maxLength": 500 }
+    },
+    "artifacts": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 50,
+      "items": { "$ref": "./common.schema.json#/$defs/artifact" }
+    },
+    "environment_names": {
+      "type": "array",
+      "maxItems": 30,
+      "uniqueItems": true,
+      "items": { "type": "string", "pattern": "^[A-Z][A-Z0-9_]{0,79}$" }
+    },
+    "timeout_ms": { "type": "integer", "minimum": 1000, "maximum": 3600000 },
+    "cost_posture": { "enum": ["free", "paid", "unknown"] },
+    "planning": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "prompt_overhead_tokens",
+        "reserved_output_tokens",
+        "input_usd_per_million",
+        "output_usd_per_million",
+        "max_cost_usd"
+      ],
+      "properties": {
+        "prompt_overhead_tokens": { "type": "integer", "minimum": 0, "maximum": 1000000 },
+        "reserved_output_tokens": { "type": "integer", "minimum": 1, "maximum": 1000000 },
+        "input_usd_per_million": { "type": "number", "minimum": 0, "maximum": 100000 },
+        "output_usd_per_million": { "type": "number", "minimum": 0, "maximum": 100000 },
+        "max_cost_usd": { "type": "number", "minimum": 0, "maximum": 100000 }
+      }
+    },
+    "diagnostics_path": { "$ref": "./common.schema.json#/$defs/relativePath" }
+  }
+}

--- a/benchmarks/agent-tasks/contracts/run-plan.schema.json
+++ b/benchmarks/agent-tasks/contracts/run-plan.schema.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://codevetter.com/schemas/agent-task/run-plan-v1.json",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "plan_id",
+    "task_id",
+    "manifest_sha256",
+    "fixture_sha256",
+    "acceptance_contract_sha256",
+    "adapter_sha256",
+    "workspace_policy",
+    "environment",
+    "filtered_input_bytes",
+    "estimated_input_tokens",
+    "reserved_output_tokens",
+    "estimated_max_cost_usd",
+    "max_cost_usd",
+    "cost_posture",
+    "within_cost_limit",
+    "command",
+    "approval",
+    "blocked_reasons",
+    "limitations"
+  ],
+  "properties": {
+    "schema_version": { "const": "codevetter.agent-task-plan.v1" },
+    "plan_id": { "$ref": "./common.schema.json#/$defs/id" },
+    "task_id": { "$ref": "./common.schema.json#/$defs/id" },
+    "manifest_sha256": { "$ref": "./common.schema.json#/$defs/sha256" },
+    "fixture_sha256": { "$ref": "./common.schema.json#/$defs/sha256" },
+    "acceptance_contract_sha256": { "$ref": "./common.schema.json#/$defs/sha256" },
+    "adapter_sha256": { "$ref": "./common.schema.json#/$defs/sha256" },
+    "workspace_policy": { "const": "public_fixture_and_task_packet_v1" },
+    "environment": {
+      "type": "array",
+      "maxItems": 30,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "available"],
+        "properties": {
+          "name": { "type": "string", "pattern": "^[A-Z][A-Z0-9_]{0,79}$" },
+          "available": { "type": "boolean" }
+        }
+      }
+    },
+    "filtered_input_bytes": { "type": "integer", "minimum": 1, "maximum": 104857600 },
+    "estimated_input_tokens": { "type": "integer", "minimum": 1, "maximum": 100000000 },
+    "reserved_output_tokens": { "type": "integer", "minimum": 1, "maximum": 1000000 },
+    "estimated_max_cost_usd": { "type": "number", "minimum": 0, "maximum": 100000 },
+    "max_cost_usd": { "type": "number", "minimum": 0, "maximum": 100000 },
+    "cost_posture": { "enum": ["free", "paid", "unknown"] },
+    "within_cost_limit": { "type": "boolean" },
+    "command": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 50,
+      "items": { "type": "string", "minLength": 1, "maxLength": 500 }
+    },
+    "approval": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["launch_required", "paid_required"],
+      "properties": {
+        "launch_required": { "const": true },
+        "paid_required": { "type": "boolean" }
+      }
+    },
+    "blocked_reasons": {
+      "type": "array",
+      "maxItems": 50,
+      "items": { "type": "string", "minLength": 1, "maxLength": 200 }
+    },
+    "limitations": {
+      "type": "array",
+      "maxItems": 50,
+      "items": { "type": "string", "minLength": 1, "maxLength": 500 }
+    }
+  }
+}

--- a/benchmarks/agent-tasks/contracts/run-receipt-v2.schema.json
+++ b/benchmarks/agent-tasks/contracts/run-receipt-v2.schema.json
@@ -1,0 +1,129 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://codevetter.com/schemas/agent-task/run-receipt-v2.json",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "run_id",
+    "plan_id",
+    "task_id",
+    "manifest_sha256",
+    "fixture_sha256",
+    "acceptance_contract_sha256",
+    "adapter_sha256",
+    "environment_sha256",
+    "workspace_policy",
+    "terminal_status",
+    "lifecycle",
+    "agent",
+    "checks",
+    "regression_count",
+    "cleanup",
+    "limitations"
+  ],
+  "properties": {
+    "schema_version": { "const": "codevetter.agent-task-run.v2" },
+    "run_id": { "$ref": "./common.schema.json#/$defs/id" },
+    "plan_id": { "$ref": "./common.schema.json#/$defs/id" },
+    "task_id": { "$ref": "./common.schema.json#/$defs/id" },
+    "manifest_sha256": { "$ref": "./common.schema.json#/$defs/sha256" },
+    "fixture_sha256": { "$ref": "./common.schema.json#/$defs/sha256" },
+    "acceptance_contract_sha256": { "$ref": "./common.schema.json#/$defs/sha256" },
+    "adapter_sha256": { "$ref": "./common.schema.json#/$defs/sha256" },
+    "environment_sha256": { "$ref": "./common.schema.json#/$defs/sha256" },
+    "workspace_policy": { "const": "public_fixture_and_task_packet_v1" },
+    "terminal_status": {
+      "enum": [
+        "setup_failure",
+        "agent_failure",
+        "cancelled",
+        "timeout",
+        "incomplete_checks",
+        "check_failure",
+        "regression",
+        "check_error",
+        "cleanup_failure",
+        "success"
+      ]
+    },
+    "lifecycle": {
+      "type": "array",
+      "maxItems": 7,
+      "items": {
+        "enum": [
+          "workspace_prepared",
+          "agent_started",
+          "agent_terminated",
+          "checks_started",
+          "checks_finished",
+          "cleanup_complete",
+          "cleanup_failed"
+        ]
+      }
+    },
+    "agent": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "exit_code",
+        "stdout_sha256",
+        "stderr_sha256",
+        "stdout_bytes",
+        "stderr_bytes",
+        "output_truncated"
+      ],
+      "properties": {
+        "status": { "enum": ["not_started", "exited", "failed", "cancelled", "timeout"] },
+        "exit_code": { "type": ["integer", "null"], "minimum": 0, "maximum": 255 },
+        "stdout_sha256": { "$ref": "./common.schema.json#/$defs/sha256" },
+        "stderr_sha256": { "$ref": "./common.schema.json#/$defs/sha256" },
+        "stdout_bytes": { "type": "integer", "minimum": 0, "maximum": 262144 },
+        "stderr_bytes": { "type": "integer", "minimum": 0, "maximum": 262144 },
+        "output_truncated": { "type": "boolean" }
+      }
+    },
+    "checks": {
+      "type": "array",
+      "maxItems": 200,
+      "items": { "$ref": "./common.schema.json#/$defs/check" }
+    },
+    "regression_count": { "type": "integer", "minimum": 0, "maximum": 100 },
+    "cleanup": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status"],
+      "properties": { "status": { "enum": ["complete", "failed"] } }
+    },
+    "diagnostics": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "input_tokens": { "type": "integer", "minimum": 0 },
+        "output_tokens": { "type": "integer", "minimum": 0 },
+        "cost_usd": { "type": "number", "minimum": 0 },
+        "tool_calls": {
+          "type": "array",
+          "maxItems": 1000,
+          "items": { "type": "string", "maxLength": 200 }
+        },
+        "files_inspected": {
+          "type": "array",
+          "maxItems": 1000,
+          "items": { "$ref": "./common.schema.json#/$defs/relativePath" }
+        },
+        "files_modified": {
+          "type": "array",
+          "maxItems": 1000,
+          "items": { "$ref": "./common.schema.json#/$defs/relativePath" }
+        }
+      }
+    },
+    "limitations": {
+      "type": "array",
+      "maxItems": 50,
+      "items": { "type": "string", "minLength": 1, "maxLength": 500 }
+    }
+  }
+}

--- a/benchmarks/agent-tasks/sample/adapters/synthetic-false-fix.json
+++ b/benchmarks/agent-tasks/sample/adapters/synthetic-false-fix.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": "codevetter.agent-task-adapter.v2",
+  "adapter_id": "synthetic-false-fix",
+  "agent": "Repository-owned synthetic fixture adapter",
+  "model": "none",
+  "configuration": "offline-exact-replacement",
+  "command": ["{node}", "{adapter_root}/synthetic-false-fix.mjs", "{workspace}"],
+  "artifacts": [
+    {
+      "path": "synthetic-false-fix.mjs",
+      "sha256": "49493d89b1e5e8c5e5870a2ae1d1d4f775edda90368f6a13fe1f58ccafe76de0"
+    }
+  ],
+  "environment_names": ["FIXTURE_TOKEN"],
+  "timeout_ms": 5000,
+  "cost_posture": "free",
+  "planning": {
+    "prompt_overhead_tokens": 64,
+    "reserved_output_tokens": 128,
+    "input_usd_per_million": 0,
+    "output_usd_per_million": 0,
+    "max_cost_usd": 0
+  }
+}

--- a/benchmarks/agent-tasks/sample/adapters/synthetic-false-fix.mjs
+++ b/benchmarks/agent-tasks/sample/adapters/synthetic-false-fix.mjs
@@ -1,0 +1,15 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const [workspace] = process.argv.slice(2);
+const transformerPath = join(workspace, 'transformer.mjs');
+const before = await readFile(transformerPath, 'utf8');
+const after = before.replace('input.enabled || true', 'input.enabled ?? true');
+
+if (after === before) {
+  process.stderr.write('Expected synthetic defect was not present.\n');
+  process.exitCode = 2;
+} else {
+  await writeFile(transformerPath, after);
+  process.stdout.write(`FIXTURE_TOKEN=${process.env.FIXTURE_TOKEN}\nSynthetic repair complete.\n`);
+}

--- a/docs/development/agent-task-corpus.md
+++ b/docs/development/agent-task-corpus.md
@@ -7,10 +7,11 @@ sidebar:
 
 # Agent-task corpus contracts
 
-This is the contract and qualification foundation for
+This is the contract, qualification, and provider-neutral runner foundation for
 [GitHub issue #53](https://github.com/Codevetter/codevetter/issues/53). It makes
-task packages inspectable and immutable, then proves their baseline failure and
-known-good success without launching an agent.
+task packages inspectable and immutable, proves their baseline failure and
+known-good success, and gates one disposable adapter attempt behind a
+deterministic plan and explicit approval.
 
 The current owned sample is qualified through the real local path. It proves
 the machinery, not product value: one synthetic task remains far below corpus
@@ -27,6 +28,11 @@ pnpm corpus:validate --root benchmarks/agent-tasks/sample --json
 pnpm corpus:qualify --task preserve-explicit-false
 pnpm corpus:qualify --task preserve-explicit-false --json
 pnpm corpus:qualify --task preserve-explicit-false --out /tmp/qualification.json
+FIXTURE_TOKEN=synthetic pnpm corpus:plan --task preserve-explicit-false \
+  --adapter benchmarks/agent-tasks/sample/adapters/synthetic-false-fix.json
+FIXTURE_TOKEN=synthetic pnpm corpus:run --task preserve-explicit-false \
+  --adapter benchmarks/agent-tasks/sample/adapters/synthetic-false-fix.json \
+  --approve-plan <exact-plan-id>
 pnpm corpus:readiness
 pnpm corpus:readiness --json
 pnpm test:corpus-contracts
@@ -54,6 +60,19 @@ failure repeats at baseline, every check repeats successfully after the
 known-good replacement, and every workspace is removed. `--out` writes the
 receipt atomically.
 
+`corpus:plan` is the mandatory dry run. It binds the qualified task and
+immutable v2 adapter, reports public input bytes, conservative token/cost
+bounds, environment-name availability, cost posture, blockers, and approval
+requirements, but reads no environment values and creates no process or
+workspace.
+
+`corpus:run` performs one attempt only when `--approve-plan` names the exact
+current plan. Paid or unknown-cost adapters also require `--approve-paid`.
+Execution reads only declared environment values, launches without a shell in
+a fresh public-input-only workspace, bounds and redacts output, terminates the
+owned process group on timeout/cancellation, and starts hidden checks only
+after clean agent termination. `--out` atomically writes the v2 run receipt.
+
 ## Layout
 
 ```text
@@ -69,8 +88,14 @@ benchmarks/agent-tasks/
 │   ├── qualification-receipt.schema.json
 │   ├── qualification-receipt-v2.schema.json
 │   ├── agent-adapter.schema.json
-│   └── run-receipt.schema.json
+│   ├── agent-adapter-v2.schema.json
+│   ├── run-plan.schema.json
+│   ├── run-receipt.schema.json
+│   └── run-receipt-v2.schema.json
 └── sample/
+    ├── adapters/
+    │   ├── synthetic-false-fix.json
+    │   └── synthetic-false-fix.mjs
     ├── corpus.json
     ├── qualification.json
     └── tasks/<task-id>/
@@ -128,6 +153,20 @@ Qualification distinguishes wrong baseline failure, incomplete checks,
 timeouts, check errors, flakiness, patch drift, regression, and cleanup failure.
 Receipts omit temporary paths, timing, environment values, and raw output.
 
+## Runner boundary
+
+V2 adapter descriptors bind every adapter-root file by SHA-256 and permit only
+the closed `{node}`, `{adapter_root}`, `{workspace}`, and `{task_packet}`
+placeholders. The deterministic plan is the approval object; task, adapter,
+environment availability, input sizing, pricing, or limit drift produces a new
+plan ID and invalidates the old approval. Free adapters declare zero pricing.
+
+The run receipt binds the plan, task, fixture, acceptance contract, adapter,
+hashed environment identity, lifecycle ordering, agent termination, redacted
+output identities, exact checks, regression count, and cleanup. Optional
+provider diagnostics remain absent unless the adapter actually supplies them;
+the runner does not fabricate token, cost, tool, or file counts.
+
 ## Authoring rules
 
 - Keep task IDs, category IDs, failure modes, and check IDs lowercase
@@ -151,15 +190,18 @@ shortfalls with sorted path-specific errors.
 
 Validation and readiness only read local files and compute hashes.
 Qualification may create bounded temporary workspaces and execute the trusted
-repository-owned check driver. These paths do not:
+repository-owned check driver. An explicitly approved runner invocation may
+also execute one immutable adapter before those withheld checks. These paths do
+not:
 
-- launch an agent or subprocess adapter;
-- read credentials or environment values;
+- automatically launch an adapter from planning or validation;
+- read undeclared credentials or retain declared values in output/receipts;
 - make network requests;
 - project receipts into the structural-context evaluator; or
 - mutate corpus content.
 
-Agent execution and evaluator projection remain later, separately reviewed
-slices on issue #53. The sample reports `1 qualified` and
+The repository-owned synthetic adapter proves lifecycle mechanics only; no real
+provider/model or paid adapter was run. Real provider proof and evaluator
+projection remain later slices on issue #53. The sample reports `1 qualified` and
 `publishable: false`; task count, browser-lane, TypeScript-runtime, and category
 breadth gates remain closed.

--- a/docs/operations/ci.md
+++ b/docs/operations/ci.md
@@ -23,7 +23,8 @@ Steps, in order (a failure stops the job):
 8. **Unit tests** — `pnpm run test:unit` in `apps/desktop`
 9. **Automation readiness tests** — `pnpm run test:automation` and
    `pnpm run test:corpus-contracts` at root (hermetic Foundry receipt
-   sanitization plus agent-task contract, qualification, timeout, cleanup, and
+   sanitization plus agent-task contract, qualification, dry-run/approval,
+   disposable runner, timeout/cancellation, output-redaction, cleanup, and
    readiness tests; the live manifest verifier runs in `release.yml` as a
    post-upload check, not here)
 10. **MCP sidecar build smoke** — `pnpm run prepare:mcp-sidecar`

--- a/openspec/changes/archive/2026-07-31-add-agent-task-runner/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-31-add-agent-task-runner/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-31

--- a/openspec/changes/archive/2026-07-31-add-agent-task-runner/design.md
+++ b/openspec/changes/archive/2026-07-31-add-agent-task-runner/design.md
@@ -1,0 +1,84 @@
+## Context
+
+Qualification now owns safe task-package loading, public workspace
+materialization, immutable driver execution, and exact check-result contracts.
+The runner should compose those authorities without exposing withheld material
+to an adapter or coupling the corpus to Codex, Claude, or a hosted provider.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Produce a useful deterministic plan before any mutable or secret-reading
+  action.
+- Make launch and paid-cost approval explicit for one exact attempt.
+- Bound and redact adapter execution while guaranteeing process termination and
+  workspace cleanup.
+- Preserve task, adapter, environment, lifecycle, check, and cleanup evidence
+  in a closed receipt.
+
+**Non-Goals:**
+
+- Integrate a real provider, invoke a model, or perform a paid run.
+- Claim OS-level sandboxing against a malicious adapter.
+- Persist approvals, schedule concurrent runs, or add a desktop UI.
+- Project receipts into the structural-context evaluator.
+
+## Decisions
+
+### Version adapters and receipts instead of mutating v1
+
+V2 adapters add immutable executable artifacts and conservative planning
+inputs. V2 receipts add plan, fixture, acceptance, lifecycle, termination, and
+redacted-output identities. The dependency-free validator dispatches by
+`schema_version`, preserving v1 readers.
+
+### Treat the dry-run plan as the approval object
+
+The plan identity hashes canonical task, adapter, environment-availability,
+input-size, timeout, token, and cost fields. Execution requires that exact ID;
+paid adapters require an additional flag. Each invocation represents one
+attempt, so approval cannot silently authorize a retry.
+
+Planning checks only membership in the supplied available-name set. It does not
+read values, create a workspace, resolve temporary paths, or run either process.
+
+### Use closed placeholders and immutable artifacts
+
+V2 command arguments permit only `{node}`, `{adapter_root}`, `{workspace}`, and
+`{task_packet}`. Every adapter-root file referenced by the command must be a
+declared regular artifact with an exact SHA-256. Execution uses Node
+`spawn(..., { shell: false, detached: true })`.
+
+### Terminate before checking
+
+The agent process and its owned process group reach a terminal exit, timeout,
+or cancellation state before the check driver can start. Checks run only on
+exit zero. Timeout, cancellation, setup failure, agent failure, and cleanup
+failure never execute hidden checks.
+
+### Retain hashes and redacted bounded text, not raw output
+
+The runner caps stdout and stderr independently, replaces declared environment
+values plus credential-like assignments, and returns only bounded redacted
+text. The receipt keeps SHA-256 identities, byte counts, and truncation state;
+it never stores raw output, environment values, temporary paths, or commands
+after placeholder resolution.
+
+## Risks / Trade-offs
+
+- **Process groups vary by platform** → Use detached POSIX groups with a direct
+  child fallback; keep the lifecycle logic injectable for focused tests.
+- **A trusted adapter can escape the directory** → State the boundary honestly;
+  OS sandboxing is a later runner-hardening slice.
+- **Token estimation is approximate** → Label it conservative and use declared
+  overhead/output reserves plus a hard maximum-cost gate.
+- **Synthetic proof is not provider proof** → Keep the sample named synthetic
+  and do not check real-provider or corpus-breadth criteria.
+
+## Migration Plan
+
+Add v2 schemas and readers alongside v1, add one synthetic adapter under the
+owned sample, and exercise it only in focused tests/explicit CLI commands.
+Rollback removes v2 planning/execution while leaving qualification and v1
+contracts intact. No database, production, or external state changes.

--- a/openspec/changes/archive/2026-07-31-add-agent-task-runner/proposal.md
+++ b/openspec/changes/archive/2026-07-31-add-agent-task-runner/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+CodeVetter can now prove that a task fixture fails and its known-good change
+passes, but it cannot yet plan or execute a provider-neutral agent attempt
+without bypassing the corpus contracts. Issue #53 needs one fail-closed runner
+boundary before realistic agent receipts can be collected.
+
+## What Changes
+
+- Add v2 agent-adapter contracts that bind executable artifacts, closed command
+  placeholders, declared environment names, timeout, cost posture, and
+  conservative token/cost planning inputs.
+- Add a closed deterministic dry-run plan that reads no environment values and
+  launches neither an agent nor checks.
+- Require exact one-attempt launch approval and a second paid-cost approval
+  before any adapter process starts.
+- Run approved adapters without a shell in a fresh public-input-only workspace,
+  capture bounded redacted output, terminate owned process groups on
+  timeout/cancellation, and remove the workspace.
+- Withhold acceptance checks until the adapter process has terminated, then
+  classify exact required/regression evidence into a v2 immutable run receipt.
+- Prove the lifecycle with a repository-owned synthetic adapter; do not launch
+  a real provider or claim corpus breadth.
+
+## Capabilities
+
+### New Capabilities
+
+- `agent-task-runner`: deterministic planning, approval, disposable execution,
+  withheld checks, cancellation, and receipts for one agent-task attempt.
+
+### Modified Capabilities
+
+- `agent-task-corpus-contracts`: add closed v2 adapter, run-plan, and v2
+  run-receipt contracts while preserving v1 readers.
+
+## Impact
+
+This adds dependency-free Node scripts, JSON schemas, a synthetic sample
+adapter, focused tests, root CLI commands, documentation, and OpenSpec
+contracts. It does not add a production dependency, desktop route, provider
+integration, model call, network request, deploy, migration, or release.

--- a/openspec/changes/archive/2026-07-31-add-agent-task-runner/specs/agent-task-corpus-contracts/spec.md
+++ b/openspec/changes/archive/2026-07-31-add-agent-task-runner/specs/agent-task-corpus-contracts/spec.md
@@ -1,0 +1,23 @@
+## MODIFIED Requirements
+
+### Requirement: Corpus documents use closed versioned contracts
+
+The system SHALL define closed versioned contracts for corpus indexes, task
+manifests, fixture bundles, acceptance contracts, known-good changes, check
+results, qualification receipts, agent adapters, deterministic run plans, and
+run receipts. Adapter and receipt readers MUST preserve supported v1 documents
+while new runner output uses v2 identities and lifecycle evidence. Every
+contract MUST reject unknown fields, missing required fields, invalid enum
+values, duplicate identifiers, unsafe placeholders, and values outside
+declared bounds.
+
+#### Scenario: A contract document is valid
+
+- **WHEN** a document contains exactly the required and optional fields for its
+  declared schema version and every value is within bounds
+- **THEN** contract validation accepts it without adding inferred values
+
+#### Scenario: An unknown field appears
+
+- **WHEN** any contract object contains a field not declared by its schema
+- **THEN** validation rejects the document and identifies the exact field path

--- a/openspec/changes/archive/2026-07-31-add-agent-task-runner/specs/agent-task-runner/spec.md
+++ b/openspec/changes/archive/2026-07-31-add-agent-task-runner/specs/agent-task-runner/spec.md
@@ -1,0 +1,110 @@
+## Purpose
+
+Defines fail-closed provider-neutral planning and one approved disposable
+agent-task attempt whose hidden checks remain authoritative.
+
+## ADDED Requirements
+
+### Requirement: Dry-run planning is deterministic and non-executing
+
+The runner SHALL resolve a qualified task and immutable v2 adapter into one
+closed deterministic plan. Planning MUST report public input size,
+conservative input/output token bounds, maximum estimated cost, cost posture,
+declared environment availability, exact identities, and approval
+requirements without reading environment values, materializing a workspace,
+launching an adapter, or executing checks.
+
+#### Scenario: An unchanged plan is repeated
+
+- **WHEN** unchanged task, adapter, and environment-name availability are
+  planned twice
+- **THEN** the semantic plan and plan identity are identical
+
+#### Scenario: A required environment name is unavailable
+
+- **WHEN** the adapter declares an environment name absent from the planning
+  availability set
+- **THEN** the plan remains inspectable but records that execution is blocked
+
+### Requirement: Every launch consumes exact explicit approval
+
+The runner MUST require an approval naming the exact current plan before
+starting an adapter. A paid adapter MUST additionally receive explicit paid
+approval, and no approval may authorize more than one execution attempt.
+Identity drift or a failed cost gate MUST invalidate approval before launch.
+
+#### Scenario: Launch approval is missing or stale
+
+- **WHEN** execution is requested without the current plan identity
+- **THEN** the runner rejects the request before creating a workspace or
+  launching an adapter
+
+#### Scenario: A paid adapter lacks paid approval
+
+- **WHEN** launch approval is exact but the paid-cost approval is absent
+- **THEN** the runner rejects the request before launching the adapter
+
+### Requirement: Approved agent execution is disposable and bounded
+
+An approved attempt SHALL materialize a fresh workspace containing only public
+fixture files and the task packet, resolve only closed command placeholders,
+launch the immutable adapter without a shell, pass only declared environment
+values plus a minimal runner environment, and bound runtime and captured
+output. Timeout or cancellation MUST terminate the owned process group before
+cleanup. Output returned to an operator MUST be bounded and redact credential
+markers and exact declared environment values.
+
+#### Scenario: A synthetic adapter exits successfully
+
+- **WHEN** one approved adapter changes the public fixture and exits zero
+- **THEN** the runner records agent termination before starting withheld checks
+
+#### Scenario: An adapter exceeds its timeout
+
+- **WHEN** the adapter runs past its declared timeout
+- **THEN** the runner terminates its owned process group, skips checks, records
+  `timeout`, and attempts cleanup
+
+#### Scenario: An operator cancels the attempt
+
+- **WHEN** cancellation is requested after agent start
+- **THEN** the runner terminates its owned process group, skips checks, records
+  `cancelled`, and attempts cleanup
+
+### Requirement: Hidden checks run only after agent termination
+
+The acceptance contract, check driver, known-good change, and qualification
+receipt MUST remain outside the agent workspace. The runner SHALL start the
+immutable check driver only after the adapter process has terminated
+successfully, require the exact declared inventory, and classify incomplete
+checks, check failures, and regressions distinctly.
+
+#### Scenario: The agent change passes hidden checks
+
+- **WHEN** the terminated adapter leaves every required and regression check
+  passing
+- **THEN** the run records `success`
+
+#### Scenario: A hidden regression fails
+
+- **WHEN** required checks pass but any regression check fails
+- **THEN** the run records `regression` and cannot be successful
+
+### Requirement: Run receipts preserve exact bounded evidence
+
+Every attempted execution SHALL return a closed v2 receipt tied to the plan,
+task, manifest, fixture, acceptance contract, adapter, environment, public
+workspace policy, ordered lifecycle, agent termination, redacted output
+identities, checks, cleanup, and limitations. Missing token, cost, tool, or
+file diagnostics MUST remain absent rather than being fabricated as zero.
+
+#### Scenario: Cleanup succeeds
+
+- **WHEN** the attempt reaches its terminal state and the workspace is removed
+- **THEN** the receipt records complete cleanup and contains no temporary path
+  or credential value
+
+#### Scenario: Cleanup fails
+
+- **WHEN** workspace removal fails
+- **THEN** the receipt preserves `cleanup_failure` and cannot record success

--- a/openspec/changes/archive/2026-07-31-add-agent-task-runner/tasks.md
+++ b/openspec/changes/archive/2026-07-31-add-agent-task-runner/tasks.md
@@ -1,0 +1,45 @@
+## 1. Runner Contracts
+
+- [x] 1.1 Add closed v2 agent-adapter, deterministic run-plan, and v2
+  run-receipt schemas plus semantic validators.
+- [x] 1.2 Bind command placeholders to immutable adapter artifacts and preserve
+  v1 adapter/receipt validation.
+
+## 2. Planning and Approval
+
+- [x] 2.1 Export safe task-package loading for runner composition without
+  exposing withheld artifacts to the workspace.
+- [x] 2.2 Implement deterministic non-executing plans with environment-name
+  availability, input/token/cost bounds, and exact identities.
+- [x] 2.3 Require exact one-attempt launch approval, separate paid approval,
+  environment availability, and a passing cost gate before setup.
+
+## 3. Disposable Execution and Evidence
+
+- [x] 3.1 Implement fresh public-input-only workspace setup and closed command
+  placeholder resolution.
+- [x] 3.2 Implement shell-free process-group execution, bounded redacted
+  output, timeout/cancellation, and terminal-before-check ordering.
+- [x] 3.3 Run exact withheld checks after successful termination and classify
+  incomplete checks, failures, and regressions.
+- [x] 3.4 Emit closed v2 receipts with lifecycle, termination, output
+  identities, optional diagnostics, cleanup, and limitations.
+- [x] 3.5 Add human/JSON CLI planning plus explicitly approved execution and
+  optional atomic receipt output.
+
+## 4. Synthetic Proof and Tests
+
+- [x] 4.1 Add one immutable synthetic adapter that repairs the owned sample
+  without reading hidden checks or known-good data.
+- [x] 4.2 Test deterministic no-execution planning, stale/missing/paid approval,
+  environment and cost gates, success ordering, failure, timeout,
+  cancellation, output redaction/truncation, withheld-check gating, and cleanup.
+- [x] 4.3 Update corpus, CI, authoring, and project-status documentation.
+
+## 5. Delivery
+
+- [x] 5.1 Run focused tests, synthetic execution, corpus
+  validation/readiness, lint, docs, workflow YAML, strict OpenSpec validation,
+  and diff checks.
+- [x] 5.2 Sync/archive the change and deliver it through a pull request linked
+  to issue #53 without claiming a real provider run or corpus readiness.

--- a/openspec/specs/agent-task-corpus-contracts/spec.md
+++ b/openspec/specs/agent-task-corpus-contracts/spec.md
@@ -8,9 +8,12 @@ build a reproducible coding-agent task corpus without launching an agent.
 
 The system SHALL define closed versioned contracts for corpus indexes, task
 manifests, fixture bundles, acceptance contracts, known-good changes, check
-results, qualification receipts, agent adapters, and run receipts. Every
+results, qualification receipts, agent adapters, deterministic run plans, and
+run receipts. Adapter and receipt readers MUST preserve supported v1 documents
+while new runner output uses v2 identities and lifecycle evidence. Every
 contract MUST reject unknown fields, missing required fields, invalid enum
-values, duplicate identifiers, and values outside declared bounds.
+values, duplicate identifiers, unsafe placeholders, and values outside
+declared bounds.
 
 #### Scenario: A contract document is valid
 

--- a/openspec/specs/agent-task-runner/spec.md
+++ b/openspec/specs/agent-task-runner/spec.md
@@ -1,0 +1,112 @@
+# agent-task-runner Specification
+
+## Purpose
+
+Defines fail-closed provider-neutral planning and one approved disposable
+agent-task attempt whose hidden checks remain authoritative.
+
+## Requirements
+
+### Requirement: Dry-run planning is deterministic and non-executing
+
+The runner SHALL resolve a qualified task and immutable v2 adapter into one
+closed deterministic plan. Planning MUST report public input size,
+conservative input/output token bounds, maximum estimated cost, cost posture,
+declared environment availability, exact identities, and approval
+requirements without reading environment values, materializing a workspace,
+launching an adapter, or executing checks.
+
+#### Scenario: An unchanged plan is repeated
+
+- **WHEN** unchanged task, adapter, and environment-name availability are
+  planned twice
+- **THEN** the semantic plan and plan identity are identical
+
+#### Scenario: A required environment name is unavailable
+
+- **WHEN** the adapter declares an environment name absent from the planning
+  availability set
+- **THEN** the plan remains inspectable but records that execution is blocked
+
+### Requirement: Every launch consumes exact explicit approval
+
+The runner MUST require an approval naming the exact current plan before
+starting an adapter. A paid adapter MUST additionally receive explicit paid
+approval, and no approval may authorize more than one execution attempt.
+Identity drift or a failed cost gate MUST invalidate approval before launch.
+
+#### Scenario: Launch approval is missing or stale
+
+- **WHEN** execution is requested without the current plan identity
+- **THEN** the runner rejects the request before creating a workspace or
+  launching an adapter
+
+#### Scenario: A paid adapter lacks paid approval
+
+- **WHEN** launch approval is exact but the paid-cost approval is absent
+- **THEN** the runner rejects the request before launching the adapter
+
+### Requirement: Approved agent execution is disposable and bounded
+
+An approved attempt SHALL materialize a fresh workspace containing only public
+fixture files and the task packet, resolve only closed command placeholders,
+launch the immutable adapter without a shell, pass only declared environment
+values plus a minimal runner environment, and bound runtime and captured
+output. Timeout or cancellation MUST terminate the owned process group before
+cleanup. Output returned to an operator MUST be bounded and redact credential
+markers and exact declared environment values.
+
+#### Scenario: A synthetic adapter exits successfully
+
+- **WHEN** one approved adapter changes the public fixture and exits zero
+- **THEN** the runner records agent termination before starting withheld checks
+
+#### Scenario: An adapter exceeds its timeout
+
+- **WHEN** the adapter runs past its declared timeout
+- **THEN** the runner terminates its owned process group, skips checks, records
+  `timeout`, and attempts cleanup
+
+#### Scenario: An operator cancels the attempt
+
+- **WHEN** cancellation is requested after agent start
+- **THEN** the runner terminates its owned process group, skips checks, records
+  `cancelled`, and attempts cleanup
+
+### Requirement: Hidden checks run only after agent termination
+
+The acceptance contract, check driver, known-good change, and qualification
+receipt MUST remain outside the agent workspace. The runner SHALL start the
+immutable check driver only after the adapter process has terminated
+successfully, require the exact declared inventory, and classify incomplete
+checks, check failures, and regressions distinctly.
+
+#### Scenario: The agent change passes hidden checks
+
+- **WHEN** the terminated adapter leaves every required and regression check
+  passing
+- **THEN** the run records `success`
+
+#### Scenario: A hidden regression fails
+
+- **WHEN** required checks pass but any regression check fails
+- **THEN** the run records `regression` and cannot be successful
+
+### Requirement: Run receipts preserve exact bounded evidence
+
+Every attempted execution SHALL return a closed v2 receipt tied to the plan,
+task, manifest, fixture, acceptance contract, adapter, environment, public
+workspace policy, ordered lifecycle, agent termination, redacted output
+identities, checks, cleanup, and limitations. Missing token, cost, tool, or
+file diagnostics MUST remain absent rather than being fabricated as zero.
+
+#### Scenario: Cleanup succeeds
+
+- **WHEN** the attempt reaches its terminal state and the workspace is removed
+- **THEN** the receipt records complete cleanup and contains no temporary path
+  or credential value
+
+#### Scenario: Cleanup fails
+
+- **WHEN** workspace removal fails
+- **THEN** the receipt preserves `cleanup_failure` and cannot record success

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "corpus:validate": "node scripts/agent-task-corpus/cli.mjs",
     "corpus:readiness": "node scripts/agent-task-corpus/cli.mjs --strict",
     "corpus:qualify": "node scripts/agent-task-corpus/qualify-cli.mjs",
+    "corpus:plan": "node scripts/agent-task-corpus/run-cli.mjs",
+    "corpus:run": "node scripts/agent-task-corpus/run-cli.mjs --execute",
     "test:benchmark": "node --test scripts/run-catch-rate-benchmark.test.mjs scripts/run-structural-context-evaluation.test.mjs",
     "test:graph-context": "node --test scripts/run-structural-context-evaluation.test.mjs",
     "test:corpus-contracts": "node --test scripts/agent-task-corpus/*.test.mjs",

--- a/scripts/agent-task-corpus/contracts.mjs
+++ b/scripts/agent-task-corpus/contracts.mjs
@@ -4,6 +4,7 @@ import { readFileSync } from 'node:fs';
 export const CONTRACT_SCHEMA_VERSIONS = Object.freeze({
   'acceptance-contract': 'codevetter.agent-task-acceptance.v1',
   'agent-adapter': 'codevetter.agent-task-adapter.v1',
+  'agent-adapter-v2': 'codevetter.agent-task-adapter.v2',
   'check-result': 'codevetter.agent-task-check-result.v1',
   'corpus-index': 'codevetter.agent-task-corpus.v1',
   'fixture-bundle': 'codevetter.agent-task-fixture.v1',
@@ -11,6 +12,8 @@ export const CONTRACT_SCHEMA_VERSIONS = Object.freeze({
   'qualification-receipt': 'codevetter.agent-task-qualification.v1',
   'qualification-receipt-v2': 'codevetter.agent-task-qualification.v2',
   'run-receipt': 'codevetter.agent-task-run.v1',
+  'run-plan': 'codevetter.agent-task-plan.v1',
+  'run-receipt-v2': 'codevetter.agent-task-run.v2',
   'task-manifest': 'codevetter.agent-task.v1',
 });
 
@@ -31,6 +34,11 @@ const ENVIRONMENT_NAME_PATTERN = /^[A-Z][A-Z0-9_]{0,79}$/;
 
 export function canonicalJson(value) {
   return JSON.stringify(sortJson(value));
+}
+
+export function deriveRunPlanId(value) {
+  const { plan_id: _planId, ...identity } = value;
+  return `plan-${sha256Bytes(Buffer.from(canonicalJson(identity))).slice(0, 32)}`;
 }
 
 export function sha256Bytes(value) {
@@ -427,6 +435,14 @@ function validateQualificationReceiptV2(value, path, errors) {
 }
 
 function validateAgentAdapter(value, path, errors) {
+  if (value?.schema_version === CONTRACT_SCHEMA_VERSIONS['agent-adapter-v2']) {
+    validateAgentAdapterV2(value, path, errors);
+    return;
+  }
+  validateAgentAdapterV1(value, path, errors);
+}
+
+function validateAgentAdapterV1(value, path, errors) {
   const fields = [
     'schema_version',
     'adapter_id',
@@ -480,7 +496,172 @@ function validateAgentAdapter(value, path, errors) {
   }
 }
 
+function validateAgentAdapterV2(value, path, errors) {
+  const fields = [
+    'schema_version',
+    'adapter_id',
+    'agent',
+    'model',
+    'configuration',
+    'command',
+    'artifacts',
+    'environment_names',
+    'timeout_ms',
+    'cost_posture',
+    'planning',
+    'diagnostics_path',
+  ];
+  if (
+    !closedObject(
+      value,
+      path,
+      fields,
+      fields.filter((field) => field !== 'diagnostics_path'),
+      errors
+    )
+  ) {
+    return;
+  }
+  exact(
+    value.schema_version,
+    CONTRACT_SCHEMA_VERSIONS['agent-adapter-v2'],
+    `${path}.schema_version`,
+    errors
+  );
+  id(value.adapter_id, `${path}.adapter_id`, errors);
+  boundedString(value.agent, `${path}.agent`, errors, 1, 120);
+  boundedString(value.model, `${path}.model`, errors, 1, 160);
+  boundedString(value.configuration, `${path}.configuration`, errors, 1, 160);
+  stringArray(value.command, `${path}.command`, errors, { min: 1, max: 50, itemMax: 500 });
+  validateAdapterCommand(value.command, `${path}.command`, errors);
+  artifactArray(value.artifacts, `${path}.artifacts`, errors);
+  const artifactPaths = new Set((value.artifacts ?? []).map((item) => item?.path));
+  for (const [index, argument] of (value.command ?? []).entries()) {
+    if (typeof argument !== 'string' || !argument.startsWith('{adapter_root}/')) continue;
+    const declaredPath = argument.slice('{adapter_root}/'.length);
+    if (!artifactPaths.has(declaredPath)) {
+      errors.push(`${path}.command[${index}]: adapter artifact is not declared`);
+    }
+  }
+  validateEnvironmentNames(value.environment_names, `${path}.environment_names`, errors);
+  integer(value.timeout_ms, `${path}.timeout_ms`, errors, 1000, 3_600_000);
+  oneOf(value.cost_posture, ['free', 'paid', 'unknown'], `${path}.cost_posture`, errors);
+  validatePlanning(value.planning, `${path}.planning`, errors);
+  if (value.cost_posture === 'free') {
+    if (value.planning?.input_usd_per_million !== 0) {
+      errors.push(`${path}.planning.input_usd_per_million: free adapters require zero pricing`);
+    }
+    if (value.planning?.output_usd_per_million !== 0) {
+      errors.push(`${path}.planning.output_usd_per_million: free adapters require zero pricing`);
+    }
+  }
+  if (value.diagnostics_path !== undefined) {
+    relativePath(value.diagnostics_path, `${path}.diagnostics_path`, errors);
+  }
+}
+
+function validateRunPlan(value, path, errors) {
+  const fields = [
+    'schema_version',
+    'plan_id',
+    'task_id',
+    'manifest_sha256',
+    'fixture_sha256',
+    'acceptance_contract_sha256',
+    'adapter_sha256',
+    'workspace_policy',
+    'environment',
+    'filtered_input_bytes',
+    'estimated_input_tokens',
+    'reserved_output_tokens',
+    'estimated_max_cost_usd',
+    'max_cost_usd',
+    'cost_posture',
+    'within_cost_limit',
+    'command',
+    'approval',
+    'blocked_reasons',
+    'limitations',
+  ];
+  if (!closedObject(value, path, fields, fields, errors)) return;
+  exact(
+    value.schema_version,
+    CONTRACT_SCHEMA_VERSIONS['run-plan'],
+    `${path}.schema_version`,
+    errors
+  );
+  id(value.plan_id, `${path}.plan_id`, errors);
+  id(value.task_id, `${path}.task_id`, errors);
+  for (const field of [
+    'manifest_sha256',
+    'fixture_sha256',
+    'acceptance_contract_sha256',
+    'adapter_sha256',
+  ]) {
+    sha256(value[field], `${path}.${field}`, errors);
+  }
+  exact(
+    value.workspace_policy,
+    'public_fixture_and_task_packet_v1',
+    `${path}.workspace_policy`,
+    errors
+  );
+  validateEnvironmentAvailability(value.environment, `${path}.environment`, errors);
+  integer(value.filtered_input_bytes, `${path}.filtered_input_bytes`, errors, 1, 104_857_600);
+  integer(value.estimated_input_tokens, `${path}.estimated_input_tokens`, errors, 1, 100_000_000);
+  integer(value.reserved_output_tokens, `${path}.reserved_output_tokens`, errors, 1, 1_000_000);
+  finiteNumber(value.estimated_max_cost_usd, `${path}.estimated_max_cost_usd`, errors, 0, 100_000);
+  finiteNumber(value.max_cost_usd, `${path}.max_cost_usd`, errors, 0, 100_000);
+  oneOf(value.cost_posture, ['free', 'paid', 'unknown'], `${path}.cost_posture`, errors);
+  boolean(value.within_cost_limit, `${path}.within_cost_limit`, errors);
+  if (
+    typeof value.estimated_max_cost_usd === 'number' &&
+    typeof value.max_cost_usd === 'number' &&
+    value.within_cost_limit !== value.estimated_max_cost_usd <= value.max_cost_usd
+  ) {
+    errors.push(`${path}.within_cost_limit: must match the declared cost gate`);
+  }
+  stringArray(value.command, `${path}.command`, errors, { min: 1, max: 50, itemMax: 500 });
+  validateAdapterCommand(value.command, `${path}.command`, errors);
+  if (
+    closedObject(
+      value.approval,
+      `${path}.approval`,
+      ['launch_required', 'paid_required'],
+      ['launch_required', 'paid_required'],
+      errors
+    )
+  ) {
+    exact(value.approval.launch_required, true, `${path}.approval.launch_required`, errors);
+    boolean(value.approval.paid_required, `${path}.approval.paid_required`, errors);
+    const expectedPaid = value.cost_posture !== 'free';
+    if (value.approval.paid_required !== expectedPaid) {
+      errors.push(`${path}.approval.paid_required: must match conservative cost posture`);
+    }
+  }
+  stringArray(value.blocked_reasons, `${path}.blocked_reasons`, errors, {
+    max: 50,
+    itemMax: 200,
+  });
+  if (Array.isArray(value.blocked_reasons)) {
+    unique(value.blocked_reasons, `${path}.blocked_reasons`, errors);
+    sorted(value.blocked_reasons, `${path}.blocked_reasons`, errors);
+  }
+  stringArray(value.limitations, `${path}.limitations`, errors, { max: 50, itemMax: 500 });
+  if (typeof value.plan_id === 'string' && value.plan_id !== deriveRunPlanId(value)) {
+    errors.push(`${path}.plan_id: does not match the canonical plan identity`);
+  }
+}
+
 function validateRunReceipt(value, path, errors) {
+  if (value?.schema_version === CONTRACT_SCHEMA_VERSIONS['run-receipt-v2']) {
+    validateRunReceiptV2(value, path, errors);
+    return;
+  }
+  validateRunReceiptV1(value, path, errors);
+}
+
+function validateRunReceiptV1(value, path, errors) {
   const fields = [
     'schema_version',
     'run_id',
@@ -558,6 +739,112 @@ function validateRunReceipt(value, path, errors) {
   }
 }
 
+function validateRunReceiptV2(value, path, errors) {
+  const fields = [
+    'schema_version',
+    'run_id',
+    'plan_id',
+    'task_id',
+    'manifest_sha256',
+    'fixture_sha256',
+    'acceptance_contract_sha256',
+    'adapter_sha256',
+    'environment_sha256',
+    'workspace_policy',
+    'terminal_status',
+    'lifecycle',
+    'agent',
+    'checks',
+    'regression_count',
+    'cleanup',
+    'diagnostics',
+    'limitations',
+  ];
+  if (
+    !closedObject(
+      value,
+      path,
+      fields,
+      fields.filter((field) => field !== 'diagnostics'),
+      errors
+    )
+  ) {
+    return;
+  }
+  exact(
+    value.schema_version,
+    CONTRACT_SCHEMA_VERSIONS['run-receipt-v2'],
+    `${path}.schema_version`,
+    errors
+  );
+  id(value.run_id, `${path}.run_id`, errors);
+  id(value.plan_id, `${path}.plan_id`, errors);
+  id(value.task_id, `${path}.task_id`, errors);
+  for (const field of [
+    'manifest_sha256',
+    'fixture_sha256',
+    'acceptance_contract_sha256',
+    'adapter_sha256',
+    'environment_sha256',
+  ]) {
+    sha256(value[field], `${path}.${field}`, errors);
+  }
+  exact(
+    value.workspace_policy,
+    'public_fixture_and_task_packet_v1',
+    `${path}.workspace_policy`,
+    errors
+  );
+  const terminalStatuses = [
+    'setup_failure',
+    'agent_failure',
+    'cancelled',
+    'timeout',
+    'incomplete_checks',
+    'check_failure',
+    'regression',
+    'check_error',
+    'cleanup_failure',
+    'success',
+  ];
+  oneOf(value.terminal_status, terminalStatuses, `${path}.terminal_status`, errors);
+  validateLifecycle(value.lifecycle, `${path}.lifecycle`, errors);
+  validateAgentTermination(value.agent, `${path}.agent`, errors);
+  checkArray(value.checks, `${path}.checks`, errors);
+  integer(value.regression_count, `${path}.regression_count`, errors, 0, CORPUS_LIMITS.maxChecks);
+  if (closedObject(value.cleanup, `${path}.cleanup`, ['status'], ['status'], errors)) {
+    oneOf(value.cleanup.status, ['complete', 'failed'], `${path}.cleanup.status`, errors);
+  }
+  validateDiagnostics(value.diagnostics, `${path}.diagnostics`, errors);
+  stringArray(value.limitations, `${path}.limitations`, errors, { max: 50, itemMax: 500 });
+
+  const checksStarted = value.lifecycle?.includes('checks_started');
+  const agentTerminated = value.lifecycle?.includes('agent_terminated');
+  if (checksStarted && !agentTerminated) {
+    errors.push(`${path}.lifecycle: checks require prior agent termination`);
+  }
+  if (value.terminal_status === 'success') {
+    if (value.cleanup?.status !== 'complete') {
+      errors.push(`${path}.cleanup.status: success requires complete cleanup`);
+    }
+    if (value.agent?.status !== 'exited' || value.agent?.exit_code !== 0) {
+      errors.push(`${path}.agent: success requires a clean zero exit`);
+    }
+    if (!checksStarted || !value.lifecycle?.includes('checks_finished')) {
+      errors.push(`${path}.lifecycle: success requires completed checks`);
+    }
+    if (value.regression_count !== 0) {
+      errors.push(`${path}.regression_count: success requires zero regressions`);
+    }
+    if (value.checks?.some((check) => check?.status !== 'pass')) {
+      errors.push(`${path}.checks: success requires every check to pass`);
+    }
+  }
+  if (value.cleanup?.status === 'failed' && value.terminal_status !== 'cleanup_failure') {
+    errors.push(`${path}.terminal_status: failed cleanup requires cleanup_failure`);
+  }
+}
+
 function validateDiagnostics(value, path, errors) {
   if (value === undefined) return;
   const fields = [
@@ -592,6 +879,167 @@ function validateDiagnostics(value, path, errors) {
         relativePath(item, `${path}.${field}[${index}]`, errors);
       }
     }
+  }
+}
+
+function validateAdapterCommand(value, path, errors) {
+  if (!Array.isArray(value)) return;
+  const allowed = new Set(['{node}', '{adapter_root}', '{workspace}', '{task_packet}']);
+  if (value[0] !== '{node}') {
+    errors.push(`${path}[0]: v2 adapters must use the immutable Node runtime placeholder`);
+  }
+  for (const [index, argument] of value.entries()) {
+    if (typeof argument !== 'string') continue;
+    const placeholders = argument.match(/\{[^}]+\}/g) ?? [];
+    for (const placeholder of placeholders) {
+      if (!allowed.has(placeholder)) {
+        errors.push(`${path}[${index}]: unknown placeholder "${placeholder}"`);
+      }
+    }
+    if (placeholders.length > 1 || /[{}]/.test(argument.replace(/\{[^}]+\}/g, ''))) {
+      errors.push(`${path}[${index}]: expected at most one closed placeholder`);
+    }
+    if (argument.includes('{node}') && argument !== '{node}') {
+      errors.push(`${path}[${index}]: node placeholder must be the complete argument`);
+    }
+    if (argument.includes('{task_packet}') && argument !== '{task_packet}') {
+      errors.push(`${path}[${index}]: task_packet placeholder must be the complete argument`);
+    }
+    if (argument.includes('{workspace}') && argument !== '{workspace}') {
+      if (!argument.startsWith('{workspace}/')) {
+        errors.push(`${path}[${index}]: workspace must prefix one safe relative path`);
+      } else {
+        relativePath(
+          argument.slice('{workspace}/'.length),
+          `${path}[${index}] workspace path`,
+          errors
+        );
+      }
+    }
+    if (argument.includes('{adapter_root}')) {
+      if (!argument.startsWith('{adapter_root}/') || argument.match(/\{[^}]+\}/g)?.length !== 1) {
+        errors.push(`${path}[${index}]: adapter_root must prefix one declared artifact path`);
+      } else {
+        relativePath(
+          argument.slice('{adapter_root}/'.length),
+          `${path}[${index}] adapter path`,
+          errors
+        );
+      }
+    }
+  }
+}
+
+function artifactArray(value, path, errors) {
+  array(value, path, errors, { min: 1, max: 50 });
+  if (!Array.isArray(value)) return;
+  const paths = [];
+  for (const [index, item] of value.entries()) {
+    artifact(item, `${path}[${index}]`, errors);
+    if (typeof item?.path === 'string') paths.push(item.path);
+  }
+  unique(paths, `${path} path`, errors);
+  sorted(paths, path, errors);
+}
+
+function validateEnvironmentNames(value, path, errors) {
+  stringArray(value, path, errors, { max: 30, itemMax: 80 });
+  if (!Array.isArray(value)) return;
+  unique(value, path, errors);
+  sorted(value, path, errors);
+  for (const [index, name] of value.entries()) {
+    if (typeof name === 'string' && !ENVIRONMENT_NAME_PATTERN.test(name)) {
+      errors.push(`${path}[${index}]: invalid environment variable name`);
+    }
+  }
+}
+
+function validateEnvironmentAvailability(value, path, errors) {
+  array(value, path, errors, { max: 30 });
+  if (!Array.isArray(value)) return;
+  const names = [];
+  for (const [index, entry] of value.entries()) {
+    const entryPath = `${path}[${index}]`;
+    if (!closedObject(entry, entryPath, ['name', 'available'], ['name', 'available'], errors)) {
+      continue;
+    }
+    stringPattern(entry.name, ENVIRONMENT_NAME_PATTERN, `${entryPath}.name`, errors, 80);
+    boolean(entry.available, `${entryPath}.available`, errors);
+    if (typeof entry.name === 'string') names.push(entry.name);
+  }
+  unique(names, `${path} name`, errors);
+  sorted(names, path, errors);
+}
+
+function validatePlanning(value, path, errors) {
+  const fields = [
+    'prompt_overhead_tokens',
+    'reserved_output_tokens',
+    'input_usd_per_million',
+    'output_usd_per_million',
+    'max_cost_usd',
+  ];
+  if (!closedObject(value, path, fields, fields, errors)) return;
+  integer(value.prompt_overhead_tokens, `${path}.prompt_overhead_tokens`, errors, 0, 1_000_000);
+  integer(value.reserved_output_tokens, `${path}.reserved_output_tokens`, errors, 1, 1_000_000);
+  for (const field of ['input_usd_per_million', 'output_usd_per_million', 'max_cost_usd']) {
+    finiteNumber(value[field], `${path}.${field}`, errors, 0, 100_000);
+  }
+}
+
+function validateLifecycle(value, path, errors) {
+  const order = [
+    'workspace_prepared',
+    'agent_started',
+    'agent_terminated',
+    'checks_started',
+    'checks_finished',
+    'cleanup_complete',
+    'cleanup_failed',
+  ];
+  array(value, path, errors, { max: order.length });
+  if (!Array.isArray(value)) return;
+  for (const [index, item] of value.entries()) {
+    oneOf(item, order, `${path}[${index}]`, errors);
+  }
+  unique(value, path, errors);
+  const positions = value.map((item) => order.indexOf(item));
+  if (positions.some((position, index) => index > 0 && position <= positions[index - 1])) {
+    errors.push(`${path}: lifecycle events must follow terminal execution order`);
+  }
+  if (value.includes('cleanup_complete') && value.includes('cleanup_failed')) {
+    errors.push(`${path}: cleanup cannot be both complete and failed`);
+  }
+}
+
+function validateAgentTermination(value, path, errors) {
+  const fields = [
+    'status',
+    'exit_code',
+    'stdout_sha256',
+    'stderr_sha256',
+    'stdout_bytes',
+    'stderr_bytes',
+    'output_truncated',
+  ];
+  if (!closedObject(value, path, fields, fields, errors)) return;
+  oneOf(
+    value.status,
+    ['not_started', 'exited', 'failed', 'cancelled', 'timeout'],
+    `${path}.status`,
+    errors
+  );
+  if (value.exit_code !== null) integer(value.exit_code, `${path}.exit_code`, errors, 0, 255);
+  sha256(value.stdout_sha256, `${path}.stdout_sha256`, errors);
+  sha256(value.stderr_sha256, `${path}.stderr_sha256`, errors);
+  integer(value.stdout_bytes, `${path}.stdout_bytes`, errors, 0, 262_144);
+  integer(value.stderr_bytes, `${path}.stderr_bytes`, errors, 0, 262_144);
+  boolean(value.output_truncated, `${path}.output_truncated`, errors);
+  if (value.status === 'exited' && value.exit_code !== 0) {
+    errors.push(`${path}.exit_code: exited status requires zero`);
+  }
+  if (['not_started', 'cancelled', 'timeout'].includes(value.status) && value.exit_code !== null) {
+    errors.push(`${path}.exit_code: status requires null`);
   }
 }
 
@@ -853,6 +1301,12 @@ function integer(value, path, errors, min, max = Number.MAX_SAFE_INTEGER) {
   }
 }
 
+function finiteNumber(value, path, errors, min, max) {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < min || value > max) {
+    errors.push(`${path}: expected a finite number from ${min} to ${max}`);
+  }
+}
+
 function boolean(value, path, errors) {
   if (typeof value !== 'boolean') errors.push(`${path}: expected a boolean`);
 }
@@ -900,6 +1354,7 @@ const validators = Object.freeze({
   'fixture-bundle': validateFixtureBundle,
   'known-good-change': validateKnownGoodChange,
   'qualification-receipt': validateQualificationReceipt,
+  'run-plan': validateRunPlan,
   'run-receipt': validateRunReceipt,
   'task-manifest': validateTaskManifest,
 });

--- a/scripts/agent-task-corpus/contracts.test.mjs
+++ b/scripts/agent-task-corpus/contracts.test.mjs
@@ -6,6 +6,7 @@ import test from 'node:test';
 import {
   CONTRACT_SCHEMA_VERSIONS,
   canonicalJson,
+  deriveRunPlanId,
   sha256Bytes,
   validateContract,
 } from './contracts.mjs';
@@ -23,6 +24,7 @@ test('all public contract schemas are closed and parseable', async () => {
   const names = [
     'acceptance-contract',
     'agent-adapter',
+    'agent-adapter-v2',
     'check-result',
     'corpus-index',
     'fixture-bundle',
@@ -30,6 +32,8 @@ test('all public contract schemas are closed and parseable', async () => {
     'qualification-receipt',
     'qualification-receipt-v2',
     'run-receipt',
+    'run-plan',
+    'run-receipt-v2',
     'task-manifest',
   ];
   for (const name of names) {
@@ -41,6 +45,27 @@ test('all public contract schemas are closed and parseable', async () => {
 });
 
 test('accepts representative documents for all qualification and runner contracts', () => {
+  const runPlanDraft = {
+    schema_version: CONTRACT_SCHEMA_VERSIONS['run-plan'],
+    task_id: 'preserve-explicit-false',
+    manifest_sha256: DIGEST,
+    fixture_sha256: DIGEST,
+    acceptance_contract_sha256: DIGEST,
+    adapter_sha256: DIGEST,
+    workspace_policy: 'public_fixture_and_task_packet_v1',
+    environment: [{ name: 'FIXTURE_TOKEN', available: true }],
+    filtered_input_bytes: 400,
+    estimated_input_tokens: 164,
+    reserved_output_tokens: 128,
+    estimated_max_cost_usd: 0,
+    max_cost_usd: 0,
+    cost_posture: 'free',
+    within_cost_limit: true,
+    command: ['{node}', '{adapter_root}/fixture-agent.mjs', '{workspace}'],
+    approval: { launch_required: true, paid_required: false },
+    blocked_reasons: [],
+    limitations: [],
+  };
   const documents = {
     'acceptance-contract': {
       schema_version: CONTRACT_SCHEMA_VERSIONS['acceptance-contract'],
@@ -61,6 +86,25 @@ test('accepts representative documents for all qualification and runner contract
       environment_names: [],
       timeout_ms: 30_000,
       cost_posture: 'free',
+    },
+    'agent-adapter-v2': {
+      schema_version: CONTRACT_SCHEMA_VERSIONS['agent-adapter-v2'],
+      adapter_id: 'fixture-agent',
+      agent: 'Fixture Agent',
+      model: 'none',
+      configuration: 'offline',
+      command: ['{node}', '{adapter_root}/fixture-agent.mjs', '{workspace}'],
+      artifacts: [{ path: 'fixture-agent.mjs', sha256: DIGEST }],
+      environment_names: ['FIXTURE_TOKEN'],
+      timeout_ms: 30_000,
+      cost_posture: 'free',
+      planning: {
+        prompt_overhead_tokens: 64,
+        reserved_output_tokens: 128,
+        input_usd_per_million: 0,
+        output_usd_per_million: 0,
+        max_cost_usd: 0,
+      },
     },
     'check-result': {
       schema_version: CONTRACT_SCHEMA_VERSIONS['check-result'],
@@ -151,6 +195,44 @@ test('accepts representative documents for all qualification and runner contract
       cleanup: { status: 'complete' },
       limitations: [],
     },
+    'run-plan': {
+      ...runPlanDraft,
+      plan_id: deriveRunPlanId(runPlanDraft),
+    },
+    'run-receipt-v2': {
+      schema_version: CONTRACT_SCHEMA_VERSIONS['run-receipt-v2'],
+      run_id: 'fixture-run-v2',
+      plan_id: 'plan-fixture',
+      task_id: 'preserve-explicit-false',
+      manifest_sha256: DIGEST,
+      fixture_sha256: DIGEST,
+      acceptance_contract_sha256: DIGEST,
+      adapter_sha256: DIGEST,
+      environment_sha256: DIGEST,
+      workspace_policy: 'public_fixture_and_task_packet_v1',
+      terminal_status: 'success',
+      lifecycle: [
+        'workspace_prepared',
+        'agent_started',
+        'agent_terminated',
+        'checks_started',
+        'checks_finished',
+        'cleanup_complete',
+      ],
+      agent: {
+        status: 'exited',
+        exit_code: 0,
+        stdout_sha256: DIGEST,
+        stderr_sha256: DIGEST,
+        stdout_bytes: 10,
+        stderr_bytes: 0,
+        output_truncated: false,
+      },
+      checks: [{ id: 'explicit-false-preserved', status: 'pass' }],
+      regression_count: 0,
+      cleanup: { status: 'complete' },
+      limitations: [],
+    },
     'task-manifest': {
       schema_version: CONTRACT_SCHEMA_VERSIONS['task-manifest'],
       task_id: 'preserve-explicit-false',
@@ -177,7 +259,12 @@ test('accepts representative documents for all qualification and runner contract
   };
 
   for (const [name, document] of Object.entries(documents)) {
-    const kind = name === 'qualification-receipt-v2' ? 'qualification-receipt' : name;
+    const kind =
+      {
+        'agent-adapter-v2': 'agent-adapter',
+        'qualification-receipt-v2': 'qualification-receipt',
+        'run-receipt-v2': 'run-receipt',
+      }[name] ?? name;
     assert.deepEqual(validateContract(kind, document), [], name);
   }
 });
@@ -200,6 +287,30 @@ test('rejects unknown fields, unsafe paths, bounds, duplicates, and false qualif
     '$.secret_value: unknown field',
     '$.timeout_ms: expected an integer from 1000 to 3600000',
   ]);
+
+  const unsafeV2Adapter = {
+    schema_version: CONTRACT_SCHEMA_VERSIONS['agent-adapter-v2'],
+    adapter_id: 'fixture-agent',
+    agent: 'Fixture Agent',
+    model: 'none',
+    configuration: 'offline',
+    command: ['{node}', '{adapter_root}/fixture-agent.mjs', '{workspace}/../hidden'],
+    artifacts: [{ path: 'fixture-agent.mjs', sha256: DIGEST }],
+    environment_names: [],
+    timeout_ms: 30_000,
+    cost_posture: 'free',
+    planning: {
+      prompt_overhead_tokens: 0,
+      reserved_output_tokens: 1,
+      input_usd_per_million: 0,
+      output_usd_per_million: 0,
+      max_cost_usd: 0,
+    },
+  };
+  assert.match(
+    validateContract('agent-adapter', unsafeV2Adapter).join('\n'),
+    /safe POSIX relative path/
+  );
 
   const qualification = {
     schema_version: CONTRACT_SCHEMA_VERSIONS['qualification-receipt'],

--- a/scripts/agent-task-corpus/qualify-task.mjs
+++ b/scripts/agent-task-corpus/qualify-task.mjs
@@ -73,7 +73,7 @@ export async function writeQualificationReceipt(path, receipt) {
   await rename(temporary, destination);
 }
 
-async function loadTaskPackage(root, taskId) {
+export async function loadTaskPackage(root, taskId) {
   const corpusRoot = resolve(root);
   const validation = validateCorpus({ root: corpusRoot, ignoreQualification: true });
   if (!validation.valid) {

--- a/scripts/agent-task-corpus/run-cli.mjs
+++ b/scripts/agent-task-corpus/run-cli.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+
+import { pathToFileURL } from 'node:url';
+
+import { executeAgentTask, planAgentTask, writeRunReceipt } from './run-task.mjs';
+
+export async function runAgentTaskCli(args = process.argv.slice(2)) {
+  const wantsJson = args.includes('--json');
+  try {
+    const options = parseArgs(args);
+    const availableEnvironmentNames = Object.keys(process.env);
+    const plan = await planAgentTask({
+      root: options.root,
+      taskId: options.taskId,
+      adapterPath: options.adapterPath,
+      availableEnvironmentNames,
+    });
+    if (!options.execute) {
+      return {
+        exitCode: 0,
+        output: wantsJson ? `${JSON.stringify(plan)}\n` : planOutput(plan),
+        plan,
+        receipt: null,
+      };
+    }
+    const environment = {};
+    for (const entry of plan.environment) {
+      if (entry.available) environment[entry.name] = process.env[entry.name];
+    }
+    const result = await executeAgentTask({
+      root: options.root,
+      taskId: options.taskId,
+      adapterPath: options.adapterPath,
+      environment,
+      approvePlanId: options.approvePlanId,
+      approvePaid: options.approvePaid,
+    });
+    if (options.out) await writeRunReceipt(options.out, result.receipt);
+    const rendered = wantsJson ? `${JSON.stringify(result)}\n` : runOutput(result, options.out);
+    return {
+      ...result,
+      operatorOutput: result.output,
+      exitCode: result.receipt.terminal_status === 'success' ? 0 : 1,
+      output: rendered,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      exitCode: 2,
+      output: wantsJson
+        ? `${JSON.stringify({ error: message })}\n`
+        : `Agent-task runner failed: ${message}\n`,
+      plan: null,
+      receipt: null,
+    };
+  }
+}
+
+function parseArgs(args) {
+  const options = {
+    root: undefined,
+    taskId: undefined,
+    adapterPath: undefined,
+    approvePlanId: undefined,
+    out: undefined,
+    execute: false,
+    approvePaid: false,
+  };
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    if (argument === '--json') continue;
+    if (argument === '--execute') {
+      options.execute = true;
+      continue;
+    }
+    if (argument === '--approve-paid') {
+      options.approvePaid = true;
+      continue;
+    }
+    if (['--root', '--task', '--adapter', '--approve-plan', '--out'].includes(argument)) {
+      const value = args[index + 1];
+      if (!value || value.startsWith('--')) throw new Error(`${argument} requires a value`);
+      index += 1;
+      if (argument === '--root') options.root = value;
+      if (argument === '--task') options.taskId = value;
+      if (argument === '--adapter') options.adapterPath = value;
+      if (argument === '--approve-plan') options.approvePlanId = value;
+      if (argument === '--out') options.out = value;
+      continue;
+    }
+    throw new Error(`unknown argument: ${argument}`);
+  }
+  if (!options.taskId) throw new Error('--task is required');
+  if (!options.adapterPath) throw new Error('--adapter is required');
+  return options;
+}
+
+function planOutput(plan) {
+  const lines = [
+    `Plan: ${plan.plan_id}`,
+    `Task: ${plan.task_id}`,
+    `Cost posture: ${plan.cost_posture}`,
+    `Estimated maximum cost: $${plan.estimated_max_cost_usd.toFixed(6)}`,
+    `Cost limit: $${plan.max_cost_usd.toFixed(6)}`,
+    `Launch approval required: yes`,
+    `Paid approval required: ${plan.approval.paid_required ? 'yes' : 'no'}`,
+    `Blocked: ${plan.blocked_reasons.length > 0 ? plan.blocked_reasons.join(', ') : 'no'}`,
+  ];
+  return `${lines.join('\n')}\n`;
+}
+
+function runOutput(result, outputPath) {
+  const lines = [
+    `Run: ${result.receipt.run_id}`,
+    `Plan: ${result.plan.plan_id}`,
+    `Status: ${result.receipt.terminal_status}`,
+    `Cleanup: ${result.receipt.cleanup.status}`,
+  ];
+  if (result.output.stdout) lines.push(`Stdout:\n${result.output.stdout.trimEnd()}`);
+  if (result.output.stderr) lines.push(`Stderr:\n${result.output.stderr.trimEnd()}`);
+  if (outputPath) lines.push(`Receipt: ${outputPath}`);
+  return `${lines.join('\n')}\n`;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const result = await runAgentTaskCli();
+  process.stdout.write(result.output);
+  process.exitCode = result.exitCode;
+}

--- a/scripts/agent-task-corpus/run-task.mjs
+++ b/scripts/agent-task-corpus/run-task.mjs
@@ -1,0 +1,474 @@
+import { spawn } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises';
+import { basename, dirname, join, resolve } from 'node:path';
+
+import {
+  CONTRACT_SCHEMA_VERSIONS,
+  CORPUS_LIMITS,
+  canonicalJson,
+  deriveRunPlanId,
+  sha256Bytes,
+  validateContract,
+} from './contracts.mjs';
+import { executeCheckDriver, loadTaskPackage, materializeWorkspace } from './qualify-task.mjs';
+import { DEFAULT_CORPUS_ROOT, resolveArtifact, validateCorpus } from './validate-corpus.mjs';
+
+const MAX_OUTPUT_BYTES = 256 * 1024;
+const EMPTY_SHA256 = sha256Bytes(Buffer.alloc(0));
+const WORKSPACE_POLICY = 'public_fixture_and_task_packet_v1';
+const PLAN_LIMITATIONS = Object.freeze([
+  'Token counts use a conservative byte heuristic rather than provider tokenization.',
+  'Planning checks environment-name availability without reading environment values.',
+]);
+const RUN_LIMITATIONS = Object.freeze([
+  'The runner executes an immutable adapter without an operating-system sandbox.',
+  'Captured operator output is bounded and redacted before it leaves the runner.',
+]);
+
+export async function planAgentTask({
+  root = DEFAULT_CORPUS_ROOT,
+  taskId,
+  adapterPath,
+  availableEnvironmentNames = [],
+} = {}) {
+  const validation = validateCorpus({ root });
+  const taskRow = validation.tasks.find((task) => task.task_id === taskId);
+  if (!validation.valid || !taskRow?.qualified) {
+    throw new Error(
+      !validation.valid
+        ? `corpus validation failed:\n${validation.errors.join('\n')}`
+        : `task "${taskId}" does not have valid qualification evidence`
+    );
+  }
+  const task = await loadTaskPackage(root, taskId);
+  const adapter = await loadAgentAdapter(adapterPath);
+  const available = new Set(availableEnvironmentNames);
+  const environment = adapter.value.environment_names.map((name) => ({
+    name,
+    available: available.has(name),
+  }));
+  const filteredInputBytes =
+    task.taskPacket.length +
+    task.fixture.files.reduce(
+      (total, file) => total + Buffer.from(file.content_base64, 'base64').length,
+      0
+    );
+  const estimatedInputTokens =
+    Math.ceil(filteredInputBytes / 4) + adapter.value.planning.prompt_overhead_tokens;
+  const estimatedMaxCostUsd = roundCostUp(
+    (estimatedInputTokens * adapter.value.planning.input_usd_per_million +
+      adapter.value.planning.reserved_output_tokens *
+        adapter.value.planning.output_usd_per_million) /
+      1_000_000
+  );
+  const withinCostLimit = estimatedMaxCostUsd <= adapter.value.planning.max_cost_usd;
+  const blockedReasons = environment
+    .filter((entry) => !entry.available)
+    .map((entry) => `missing-environment:${entry.name}`);
+  if (!withinCostLimit) blockedReasons.push('cost-limit-exceeded');
+  blockedReasons.sort();
+
+  const draft = {
+    schema_version: CONTRACT_SCHEMA_VERSIONS['run-plan'],
+    task_id: taskId,
+    manifest_sha256: task.identities.manifest,
+    fixture_sha256: task.identities.fixture,
+    acceptance_contract_sha256: task.identities.acceptance,
+    adapter_sha256: adapter.sha256,
+    workspace_policy: WORKSPACE_POLICY,
+    environment,
+    filtered_input_bytes: filteredInputBytes,
+    estimated_input_tokens: estimatedInputTokens,
+    reserved_output_tokens: adapter.value.planning.reserved_output_tokens,
+    estimated_max_cost_usd: estimatedMaxCostUsd,
+    max_cost_usd: adapter.value.planning.max_cost_usd,
+    cost_posture: adapter.value.cost_posture,
+    within_cost_limit: withinCostLimit,
+    command: [...adapter.value.command],
+    approval: {
+      launch_required: true,
+      paid_required: adapter.value.cost_posture !== 'free',
+    },
+    blocked_reasons: blockedReasons,
+    limitations: [...PLAN_LIMITATIONS],
+  };
+  const plan = { ...draft, plan_id: deriveRunPlanId(draft) };
+  const errors = validateContract('run-plan', plan);
+  if (errors.length > 0) throw new Error(`invalid run plan:\n${errors.join('\n')}`);
+  return plan;
+}
+
+export async function executeAgentTask({
+  root = DEFAULT_CORPUS_ROOT,
+  taskId,
+  adapterPath,
+  environment = {},
+  approvePlanId,
+  approvePaid = false,
+  signal,
+  runAdapter = runAdapterProcess,
+  executeDriver = executeCheckDriver,
+  removeWorkspace = removeRunWorkspace,
+  temporaryRoot,
+  runIdFactory = () => `run-${randomUUID()}`,
+} = {}) {
+  const plan = await planAgentTask({
+    root,
+    taskId,
+    adapterPath,
+    availableEnvironmentNames: Object.keys(environment),
+  });
+  if (approvePlanId !== plan.plan_id) {
+    throw new Error(`launch approval must name current plan "${plan.plan_id}"`);
+  }
+  if (plan.approval.paid_required && approvePaid !== true) {
+    throw new Error('paid or unknown-cost adapter requires separate paid approval');
+  }
+  if (plan.blocked_reasons.length > 0) {
+    throw new Error(`execution is blocked: ${plan.blocked_reasons.join(', ')}`);
+  }
+
+  const task = await loadTaskPackage(root, taskId);
+  const adapter = await loadAgentAdapter(adapterPath);
+  const declaredEnvironment = {};
+  for (const name of adapter.value.environment_names) {
+    if (typeof environment[name] !== 'string') {
+      throw new Error(`declared environment value is unavailable: ${name}`);
+    }
+    declaredEnvironment[name] = environment[name];
+  }
+  const environmentIdentity = adapter.value.environment_names.map((name) => ({
+    name,
+    value_sha256: sha256Bytes(Buffer.from(declaredEnvironment[name])),
+  }));
+  const environmentSha256 = sha256Bytes(Buffer.from(canonicalJson(environmentIdentity)));
+  const lifecycle = [];
+  let workspace = null;
+  let terminalStatus = 'setup_failure';
+  let checks = [];
+  let regressionCount = 0;
+  let agentResult = emptyAgentResult();
+  let operatorOutput = { stdout: '', stderr: '' };
+
+  try {
+    workspace = await materializeWorkspace(task.fixture, task.taskPacket, temporaryRoot);
+    lifecycle.push('workspace_prepared');
+    const command = resolveAdapterCommand(adapter, workspace);
+    const execution = await runAdapter({
+      command,
+      cwd: workspace,
+      environment: declaredEnvironment,
+      timeoutMs: adapter.value.timeout_ms,
+      signal,
+      onStarted: () => lifecycle.push('agent_started'),
+    });
+    const normalized = normalizeAgentOutput(execution, Object.values(declaredEnvironment));
+    agentResult = normalized.agent;
+    operatorOutput = normalized.output;
+    if (agentResult.status !== 'not_started') lifecycle.push('agent_terminated');
+
+    if (agentResult.status === 'timeout') {
+      terminalStatus = 'timeout';
+    } else if (agentResult.status === 'cancelled') {
+      terminalStatus = 'cancelled';
+    } else if (agentResult.status !== 'exited' || agentResult.exit_code !== 0) {
+      terminalStatus = 'agent_failure';
+    } else {
+      lifecycle.push('checks_started');
+      const checkExecution = await executeDriver({
+        driverPath: task.driverPath,
+        workspace,
+        taskId,
+        acceptanceSha256: task.identities.acceptance,
+        phase: 'agent_run',
+        attempt: 1,
+        timeoutMs: task.acceptance.driver.timeout_ms,
+      });
+      if (checkExecution.kind === 'result') {
+        checks = checkExecution.result.results;
+        terminalStatus = classifyRunChecks(checks, task.acceptance);
+        regressionCount = task.acceptance.regression_checks.filter(
+          (check) => checks.find((result) => result.id === check.id)?.status === 'fail'
+        ).length;
+      } else {
+        terminalStatus = checkExecution.kind === 'timeout' ? 'timeout' : 'check_error';
+      }
+      lifecycle.push('checks_finished');
+    }
+  } catch (error) {
+    if (error?.code === 'CODEVETTER_CLEANUP_FAILURE') {
+      terminalStatus = 'cleanup_failure';
+      lifecycle.push('cleanup_failed');
+    } else {
+      terminalStatus = lifecycle.includes('checks_started')
+        ? 'check_error'
+        : lifecycle.includes('agent_started')
+          ? 'agent_failure'
+          : 'setup_failure';
+    }
+  } finally {
+    if (workspace !== null) {
+      try {
+        await removeWorkspace(workspace);
+        lifecycle.push('cleanup_complete');
+      } catch {
+        lifecycle.push('cleanup_failed');
+        terminalStatus = 'cleanup_failure';
+      }
+    }
+  }
+
+  const receipt = {
+    schema_version: CONTRACT_SCHEMA_VERSIONS['run-receipt-v2'],
+    run_id: runIdFactory(),
+    plan_id: plan.plan_id,
+    task_id: taskId,
+    manifest_sha256: task.identities.manifest,
+    fixture_sha256: task.identities.fixture,
+    acceptance_contract_sha256: task.identities.acceptance,
+    adapter_sha256: adapter.sha256,
+    environment_sha256: environmentSha256,
+    workspace_policy: WORKSPACE_POLICY,
+    terminal_status: terminalStatus,
+    lifecycle,
+    agent: agentResult,
+    checks,
+    regression_count: regressionCount,
+    cleanup: { status: lifecycle.includes('cleanup_failed') ? 'failed' : 'complete' },
+    limitations: [...RUN_LIMITATIONS],
+  };
+  const errors = validateContract('run-receipt', receipt);
+  if (errors.length > 0)
+    throw new Error(`runner produced an invalid receipt:\n${errors.join('\n')}`);
+  return { plan, receipt, output: operatorOutput };
+}
+
+export async function writeRunReceipt(path, receipt) {
+  const destination = resolve(path);
+  await mkdir(dirname(destination), { recursive: true });
+  const temporary = `${destination}.tmp-${process.pid}`;
+  await writeFile(temporary, `${JSON.stringify(receipt, null, 2)}\n`, { flag: 'wx' });
+  await rename(temporary, destination);
+}
+
+export async function loadAgentAdapter(adapterPath) {
+  if (typeof adapterPath !== 'string' || adapterPath.length === 0) {
+    throw new Error('adapterPath is required');
+  }
+  const declared = resolve(adapterPath);
+  const path = resolveArtifact(
+    dirname(declared),
+    basename(declared),
+    CORPUS_LIMITS.maxDocumentBytes
+  );
+  const bytes = await readFile(path);
+  const value = JSON.parse(bytes.toString('utf8'));
+  const errors = validateContract('agent-adapter', value);
+  if (errors.length > 0) throw new Error(`invalid agent adapter:\n${errors.join('\n')}`);
+  if (value.schema_version !== CONTRACT_SCHEMA_VERSIONS['agent-adapter-v2']) {
+    throw new Error('execution requires a v2 agent adapter');
+  }
+  const root = dirname(path);
+  for (const artifact of value.artifacts) {
+    const artifactPath = resolveArtifact(root, artifact.path, CORPUS_LIMITS.maxArtifactBytes);
+    const artifactBytes = await readFile(artifactPath);
+    if (sha256Bytes(artifactBytes) !== artifact.sha256) {
+      throw new Error(`adapter artifact SHA-256 mismatch: ${artifact.path}`);
+    }
+  }
+  return { value, path, root, sha256: sha256Bytes(bytes) };
+}
+
+export async function runAdapterProcess({
+  command,
+  cwd,
+  environment,
+  timeoutMs,
+  signal,
+  onStarted,
+}) {
+  return new Promise((resolvePromise) => {
+    const child = spawn(command[0], command.slice(1), {
+      cwd,
+      detached: process.platform !== 'win32',
+      env: environment,
+      shell: false,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+    });
+    onStarted?.();
+    const stdout = [];
+    const stderr = [];
+    let stdoutBytes = 0;
+    let stderrBytes = 0;
+    let truncated = false;
+    let requestedStatus = null;
+    let settled = false;
+    let escalation = null;
+
+    const capture = (chunks, currentBytes, chunk) => {
+      const remaining = MAX_OUTPUT_BYTES - currentBytes;
+      if (remaining <= 0) {
+        truncated = true;
+        return currentBytes;
+      }
+      chunks.push(chunk.subarray(0, remaining));
+      if (chunk.length > remaining) truncated = true;
+      return currentBytes + Math.min(chunk.length, remaining);
+    };
+    child.stdout.on('data', (chunk) => {
+      stdoutBytes = capture(stdout, stdoutBytes, chunk);
+    });
+    child.stderr.on('data', (chunk) => {
+      stderrBytes = capture(stderr, stderrBytes, chunk);
+    });
+
+    const terminate = (status) => {
+      if (requestedStatus !== null) return;
+      requestedStatus = status;
+      terminateProcessGroup(child, 'SIGTERM');
+      escalation = setTimeout(() => terminateProcessGroup(child, 'SIGKILL'), 250);
+      escalation.unref?.();
+    };
+    const timer = setTimeout(() => terminate('timeout'), timeoutMs);
+    timer.unref?.();
+    const abort = () => terminate('cancelled');
+    signal?.addEventListener('abort', abort, { once: true });
+    if (signal?.aborted) abort();
+
+    const finish = (code, spawnError = false) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (requestedStatus !== null) terminateProcessGroup(child, 'SIGKILL');
+      if (escalation) clearTimeout(escalation);
+      signal?.removeEventListener('abort', abort);
+      const status = requestedStatus ?? (spawnError || code !== 0 ? 'failed' : 'exited');
+      resolvePromise({
+        status,
+        exitCode: status === 'exited' || status === 'failed' ? code : null,
+        stdout: Buffer.concat(stdout).toString('utf8'),
+        stderr: Buffer.concat(stderr).toString('utf8'),
+        truncated,
+      });
+    };
+    child.once('error', () => finish(null, true));
+    child.once('close', (code) => finish(code));
+  });
+}
+
+function resolveAdapterCommand(adapter, workspace) {
+  const replacements = new Map([
+    ['{node}', process.execPath],
+    ['{adapter_root}', adapter.root],
+    ['{workspace}', workspace],
+    ['{task_packet}', join(workspace, 'TASK.md')],
+  ]);
+  return adapter.value.command.map((argument) => {
+    let resolved = argument;
+    for (const [placeholder, value] of replacements) {
+      resolved = resolved.split(placeholder).join(value);
+    }
+    if (/\{[^}]+\}/.test(resolved)) throw new Error(`unresolved command placeholder: ${argument}`);
+    return resolved;
+  });
+}
+
+function normalizeAgentOutput(execution, secretValues) {
+  const stdout = boundText(redactText(execution.stdout ?? '', secretValues));
+  const stderr = boundText(redactText(execution.stderr ?? '', secretValues));
+  const outputTruncated = Boolean(execution.truncated) || stdout.truncated || stderr.truncated;
+  const status = ['exited', 'failed', 'cancelled', 'timeout', 'not_started'].includes(
+    execution.status
+  )
+    ? execution.status
+    : 'failed';
+  const exitCode =
+    (status === 'exited' || status === 'failed') && Number.isInteger(execution.exitCode)
+      ? execution.exitCode
+      : null;
+  return {
+    agent: {
+      status,
+      exit_code: exitCode,
+      stdout_sha256: sha256Bytes(Buffer.from(stdout.text)),
+      stderr_sha256: sha256Bytes(Buffer.from(stderr.text)),
+      stdout_bytes: Buffer.byteLength(stdout.text),
+      stderr_bytes: Buffer.byteLength(stderr.text),
+      output_truncated: outputTruncated,
+    },
+    output: { stdout: stdout.text, stderr: stderr.text },
+  };
+}
+
+function redactText(value, secretValues) {
+  let redacted = String(value).replace(
+    /\b([A-Z][A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|API_KEY)[A-Z0-9_]*)=([^\s]+)/gi,
+    '$1=[REDACTED]'
+  );
+  for (const secret of secretValues.filter((item) => typeof item === 'string' && item.length > 0)) {
+    redacted = redacted.split(secret).join('[REDACTED]');
+  }
+  return redacted;
+}
+
+function boundText(value) {
+  const bytes = Buffer.from(value);
+  if (bytes.length <= MAX_OUTPUT_BYTES) return { text: value, truncated: false };
+  let text = bytes.subarray(0, MAX_OUTPUT_BYTES).toString('utf8');
+  while (Buffer.byteLength(text) > MAX_OUTPUT_BYTES) text = text.slice(0, -1);
+  return {
+    text,
+    truncated: true,
+  };
+}
+
+function emptyAgentResult() {
+  return {
+    status: 'not_started',
+    exit_code: null,
+    stdout_sha256: EMPTY_SHA256,
+    stderr_sha256: EMPTY_SHA256,
+    stdout_bytes: 0,
+    stderr_bytes: 0,
+    output_truncated: false,
+  };
+}
+
+function classifyRunChecks(results, acceptance) {
+  const required = acceptance.required_checks.map((check) => check.id);
+  const regression = acceptance.regression_checks.map((check) => check.id);
+  const expected = [...required, ...regression].sort();
+  const actual = results.map((check) => check.id).sort();
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) return 'incomplete_checks';
+  const byId = new Map(results.map((check) => [check.id, check.status]));
+  if (results.some((check) => check.status === 'error')) return 'check_error';
+  if (regression.some((id) => byId.get(id) !== 'pass')) return 'regression';
+  if (required.some((id) => byId.get(id) !== 'pass')) return 'check_failure';
+  return 'success';
+}
+
+function terminateProcessGroup(child, signal) {
+  try {
+    if (process.platform !== 'win32' && child.pid) {
+      process.kill(-child.pid, signal);
+    } else {
+      child.kill(signal);
+    }
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      // The process already reached a terminal state.
+    }
+  }
+}
+
+async function removeRunWorkspace(workspace) {
+  await rm(workspace, { force: true, recursive: true });
+}
+
+function roundCostUp(value) {
+  return Math.ceil(value * 1_000_000) / 1_000_000;
+}

--- a/scripts/agent-task-corpus/run-task.test.mjs
+++ b/scripts/agent-task-corpus/run-task.test.mjs
@@ -1,0 +1,393 @@
+import assert from 'node:assert/strict';
+import { cp, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import test from 'node:test';
+
+import { sha256Bytes } from './contracts.mjs';
+import { runAgentTaskCli } from './run-cli.mjs';
+import { executeAgentTask, planAgentTask, runAdapterProcess } from './run-task.mjs';
+
+const SAMPLE_ROOT = resolve('benchmarks/agent-tasks/sample');
+const ADAPTER_PATH = resolve('benchmarks/agent-tasks/sample/adapters/synthetic-false-fix.json');
+const TASK_ID = 'preserve-explicit-false';
+const ENVIRONMENT = { FIXTURE_TOKEN: 'synthetic-secret' };
+
+async function copyAdapter(t, mutate) {
+  const directory = await mkdtemp(join(tmpdir(), 'codevetter-runner-adapter-'));
+  t.after(() => rm(directory, { force: true, recursive: true }));
+  await cp(resolve('benchmarks/agent-tasks/sample/adapters'), directory, { recursive: true });
+  const path = join(directory, 'synthetic-false-fix.json');
+  const value = JSON.parse(await readFile(path, 'utf8'));
+  mutate(value);
+  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`);
+  return path;
+}
+
+function passingChecks(acceptanceSha256) {
+  return {
+    kind: 'result',
+    result: {
+      schema_version: 'codevetter.agent-task-check-result.v1',
+      task_id: TASK_ID,
+      acceptance_contract_sha256: acceptanceSha256,
+      results: [
+        { id: 'explicit-false-preserved', status: 'pass' },
+        { id: 'label-preserved', status: 'pass' },
+        { id: 'public-inputs-only', status: 'pass' },
+      ],
+    },
+  };
+}
+
+test('creates a deterministic non-executing plan with conservative bounds', async () => {
+  const options = {
+    root: SAMPLE_ROOT,
+    taskId: TASK_ID,
+    adapterPath: ADAPTER_PATH,
+    availableEnvironmentNames: ['FIXTURE_TOKEN'],
+  };
+  const first = await planAgentTask(options);
+  const second = await planAgentTask(options);
+
+  assert.deepEqual(second, first);
+  assert.match(first.plan_id, /^plan-[a-f0-9]{32}$/);
+  assert.equal(first.filtered_input_bytes, 434);
+  assert.equal(first.estimated_input_tokens, 173);
+  assert.equal(first.estimated_max_cost_usd, 0);
+  assert.equal(first.approval.launch_required, true);
+  assert.equal(first.approval.paid_required, false);
+  assert.deepEqual(first.blocked_reasons, []);
+  assert.deepEqual(first.command, [
+    '{node}',
+    '{adapter_root}/synthetic-false-fix.mjs',
+    '{workspace}',
+  ]);
+});
+
+test('blocks missing environment, stale approval, paid approval, and cost overflow', async (t) => {
+  const missing = await planAgentTask({
+    root: SAMPLE_ROOT,
+    taskId: TASK_ID,
+    adapterPath: ADAPTER_PATH,
+  });
+  assert.deepEqual(missing.blocked_reasons, ['missing-environment:FIXTURE_TOKEN']);
+
+  const current = await planAgentTask({
+    root: SAMPLE_ROOT,
+    taskId: TASK_ID,
+    adapterPath: ADAPTER_PATH,
+    availableEnvironmentNames: ['FIXTURE_TOKEN'],
+  });
+  await assert.rejects(
+    executeAgentTask({
+      root: SAMPLE_ROOT,
+      taskId: TASK_ID,
+      adapterPath: ADAPTER_PATH,
+      environment: ENVIRONMENT,
+      approvePlanId: 'plan-stale',
+    }),
+    /launch approval must name current plan/
+  );
+
+  const paidPath = await copyAdapter(t, (adapter) => {
+    adapter.cost_posture = 'paid';
+    adapter.planning.input_usd_per_million = 1;
+    adapter.planning.output_usd_per_million = 1;
+    adapter.planning.max_cost_usd = 1;
+  });
+  const paid = await planAgentTask({
+    root: SAMPLE_ROOT,
+    taskId: TASK_ID,
+    adapterPath: paidPath,
+    availableEnvironmentNames: ['FIXTURE_TOKEN'],
+  });
+  assert.equal(paid.approval.paid_required, true);
+  await assert.rejects(
+    executeAgentTask({
+      root: SAMPLE_ROOT,
+      taskId: TASK_ID,
+      adapterPath: paidPath,
+      environment: ENVIRONMENT,
+      approvePlanId: paid.plan_id,
+    }),
+    /separate paid approval/
+  );
+
+  const overCostPath = await copyAdapter(t, (adapter) => {
+    adapter.cost_posture = 'paid';
+    adapter.planning.input_usd_per_million = 100_000;
+    adapter.planning.output_usd_per_million = 100_000;
+    adapter.planning.max_cost_usd = 0;
+  });
+  const overCost = await planAgentTask({
+    root: SAMPLE_ROOT,
+    taskId: TASK_ID,
+    adapterPath: overCostPath,
+    availableEnvironmentNames: ['FIXTURE_TOKEN'],
+  });
+  assert.equal(overCost.within_cost_limit, false);
+  assert.deepEqual(overCost.blocked_reasons, ['cost-limit-exceeded']);
+  await assert.rejects(
+    executeAgentTask({
+      root: SAMPLE_ROOT,
+      taskId: TASK_ID,
+      adapterPath: overCostPath,
+      environment: ENVIRONMENT,
+      approvePlanId: overCost.plan_id,
+      approvePaid: true,
+    }),
+    /execution is blocked: cost-limit-exceeded/
+  );
+  assert.equal(current.blocked_reasons.length, 0);
+});
+
+test('runs the immutable synthetic adapter before hidden checks and redacts output', async () => {
+  const plan = await planAgentTask({
+    root: SAMPLE_ROOT,
+    taskId: TASK_ID,
+    adapterPath: ADAPTER_PATH,
+    availableEnvironmentNames: ['FIXTURE_TOKEN'],
+  });
+  const result = await executeAgentTask({
+    root: SAMPLE_ROOT,
+    taskId: TASK_ID,
+    adapterPath: ADAPTER_PATH,
+    environment: ENVIRONMENT,
+    approvePlanId: plan.plan_id,
+    runIdFactory: () => 'run-synthetic-success',
+  });
+
+  assert.equal(result.receipt.terminal_status, 'success');
+  assert.deepEqual(result.receipt.lifecycle, [
+    'workspace_prepared',
+    'agent_started',
+    'agent_terminated',
+    'checks_started',
+    'checks_finished',
+    'cleanup_complete',
+  ]);
+  assert.equal(result.receipt.agent.status, 'exited');
+  assert.equal(result.receipt.agent.exit_code, 0);
+  assert.equal(result.receipt.regression_count, 0);
+  assert.ok(result.receipt.checks.every((check) => check.status === 'pass'));
+  assert.match(result.output.stdout, /FIXTURE_TOKEN=\[REDACTED\]/);
+  assert.doesNotMatch(result.output.stdout, /synthetic-secret/);
+  assert.doesNotMatch(JSON.stringify(result.receipt), /synthetic-secret|codevetter-agent-task-/);
+});
+
+test('skips hidden checks after failure or timeout and preserves cleanup', async () => {
+  const plan = await planAgentTask({
+    root: SAMPLE_ROOT,
+    taskId: TASK_ID,
+    adapterPath: ADAPTER_PATH,
+    availableEnvironmentNames: ['FIXTURE_TOKEN'],
+  });
+  for (const [status, expected] of [
+    ['failed', 'agent_failure'],
+    ['timeout', 'timeout'],
+    ['cancelled', 'cancelled'],
+  ]) {
+    let checksStarted = false;
+    const result = await executeAgentTask({
+      root: SAMPLE_ROOT,
+      taskId: TASK_ID,
+      adapterPath: ADAPTER_PATH,
+      environment: ENVIRONMENT,
+      approvePlanId: plan.plan_id,
+      runAdapter: async ({ onStarted }) => {
+        onStarted();
+        return {
+          status,
+          exitCode: status === 'failed' ? 2 : null,
+          stdout: '',
+          stderr: '',
+          truncated: false,
+        };
+      },
+      executeDriver: async () => {
+        checksStarted = true;
+        return passingChecks('a'.repeat(64));
+      },
+      runIdFactory: () => `run-${status}`,
+    });
+    assert.equal(result.receipt.terminal_status, expected);
+    assert.equal(checksStarted, false);
+    assert.equal(result.receipt.cleanup.status, 'complete');
+    assert.equal(result.receipt.lifecycle.includes('checks_started'), false);
+  }
+});
+
+test('starts exact checks only after termination and classifies regression', async () => {
+  const plan = await planAgentTask({
+    root: SAMPLE_ROOT,
+    taskId: TASK_ID,
+    adapterPath: ADAPTER_PATH,
+    availableEnvironmentNames: ['FIXTURE_TOKEN'],
+  });
+  let terminated = false;
+  const result = await executeAgentTask({
+    root: SAMPLE_ROOT,
+    taskId: TASK_ID,
+    adapterPath: ADAPTER_PATH,
+    environment: ENVIRONMENT,
+    approvePlanId: plan.plan_id,
+    runAdapter: async ({ onStarted }) => {
+      onStarted();
+      terminated = true;
+      return { status: 'exited', exitCode: 0, stdout: '', stderr: '', truncated: false };
+    },
+    executeDriver: async ({ acceptanceSha256 }) => {
+      assert.equal(terminated, true);
+      const evidence = passingChecks(acceptanceSha256);
+      evidence.result.results[1].status = 'fail';
+      return evidence;
+    },
+    runIdFactory: () => 'run-regression',
+  });
+
+  assert.equal(result.receipt.terminal_status, 'regression');
+  assert.equal(result.receipt.regression_count, 1);
+  assert.ok(
+    result.receipt.lifecycle.indexOf('agent_terminated') <
+      result.receipt.lifecycle.indexOf('checks_started')
+  );
+});
+
+test('classifies incomplete checks, required failures, and check errors distinctly', async () => {
+  const plan = await planAgentTask({
+    root: SAMPLE_ROOT,
+    taskId: TASK_ID,
+    adapterPath: ADAPTER_PATH,
+    availableEnvironmentNames: ['FIXTURE_TOKEN'],
+  });
+  const cases = [
+    [
+      'incomplete_checks',
+      async ({ acceptanceSha256 }) => {
+        const evidence = passingChecks(acceptanceSha256);
+        evidence.result.results.pop();
+        return evidence;
+      },
+    ],
+    [
+      'check_failure',
+      async ({ acceptanceSha256 }) => {
+        const evidence = passingChecks(acceptanceSha256);
+        evidence.result.results[0].status = 'fail';
+        return evidence;
+      },
+    ],
+    [
+      'check_error',
+      async () => {
+        throw new Error('injected check-driver failure');
+      },
+    ],
+  ];
+  for (const [expected, executeDriver] of cases) {
+    const result = await executeAgentTask({
+      root: SAMPLE_ROOT,
+      taskId: TASK_ID,
+      adapterPath: ADAPTER_PATH,
+      environment: ENVIRONMENT,
+      approvePlanId: plan.plan_id,
+      runAdapter: async ({ onStarted }) => {
+        onStarted();
+        return { status: 'exited', exitCode: 0, stdout: '', stderr: '', truncated: false };
+      },
+      executeDriver,
+      runIdFactory: () => `run-${expected.replaceAll('_', '-')}`,
+    });
+    assert.equal(result.receipt.terminal_status, expected);
+  }
+});
+
+test('bounds redacted output and preserves cleanup failure', async () => {
+  const plan = await planAgentTask({
+    root: SAMPLE_ROOT,
+    taskId: TASK_ID,
+    adapterPath: ADAPTER_PATH,
+    availableEnvironmentNames: ['FIXTURE_TOKEN'],
+  });
+  const result = await executeAgentTask({
+    root: SAMPLE_ROOT,
+    taskId: TASK_ID,
+    adapterPath: ADAPTER_PATH,
+    environment: ENVIRONMENT,
+    approvePlanId: plan.plan_id,
+    runAdapter: async ({ onStarted }) => {
+      onStarted();
+      return {
+        status: 'exited',
+        exitCode: 0,
+        stdout: `FIXTURE_TOKEN=synthetic-secret\n${'x'.repeat(300_000)}`,
+        stderr: '',
+        truncated: false,
+      };
+    },
+    executeDriver: async ({ acceptanceSha256 }) => passingChecks(acceptanceSha256),
+    removeWorkspace: async (workspace) => {
+      await rm(workspace, { force: true, recursive: true });
+      throw new Error('injected cleanup failure');
+    },
+    runIdFactory: () => 'run-cleanup-failure',
+  });
+
+  assert.equal(result.receipt.terminal_status, 'cleanup_failure');
+  assert.equal(result.receipt.cleanup.status, 'failed');
+  assert.equal(result.receipt.agent.output_truncated, true);
+  assert.ok(result.receipt.agent.stdout_bytes <= 262_144);
+  assert.doesNotMatch(result.output.stdout, /synthetic-secret/);
+});
+
+test('terminates a real adapter process on timeout and cancellation', async (t) => {
+  const directory = await mkdtemp(join(tmpdir(), 'codevetter-runner-process-'));
+  t.after(() => rm(directory, { force: true, recursive: true }));
+  const script = join(directory, 'slow.mjs');
+  await writeFile(script, 'setInterval(() => {}, 1000);\n');
+  const command = [process.execPath, script];
+
+  const timeout = await runAdapterProcess({
+    command,
+    cwd: directory,
+    environment: {},
+    timeoutMs: 20,
+  });
+  assert.equal(timeout.status, 'timeout');
+
+  const controller = new AbortController();
+  setTimeout(() => controller.abort(), 20);
+  const cancelled = await runAdapterProcess({
+    command,
+    cwd: directory,
+    environment: {},
+    timeoutMs: 5_000,
+    signal: controller.signal,
+  });
+  assert.equal(cancelled.status, 'cancelled');
+  assert.equal(sha256Bytes(Buffer.from(cancelled.stdout)), sha256Bytes(Buffer.alloc(0)));
+});
+
+test('CLI plans first and executes only with the exact explicit approval', async (t) => {
+  const previous = process.env.FIXTURE_TOKEN;
+  process.env.FIXTURE_TOKEN = 'cli-synthetic-secret';
+  t.after(() => {
+    if (previous === undefined) delete process.env.FIXTURE_TOKEN;
+    else process.env.FIXTURE_TOKEN = previous;
+  });
+  const common = ['--root', SAMPLE_ROOT, '--task', TASK_ID, '--adapter', ADAPTER_PATH, '--json'];
+  const planned = await runAgentTaskCli(common);
+  assert.equal(planned.exitCode, 0);
+  const plan = JSON.parse(planned.output);
+
+  const rejected = await runAgentTaskCli([...common, '--execute']);
+  assert.equal(rejected.exitCode, 2);
+  assert.match(JSON.parse(rejected.output).error, /launch approval/);
+
+  const executed = await runAgentTaskCli([...common, '--execute', '--approve-plan', plan.plan_id]);
+  assert.equal(executed.exitCode, 0);
+  const result = JSON.parse(executed.output);
+  assert.equal(result.receipt.terminal_status, 'success');
+  assert.doesNotMatch(JSON.stringify(result), /cli-synthetic-secret/);
+});


### PR DESCRIPTION
## Summary

- add v2 immutable adapter, deterministic run-plan, and lifecycle run-receipt contracts while preserving v1 readers
- add non-executing input/token/cost planning with environment-name availability and exact one-attempt approval
- add shell-free disposable adapter execution with process-group timeout/cancellation, bounded redacted output, and cleanup evidence
- run withheld checks only after clean agent termination and preserve exact failure/regression taxonomy
- prove the path with a repository-owned offline synthetic adapter; no real provider or model is invoked
- sync and archive the OpenSpec change

## Validation

- pnpm run test:corpus-contracts (28 tests)
- pnpm run test:automation
- synthetic plan and explicitly approved execution CLI paths
- pnpm run corpus:validate --json
- pnpm run lint
- node scripts/check-docs.mjs
- workflow YAML parse
- openspec validate --all --strict (40 specs)
- git diff --check
- pnpm run corpus:readiness --json exits 1 as expected: corpus breadth gates remain closed

No real provider, model, paid run, network request, evaluator projection, deploy, migration, release, or production path runs in this slice.

Refs #53