### PR TITLE
feat: compose agent task receipts for evaluation

### DIFF
--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -38,6 +38,16 @@ Internal (fleet):
 
 ## Timeline
 
+- **2026-07-31 — Immutable receipt-to-evaluator composition:** added a closed
+  local evaluation bundle that binds corpus, task revision, adapter, raw v2
+  receipt, pair/order, and structural-context identities. A dependency-free
+  composer now derives evaluator manifests from those artifacts, rejects
+  incomplete or contaminated evidence before export, preserves the existing
+  structural-context scorer as sole outcome/qualification authority, and emits
+  a separate deterministic score stamped with scorer, bundle, corpus,
+  ground-truth, projection, and receipt hashes. Synthetic tests prove
+  byte-stable rescoring and raw-receipt immutability; no real provider, model,
+  paid run, network, publish, deploy, or production path ran.
 - **2026-07-31 — Provider-neutral agent-task runner foundation:** added
   deterministic non-executing plans with public-input size, conservative token
   and cost bounds, environment-name availability, exact task/adapter identity,
@@ -46,8 +56,8 @@ Internal (fleet):
   declared environment, bounded redacted output, process-group
   timeout/cancellation, terminal-before-check ordering, and v2 lifecycle
   receipts. A repository-owned synthetic adapter passes the qualified sample;
-  no real provider, model, paid run, network, evaluator projection, deploy, or
-  production path ran in this slice.
+  no real provider, model, paid run, network, deploy, or production path ran in
+  this slice.
 - **2026-07-31 — Agent-task corpus qualification foundation:** added closed,
   versioned fixture, acceptance, exact known-good, check-result, qualification,
   adapter, and runner contracts plus deterministic dependency-free validation.

--- a/benchmarks/agent-tasks/contracts/evaluation-bundle.schema.json
+++ b/benchmarks/agent-tasks/contracts/evaluation-bundle.schema.json
@@ -1,0 +1,136 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://codevetter.com/schemas/agent-task/evaluation-bundle.json",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "experiment", "corpus", "tasks", "runs"],
+  "properties": {
+    "schema_version": { "const": "codevetter.agent-task-evaluation-bundle.v1" },
+    "experiment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "title", "evidence_kind", "qualification_policy", "limitations"],
+      "properties": {
+        "id": { "$ref": "./common.schema.json#/$defs/id" },
+        "title": { "type": "string", "minLength": 1, "maxLength": 160 },
+        "evidence_kind": { "enum": ["synthetic", "real"] },
+        "qualification_policy": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "minimum_complete_pairs",
+            "minimum_distinct_tasks",
+            "minimum_aa_pairs",
+            "minimum_success_rate_delta",
+            "maximum_regression_delta",
+            "maximum_aa_discordance_rate"
+          ],
+          "properties": {
+            "minimum_complete_pairs": { "type": "integer", "minimum": 1, "maximum": 5000 },
+            "minimum_distinct_tasks": { "type": "integer", "minimum": 1, "maximum": 50 },
+            "minimum_aa_pairs": { "type": "integer", "minimum": 1, "maximum": 5000 },
+            "minimum_success_rate_delta": { "type": "number", "minimum": 0, "maximum": 1 },
+            "maximum_regression_delta": { "type": "integer", "minimum": 0, "maximum": 500000 },
+            "maximum_aa_discordance_rate": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1
+            }
+          }
+        },
+        "limitations": {
+          "type": "array",
+          "maxItems": 50,
+          "items": { "type": "string", "minLength": 1, "maxLength": 500 }
+        }
+      }
+    },
+    "corpus": { "$ref": "./common.schema.json#/$defs/artifact" },
+    "tasks": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 50,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["task_id", "repository_revision"],
+        "properties": {
+          "task_id": { "$ref": "./common.schema.json#/$defs/id" },
+          "repository_revision": {
+            "type": "string",
+            "pattern": "^(?:[a-f0-9]{40}|[a-f0-9]{64})$"
+          }
+        }
+      }
+    },
+    "runs": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 5000,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "pair_id",
+          "comparison",
+          "arm",
+          "task_id",
+          "trial_index",
+          "execution_order",
+          "receipt",
+          "adapter",
+          "context"
+        ],
+        "properties": {
+          "pair_id": { "$ref": "./common.schema.json#/$defs/id" },
+          "comparison": { "enum": ["ab", "aa"] },
+          "arm": { "enum": ["control", "treatment", "a", "b"] },
+          "task_id": { "$ref": "./common.schema.json#/$defs/id" },
+          "trial_index": { "type": "integer", "minimum": 1, "maximum": 10000 },
+          "execution_order": { "enum": [1, 2] },
+          "receipt": { "$ref": "./common.schema.json#/$defs/artifact" },
+          "adapter": { "$ref": "./common.schema.json#/$defs/artifact" },
+          "context": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "structural_context_enabled",
+              "policy_identity",
+              "graph",
+              "allowed_graph_tools"
+            ],
+            "properties": {
+              "structural_context_enabled": { "type": "boolean" },
+              "policy_identity": { "$ref": "./common.schema.json#/$defs/id" },
+              "graph": {
+                "oneOf": [
+                  { "type": "null" },
+                  {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": ["engine_id", "engine_version", "snapshot_id", "indexed_revision"],
+                    "properties": {
+                      "engine_id": { "$ref": "./common.schema.json#/$defs/id" },
+                      "engine_version": { "type": "string", "minLength": 1, "maxLength": 80 },
+                      "snapshot_id": { "$ref": "./common.schema.json#/$defs/id" },
+                      "indexed_revision": {
+                        "type": "string",
+                        "pattern": "^(?:[a-f0-9]{40}|[a-f0-9]{64})$"
+                      }
+                    }
+                  }
+                ]
+              },
+              "allowed_graph_tools": {
+                "type": "array",
+                "maxItems": 100,
+                "uniqueItems": true,
+                "items": { "type": "string", "minLength": 1, "maxLength": 200 }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/benchmarks/agent-tasks/contracts/evaluation-score.schema.json
+++ b/benchmarks/agent-tasks/contracts/evaluation-score.schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://codevetter.com/schemas/agent-task/evaluation-score.json",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "score_id", "scorer", "evidence", "scorecard"],
+  "properties": {
+    "schema_version": { "const": "codevetter.agent-task-evaluation-score.v1" },
+    "score_id": { "$ref": "./common.schema.json#/$defs/id" },
+    "scorer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["version", "sha256"],
+      "properties": {
+        "version": { "type": "string", "minLength": 1, "maxLength": 80 },
+        "sha256": { "$ref": "./common.schema.json#/$defs/sha256" }
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "bundle_sha256",
+        "corpus_sha256",
+        "ground_truth_sha256",
+        "projected_manifest_sha256",
+        "receipts"
+      ],
+      "properties": {
+        "bundle_sha256": { "$ref": "./common.schema.json#/$defs/sha256" },
+        "corpus_sha256": { "$ref": "./common.schema.json#/$defs/sha256" },
+        "ground_truth_sha256": { "$ref": "./common.schema.json#/$defs/sha256" },
+        "projected_manifest_sha256": { "$ref": "./common.schema.json#/$defs/sha256" },
+        "receipts": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 5000,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["path", "sha256", "run_id"],
+            "properties": {
+              "path": { "$ref": "./common.schema.json#/$defs/relativePath" },
+              "sha256": { "$ref": "./common.schema.json#/$defs/sha256" },
+              "run_id": { "$ref": "./common.schema.json#/$defs/id" }
+            }
+          }
+        }
+      }
+    },
+    "scorecard": { "type": "object" }
+  }
+}

--- a/benchmarks/structural-context/README.md
+++ b/benchmarks/structural-context/README.md
@@ -7,6 +7,12 @@ improve executable task outcomes?
 It scores already-produced receipts. It does not launch agents, call model
 providers, infer missing evidence, or replace the public catch-rate benchmark.
 
+New provider-neutral runner evidence should use `pnpm corpus:evaluate` with a
+closed evaluation bundle. That command validates and projects immutable v2
+receipts into this evaluator, then writes a separate score stamped with the
+exact scorer, corpus, ground-truth, projection, and receipt identities. Direct
+manifests remain supported for the original synthetic contract fixture.
+
 ## Run the synthetic contract fixture
 
 ```bash
@@ -74,6 +80,10 @@ means rather than treated as zero.
 7. Score the manifest and inspect invalid-pair reasons before interpreting
    descriptive outcomes.
 8. Treat a positive claim as qualified only when every predeclared gate passes.
+
+The receipt-composition path rejects invalid evidence before score export and
+can rescore the same raw receipts deterministically after a declared
+ground-truth update. It never edits or reruns those receipts.
 
 The HTML report is a local, self-contained reading surface. It uses no external
 assets, network requests, or required JavaScript, and adds no desktop route.

--- a/docs/development/agent-task-corpus.md
+++ b/docs/development/agent-task-corpus.md
@@ -167,6 +167,35 @@ output identities, exact checks, regression count, and cleanup. Optional
 provider diagnostics remain absent unless the adapter actually supplies them;
 the runner does not fabricate token, cost, tool, or file counts.
 
+## Receipt evaluation boundary
+
+`corpus:evaluate` composes already-produced v2 receipts into the existing
+structural-context scorer:
+
+```bash
+pnpm corpus:evaluate -- \
+  --bundle benchmarks/agent-tasks/evaluations/<experiment>/bundle.json \
+  --out artifacts/agent-task-score.json
+```
+
+The closed bundle identifies the corpus index, task revisions, adapter
+descriptors, raw receipts, pair arms/order, and graph-context policy with safe
+paths and exact SHA-256 values. The composer derives task titles, task-packet
+identity, acceptance inventory, agent/model labels, run outcomes, and available
+diagnostics from those immutable artifacts. It rejects hash drift, duplicate or
+incomplete pairs, common-identity drift, invalid order, missing checks after
+check execution, stale treatment graphs, control contamination, and mismatched
+A/A context before writing output.
+
+Raw receipts are never rewritten. The separate derived score names the scorer
+version and source hash, bundle hash, corpus hash, combined ground-truth hash,
+projected-manifest hash, and sorted raw receipt identities. Re-running the
+command with the same inputs produces the same score without launching an
+agent, executing hidden checks, calling a provider, or making a network
+request. Diagnostics absent from raw receipts remain absent. Pre-check
+setup/agent/timeout/cancellation failures project the immutable acceptance
+inventory as `skipped`, never as fabricated passes or failures.
+
 ## Authoring rules
 
 - Keep task IDs, category IDs, failure modes, and check IDs lowercase
@@ -197,11 +226,12 @@ not:
 - automatically launch an adapter from planning or validation;
 - read undeclared credentials or retain declared values in output/receipts;
 - make network requests;
-- project receipts into the structural-context evaluator; or
 - mutate corpus content.
 
-The repository-owned synthetic adapter proves lifecycle mechanics only; no real
-provider/model or paid adapter was run. Real provider proof and evaluator
-projection remain later slices on issue #53. The sample reports `1 qualified` and
-`publishable: false`; task count, browser-lane, TypeScript-runtime, and category
-breadth gates remain closed.
+Receipt evaluation is a separate read-only command and preserves the existing
+structural-context scorer as the only outcome and qualification authority. The
+repository-owned synthetic adapter and composition tests prove lifecycle and
+projection mechanics only; no real provider/model or paid adapter was run.
+Real provider evidence remains a later slice on issue #53. The sample reports
+`1 qualified` and `publishable: false`; task count, browser-lane,
+TypeScript-runtime, and category breadth gates remain closed.

--- a/docs/operations/ci.md
+++ b/docs/operations/ci.md
@@ -25,8 +25,8 @@ Steps, in order (a failure stops the job):
    `pnpm run test:corpus-contracts` at root (hermetic Foundry receipt
    sanitization plus agent-task contract, qualification, dry-run/approval,
    disposable runner, timeout/cancellation, output-redaction, cleanup, and
-   readiness tests; the live manifest verifier runs in `release.yml` as a
-   post-upload check, not here)
+   deterministic receipt-composition/rescoring tests; the live manifest
+   verifier runs in `release.yml` as a post-upload check, not here)
 10. **MCP sidecar build smoke** — `pnpm run prepare:mcp-sidecar`
 11. **CLI sidecar build smoke** — `pnpm run prepare:cli-sidecar`
 12. **CLI artifact qualification** — focused script tests plus

--- a/openspec/changes/archive/2026-07-31-compose-agent-task-receipts/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-31-compose-agent-task-receipts/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-31

--- a/openspec/changes/archive/2026-07-31-compose-agent-task-receipts/design.md
+++ b/openspec/changes/archive/2026-07-31-compose-agent-task-receipts/design.md
@@ -1,0 +1,106 @@
+## Context
+
+The v2 runner receipt already binds the task manifest, fixture, acceptance
+contract, adapter, environment, lifecycle, checks, output hashes, regressions,
+cleanup, limitations, and optional diagnostics. The structural-context scorer
+has the pairing and qualification rules needed for issue #53, but its input is
+currently a hand-authored monolithic manifest. See `proposal.md` for the
+motivation and the delta specs for observable behavior.
+
+The implementation must remain local, shell-free, bounded, dependency-free,
+and compatible with existing direct evaluator manifests.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make raw v2 receipts the authoritative source for run outcomes.
+- Keep experiment metadata and graph-context declarations explicit and
+  immutable without duplicating receipt-owned fields.
+- Reject invalid evidence before any score artifact is written.
+- Make score provenance sufficient for deterministic rescoring and audit.
+
+**Non-Goals:**
+
+- Launching real providers or generating new runner receipts.
+- Changing qualification thresholds or adding a second scorer.
+- Publishing a result, enforcing the workflow in CI, or adding UI.
+- Claiming the synthetic composition fixture is product evidence.
+
+## Decisions
+
+### Use a small composition bundle instead of extending raw receipts
+
+The bundle references the corpus root, adapter files, and raw receipts while
+declaring pair/arm/order and structural-context metadata. These are experiment
+facts that the provider-neutral runner cannot know at launch time. Keeping them
+outside the receipt preserves one runner format across experiments.
+
+Alternative: add comparison and graph fields to the runner receipt. Rejected
+because it couples task execution to one evaluator and would require agents to
+be launched with scorer-specific metadata.
+
+### Derive task and adapter fields from immutable artifacts
+
+Task titles, packets, acceptance checks, manifest identities, and agent/model
+labels are loaded from the validated corpus and adapter. The bundle declares
+only the repository revision and experiment-specific fields. This avoids
+hand-copying values that could drift.
+
+Alternative: duplicate a full evaluator task/run record in the bundle.
+Rejected because the duplicate could contradict the raw evidence while still
+looking structurally valid.
+
+### Compose first, then invoke the existing scorer
+
+The composer validates artifact hashes, projects one standard evaluator
+manifest, calls the existing manifest validator and scorer, and refuses export
+if the scorer reports invalid pairs. Missing required checks are rejected
+before scoring because issue #53 requires export to fail closed rather than
+merely classify the run as incomplete.
+
+Alternative: implement score calculations in the composer. Rejected because it
+would create competing outcome and qualification authority.
+
+### Hash canonical evidence and the actual scorer source
+
+The derived artifact records hashes of the bundle bytes, corpus index, sorted
+acceptance identities, projected manifest, raw receipt files, and scorer module
+bytes. A stable scorer version remains human-readable while the source hash
+captures exact implementation changes.
+
+Alternative: version strings alone. Rejected because a source change could
+silently alter results without a version bump.
+
+### Write only after all validation and scoring succeeds
+
+The CLI renders deterministic canonical JSON in memory, then uses an atomic
+temporary-file rename for `--out`. Raw receipts and bundle artifacts are never
+rewritten.
+
+Alternative: emit partial projection diagnostics on failure. Rejected for the
+primary output because partial files can be mistaken for valid scores; errors
+remain on stderr.
+
+## Risks / Trade-offs
+
+- [Scorer source hashing covers one module rather than its runtime] → Keep the
+  scorer dependency-free and stamp the explicit scorer version; changes to
+  composition or runtime still change bundle/projection outputs or repository
+  revision.
+- [Bundle metadata can lie about a graph snapshot] → Require exact repository
+  revision matching and fail closed on control contamination; cryptographic
+  attestation of external graph engines remains outside this slice.
+- [Pre-check failures do not contain hidden check results] → Project the
+  immutable acceptance inventory as `skipped` only when the lifecycle proves
+  checks never started; once checks start, any missing check rejects export.
+- [Direct evaluator manifests remain less strongly provenance-stamped] → Keep
+  backward compatibility, while recommending the receipt-composition CLI for
+  new runner evidence.
+
+## Migration Plan
+
+Additive only. Existing `bench:graph-context` inputs and reports continue to
+work. The new composer receives its own package script and schemas. Rollback is
+removal of the additive composer files and scripts; raw receipts remain valid
+and untouched.

--- a/openspec/changes/archive/2026-07-31-compose-agent-task-receipts/proposal.md
+++ b/openspec/changes/archive/2026-07-31-compose-agent-task-receipts/proposal.md
@@ -1,0 +1,44 @@
+## Why
+
+The agent-task runner now emits immutable provider-neutral receipts, but the
+existing structural-context evaluator still accepts a separate hand-authored
+manifest. A deterministic composition boundary is needed so real runner
+receipts can become evaluator evidence without copying outcomes, weakening the
+scorer, or mixing raw evidence with derived scores.
+
+## What Changes
+
+- Add a closed, versioned evaluation-bundle contract that references raw v2 run
+  receipts by safe path and exact SHA-256 identity.
+- Project complete paired receipts into the existing structural-context
+  evaluator manifest and reject incomplete, mismatched, stale, contaminated,
+  misordered, or missing-check evidence before export.
+- Emit a separate derived score artifact stamped with scorer version and
+  identity, bundle identity, ground-truth identity, projected-manifest identity,
+  and raw receipt identities.
+- Support deterministic local rescoring from the same immutable receipts
+  without launching an agent, executing checks, calling a provider, or mutating
+  the raw evidence.
+- Document the CLI workflow, trust boundary, limitations, and intentionally
+  synthetic test proof.
+
+## Capabilities
+
+### New Capabilities
+
+- `agent-task-receipt-evaluation`: Closed receipt composition, fail-closed
+  export, derived-score identity, and deterministic rescoring.
+
+### Modified Capabilities
+
+- `structural-context-agent-evaluation`: Accept projected provider-neutral
+  runner evidence while preserving the existing scorer as the sole outcome and
+  qualification authority.
+
+## Impact
+
+This affects the local agent-task corpus contracts and CLI, the
+structural-context evaluator module boundary, focused tests, benchmark
+documentation, package scripts, and `PROJECT_STATUS.md`. It adds no provider or
+production dependency, desktop route, hosted service, CI enforcement, agent
+launch, or network request.

--- a/openspec/changes/archive/2026-07-31-compose-agent-task-receipts/specs/agent-task-receipt-evaluation/spec.md
+++ b/openspec/changes/archive/2026-07-31-compose-agent-task-receipts/specs/agent-task-receipt-evaluation/spec.md
@@ -1,0 +1,77 @@
+## Purpose
+
+Compose immutable provider-neutral agent-task receipts into deterministic
+structural-context evaluation evidence without weakening scorer authority or
+mixing raw observations with derived conclusions.
+
+## ADDED Requirements
+
+### Requirement: Evaluation bundles are closed and identity-bound
+The system SHALL accept only a versioned closed evaluation bundle that names an
+immutable local corpus, task revisions, adapter artifacts, structural-context
+metadata, and raw v2 run receipts by safe relative path and exact SHA-256
+identity. It MUST reject unknown fields, unsafe paths, non-regular files,
+unsupported receipt or adapter versions, duplicate run identities, and any
+declared artifact whose bytes do not match its identity.
+
+#### Scenario: Every declared artifact is immutable
+- **WHEN** a valid local bundle references corpus, adapter, and receipt files whose bytes match their declared SHA-256 identities
+- **THEN** the system may load those artifacts for deterministic composition
+
+#### Scenario: A receipt changes after the bundle is declared
+- **WHEN** a referenced receipt no longer matches the bundle identity
+- **THEN** the system rejects the bundle before projecting or scoring evidence
+
+### Requirement: Receipt projection fails closed on invalid evidence
+The system SHALL project outcomes and available diagnostics from raw receipts
+without copying agent-visible ground truth into those receipts. It MUST reject
+export when a pair is incomplete or duplicated, task or common identities
+drift, execution order is invalid, required checks are missing, the treatment
+graph snapshot is stale, an A/B control is contaminated by structural context,
+or equivalent A/A arms use different context policies.
+
+#### Scenario: A complete isolated pair is supplied
+- **WHEN** both arms bind the same task, corpus, adapter, environment, trial, and ground-truth identities while satisfying their declared context policy
+- **THEN** the system projects the pair into the existing evaluator manifest
+
+#### Scenario: A required check is absent
+- **WHEN** either raw receipt completes a check-execution lifecycle but omits a check declared by the immutable acceptance contract
+- **THEN** the system refuses to export a derived score artifact
+
+#### Scenario: Agent terminates before checks
+- **WHEN** a setup, agent, timeout, or cancellation outcome correctly withholds hidden checks
+- **THEN** the projection records the immutable acceptance inventory as skipped while preserving the distinct terminal outcome
+
+#### Scenario: Control evidence is contaminated
+- **WHEN** an A/B control enables structural context, retains graph identity, or records a graph-tool call
+- **THEN** the system refuses to export the experiment
+
+### Requirement: Raw receipts and derived scores remain separate
+The system SHALL leave raw receipts byte-for-byte unchanged and SHALL emit any
+score as a separate bounded artifact. Every derived score MUST include a scorer
+version and SHA-256 identity, bundle identity, corpus identity, ground-truth
+identity, projected-manifest identity, and sorted raw receipt identities.
+Unavailable provider diagnostics MUST remain absent rather than being
+fabricated as zero values.
+
+#### Scenario: A score is derived from valid receipts
+- **WHEN** composition and the existing evaluator both succeed
+- **THEN** the derived artifact identifies the exact scorer, corpus, ground truth, projection, and raw receipt set used
+
+#### Scenario: Optional diagnostics were not captured
+- **WHEN** a raw receipt omits tokens, cost, tools, or file observations
+- **THEN** the projection and score omit those observations instead of inventing values
+
+### Requirement: Rescoring is deterministic and execution-free
+The system SHALL support repeated local scoring from the same bundle and raw
+receipts without launching an agent, executing acceptance checks, calling a
+model provider, making a network request, or mutating source artifacts.
+Equivalent inputs and scorer bytes MUST produce byte-equivalent derived JSON.
+
+#### Scenario: The same evidence is rescored
+- **WHEN** the same immutable bundle, receipts, corpus, ground truth, and scorer are supplied again
+- **THEN** the system emits the same derived score and identities without rerunning the agent
+
+#### Scenario: Ground truth is revised
+- **WHEN** an acceptance contract changes and its corpus and bundle identities are updated
+- **THEN** rescoring emits a different ground-truth and derived-score identity without claiming the original score applies

--- a/openspec/changes/archive/2026-07-31-compose-agent-task-receipts/specs/structural-context-agent-evaluation/spec.md
+++ b/openspec/changes/archive/2026-07-31-compose-agent-task-receipts/specs/structural-context-agent-evaluation/spec.md
@@ -1,0 +1,22 @@
+## MODIFIED Requirements
+
+### Requirement: Evaluation is local, deterministic, and provider-neutral
+The system SHALL read only explicitly supplied local manifests and receipts,
+produce deterministically ordered machine-readable JSON and Markdown from the
+same scorecard, and perform no model calls, network requests, repository
+mutation, checkout, hidden-test execution, or agent launch. When supplied
+projected provider-neutral runner evidence, it MUST derive outcomes only from
+validated receipts and MUST preserve the existing structural-context scorer as
+the sole outcome and qualification authority.
+
+#### Scenario: Synthetic fixture is scored
+- **WHEN** the checked-in hermetic fixture is passed to the evaluator
+- **THEN** repeated runs produce equivalent normalized results and state that the fixture cannot establish real product value
+
+#### Scenario: User has not supplied agent receipts
+- **WHEN** no real paired run receipts are present
+- **THEN** the evaluator performs no agent work and makes no claim that structural context improves outcomes
+
+#### Scenario: Runner receipts are projected
+- **WHEN** a validated receipt bundle is composed into an evaluator manifest
+- **THEN** the existing scorer applies the same pairing, outcome, isolation, and qualification rules used for a directly supplied manifest

--- a/openspec/changes/archive/2026-07-31-compose-agent-task-receipts/tasks.md
+++ b/openspec/changes/archive/2026-07-31-compose-agent-task-receipts/tasks.md
@@ -1,0 +1,18 @@
+## 1. Contracts
+
+- [x] 1.1 Add closed versioned schemas and semantic validators for evaluation bundles and derived score artifacts.
+- [x] 1.2 Extend the structural-context manifest validator only as needed to preserve runner terminal outcomes and Git revision identities.
+
+## 2. Composition
+
+- [x] 2.1 Load bundle, corpus, adapter, and raw receipt artifacts through safe bounded immutable paths.
+- [x] 2.2 Project receipt-owned outcomes and diagnostics into the existing evaluator manifest without fabricating unavailable observations.
+- [x] 2.3 Reject incomplete pairs, identity drift, invalid order, missing checks, stale graph state, and context contamination before export.
+- [x] 2.4 Emit an atomic deterministic derived score stamped with scorer, bundle, corpus, ground-truth, projection, and receipt identities.
+
+## 3. Verification And Documentation
+
+- [x] 3.1 Add focused contract, composition, rejection, immutability, and deterministic-rescoring tests.
+- [x] 3.2 Document the CLI, trust boundary, provenance fields, limitations, and synthetic-only proof.
+- [x] 3.3 Update package scripts and durable project status for the shipped capability.
+- [x] 3.4 Run targeted corpus/evaluator tests, lint, strict OpenSpec validation, and diff checks.

--- a/openspec/specs/agent-task-receipt-evaluation/spec.md
+++ b/openspec/specs/agent-task-receipt-evaluation/spec.md
@@ -1,0 +1,76 @@
+# agent-task-receipt-evaluation Specification
+
+## Purpose
+Compose immutable provider-neutral agent-task receipts into deterministic
+structural-context evaluation evidence without weakening scorer authority or
+mixing raw observations with derived conclusions.
+## Requirements
+### Requirement: Evaluation bundles are closed and identity-bound
+The system SHALL accept only a versioned closed evaluation bundle that names an
+immutable local corpus, task revisions, adapter artifacts, structural-context
+metadata, and raw v2 run receipts by safe relative path and exact SHA-256
+identity. It MUST reject unknown fields, unsafe paths, non-regular files,
+unsupported receipt or adapter versions, duplicate run identities, and any
+declared artifact whose bytes do not match its identity.
+
+#### Scenario: Every declared artifact is immutable
+- **WHEN** a valid local bundle references corpus, adapter, and receipt files whose bytes match their declared SHA-256 identities
+- **THEN** the system may load those artifacts for deterministic composition
+
+#### Scenario: A receipt changes after the bundle is declared
+- **WHEN** a referenced receipt no longer matches the bundle identity
+- **THEN** the system rejects the bundle before projecting or scoring evidence
+
+### Requirement: Receipt projection fails closed on invalid evidence
+The system SHALL project outcomes and available diagnostics from raw receipts
+without copying agent-visible ground truth into those receipts. It MUST reject
+export when a pair is incomplete or duplicated, task or common identities
+drift, execution order is invalid, required checks are missing, the treatment
+graph snapshot is stale, an A/B control is contaminated by structural context,
+or equivalent A/A arms use different context policies.
+
+#### Scenario: A complete isolated pair is supplied
+- **WHEN** both arms bind the same task, corpus, adapter, environment, trial, and ground-truth identities while satisfying their declared context policy
+- **THEN** the system projects the pair into the existing evaluator manifest
+
+#### Scenario: A required check is absent
+- **WHEN** either raw receipt completes a check-execution lifecycle but omits a check declared by the immutable acceptance contract
+- **THEN** the system refuses to export a derived score artifact
+
+#### Scenario: Agent terminates before checks
+- **WHEN** a setup, agent, timeout, or cancellation outcome correctly withholds hidden checks
+- **THEN** the projection records the immutable acceptance inventory as skipped while preserving the distinct terminal outcome
+
+#### Scenario: Control evidence is contaminated
+- **WHEN** an A/B control enables structural context, retains graph identity, or records a graph-tool call
+- **THEN** the system refuses to export the experiment
+
+### Requirement: Raw receipts and derived scores remain separate
+The system SHALL leave raw receipts byte-for-byte unchanged and SHALL emit any
+score as a separate bounded artifact. Every derived score MUST include a scorer
+version and SHA-256 identity, bundle identity, corpus identity, ground-truth
+identity, projected-manifest identity, and sorted raw receipt identities.
+Unavailable provider diagnostics MUST remain absent rather than being
+fabricated as zero values.
+
+#### Scenario: A score is derived from valid receipts
+- **WHEN** composition and the existing evaluator both succeed
+- **THEN** the derived artifact identifies the exact scorer, corpus, ground truth, projection, and raw receipt set used
+
+#### Scenario: Optional diagnostics were not captured
+- **WHEN** a raw receipt omits tokens, cost, tools, or file observations
+- **THEN** the projection and score omit those observations instead of inventing values
+
+### Requirement: Rescoring is deterministic and execution-free
+The system SHALL support repeated local scoring from the same bundle and raw
+receipts without launching an agent, executing acceptance checks, calling a
+model provider, making a network request, or mutating source artifacts.
+Equivalent inputs and scorer bytes MUST produce byte-equivalent derived JSON.
+
+#### Scenario: The same evidence is rescored
+- **WHEN** the same immutable bundle, receipts, corpus, ground truth, and scorer are supplied again
+- **THEN** the system emits the same derived score and identities without rerunning the agent
+
+#### Scenario: Ground truth is revised
+- **WHEN** an acceptance contract changes and its corpus and bundle identities are updated
+- **THEN** rescoring emits a different ground-truth and derived-score identity without claiming the original score applies

--- a/openspec/specs/structural-context-agent-evaluation/spec.md
+++ b/openspec/specs/structural-context-agent-evaluation/spec.md
@@ -2,9 +2,7 @@
 
 ## Purpose
 Evaluate whether repository structural context improves coding-agent outcomes through local, deterministic paired evidence and an inspectable report.
-
 ## Requirements
-
 ### Requirement: Experiments use immutable paired identities
 The system SHALL compare structural-context treatment and control runs only
 when both arms share the same task identity, repository revision, task packet
@@ -86,7 +84,10 @@ regression, identity, and A/A noise requirements
 The system SHALL read only explicitly supplied local manifests and receipts,
 produce deterministically ordered machine-readable JSON and Markdown from the
 same scorecard, and perform no model calls, network requests, repository
-mutation, checkout, hidden-test execution, or agent launch.
+mutation, checkout, hidden-test execution, or agent launch. When supplied
+projected provider-neutral runner evidence, it MUST derive outcomes only from
+validated receipts and MUST preserve the existing structural-context scorer as
+the sole outcome and qualification authority.
 
 #### Scenario: Synthetic fixture is scored
 - **WHEN** the checked-in hermetic fixture is passed to the evaluator
@@ -95,6 +96,10 @@ mutation, checkout, hidden-test execution, or agent launch.
 #### Scenario: User has not supplied agent receipts
 - **WHEN** no real paired run receipts are present
 - **THEN** the evaluator performs no agent work and makes no claim that structural context improves outcomes
+
+#### Scenario: Runner receipts are projected
+- **WHEN** a validated receipt bundle is composed into an evaluator manifest
+- **THEN** the existing scorer applies the same pairing, outcome, isolation, and qualification rules used for a directly supplied manifest
 
 ### Requirement: Users can inspect a bounded visual evaluation report
 The system SHALL optionally render a self-contained local HTML report from the

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "corpus:qualify": "node scripts/agent-task-corpus/qualify-cli.mjs",
     "corpus:plan": "node scripts/agent-task-corpus/run-cli.mjs",
     "corpus:run": "node scripts/agent-task-corpus/run-cli.mjs --execute",
+    "corpus:evaluate": "node scripts/agent-task-corpus/evaluate-cli.mjs",
     "test:benchmark": "node --test scripts/run-catch-rate-benchmark.test.mjs scripts/run-structural-context-evaluation.test.mjs",
     "test:graph-context": "node --test scripts/run-structural-context-evaluation.test.mjs",
     "test:corpus-contracts": "node --test scripts/agent-task-corpus/*.test.mjs",

--- a/scripts/agent-task-corpus/contracts.mjs
+++ b/scripts/agent-task-corpus/contracts.mjs
@@ -7,6 +7,8 @@ export const CONTRACT_SCHEMA_VERSIONS = Object.freeze({
   'agent-adapter-v2': 'codevetter.agent-task-adapter.v2',
   'check-result': 'codevetter.agent-task-check-result.v1',
   'corpus-index': 'codevetter.agent-task-corpus.v1',
+  'evaluation-bundle': 'codevetter.agent-task-evaluation-bundle.v1',
+  'evaluation-score': 'codevetter.agent-task-evaluation-score.v1',
   'fixture-bundle': 'codevetter.agent-task-fixture.v1',
   'known-good-change': 'codevetter.agent-task-known-good.v1',
   'qualification-receipt': 'codevetter.agent-task-qualification.v1',
@@ -845,6 +847,254 @@ function validateRunReceiptV2(value, path, errors) {
   }
 }
 
+function validateEvaluationBundle(value, path, errors) {
+  const fields = ['schema_version', 'experiment', 'corpus', 'tasks', 'runs'];
+  if (!closedObject(value, path, fields, fields, errors)) return;
+  exact(
+    value.schema_version,
+    CONTRACT_SCHEMA_VERSIONS['evaluation-bundle'],
+    `${path}.schema_version`,
+    errors
+  );
+  validateEvaluationExperiment(value.experiment, `${path}.experiment`, errors);
+  artifact(value.corpus, `${path}.corpus`, errors);
+
+  array(value.tasks, `${path}.tasks`, errors, { min: 1, max: CORPUS_LIMITS.maxTasks });
+  const taskIds = [];
+  for (const [index, task] of (Array.isArray(value.tasks) ? value.tasks : []).entries()) {
+    const taskPath = `${path}.tasks[${index}]`;
+    if (
+      !closedObject(
+        task,
+        taskPath,
+        ['task_id', 'repository_revision'],
+        ['task_id', 'repository_revision'],
+        errors
+      )
+    ) {
+      continue;
+    }
+    id(task.task_id, `${taskPath}.task_id`, errors);
+    revision(task.repository_revision, `${taskPath}.repository_revision`, errors);
+    if (typeof task.task_id === 'string') taskIds.push(task.task_id);
+  }
+  unique(taskIds, `${path}.tasks task_id`, errors);
+
+  array(value.runs, `${path}.runs`, errors, { min: 2, max: 5_000 });
+  const runKeys = [];
+  const receiptPaths = [];
+  const receiptHashes = [];
+  for (const [index, run] of (Array.isArray(value.runs) ? value.runs : []).entries()) {
+    const runPath = `${path}.runs[${index}]`;
+    const runFields = [
+      'pair_id',
+      'comparison',
+      'arm',
+      'task_id',
+      'trial_index',
+      'execution_order',
+      'receipt',
+      'adapter',
+      'context',
+    ];
+    if (!closedObject(run, runPath, runFields, runFields, errors)) continue;
+    id(run.pair_id, `${runPath}.pair_id`, errors);
+    oneOf(run.comparison, ['aa', 'ab'], `${runPath}.comparison`, errors);
+    const allowedArms = run.comparison === 'aa' ? ['a', 'b'] : ['control', 'treatment'];
+    oneOf(run.arm, allowedArms, `${runPath}.arm`, errors);
+    id(run.task_id, `${runPath}.task_id`, errors);
+    if (typeof run.task_id === 'string' && !taskIds.includes(run.task_id)) {
+      errors.push(`${runPath}.task_id: does not reference a declared task`);
+    }
+    integer(run.trial_index, `${runPath}.trial_index`, errors, 1, 10_000);
+    integer(run.execution_order, `${runPath}.execution_order`, errors, 1, 2);
+    artifact(run.receipt, `${runPath}.receipt`, errors);
+    artifact(run.adapter, `${runPath}.adapter`, errors);
+    validateEvaluationContext(run.context, `${runPath}.context`, errors);
+    if (
+      typeof run.comparison === 'string' &&
+      typeof run.pair_id === 'string' &&
+      typeof run.arm === 'string'
+    ) {
+      runKeys.push(`${run.comparison}:${run.pair_id}:${run.arm}`);
+    }
+    if (typeof run.receipt?.path === 'string') receiptPaths.push(run.receipt.path);
+    if (typeof run.receipt?.sha256 === 'string') receiptHashes.push(run.receipt.sha256);
+  }
+  unique(runKeys, `${path}.runs pair arm`, errors);
+  unique(receiptPaths, `${path}.runs receipt path`, errors);
+  unique(receiptHashes, `${path}.runs receipt sha256`, errors);
+}
+
+function validateEvaluationExperiment(value, path, errors) {
+  const fields = ['id', 'title', 'evidence_kind', 'qualification_policy', 'limitations'];
+  if (!closedObject(value, path, fields, fields, errors)) return;
+  id(value.id, `${path}.id`, errors);
+  boundedString(value.title, `${path}.title`, errors, 1, 160);
+  oneOf(value.evidence_kind, ['real', 'synthetic'], `${path}.evidence_kind`, errors);
+  const policyFields = [
+    'minimum_complete_pairs',
+    'minimum_distinct_tasks',
+    'minimum_aa_pairs',
+    'minimum_success_rate_delta',
+    'maximum_regression_delta',
+    'maximum_aa_discordance_rate',
+  ];
+  if (
+    closedObject(
+      value.qualification_policy,
+      `${path}.qualification_policy`,
+      policyFields,
+      policyFields,
+      errors
+    )
+  ) {
+    const policy = value.qualification_policy;
+    integer(
+      policy.minimum_complete_pairs,
+      `${path}.qualification_policy.minimum_complete_pairs`,
+      errors,
+      1,
+      5_000
+    );
+    integer(
+      policy.minimum_distinct_tasks,
+      `${path}.qualification_policy.minimum_distinct_tasks`,
+      errors,
+      1,
+      CORPUS_LIMITS.maxTasks
+    );
+    integer(
+      policy.minimum_aa_pairs,
+      `${path}.qualification_policy.minimum_aa_pairs`,
+      errors,
+      1,
+      5_000
+    );
+    finiteNumber(
+      policy.minimum_success_rate_delta,
+      `${path}.qualification_policy.minimum_success_rate_delta`,
+      errors,
+      0,
+      1
+    );
+    integer(
+      policy.maximum_regression_delta,
+      `${path}.qualification_policy.maximum_regression_delta`,
+      errors,
+      0,
+      CORPUS_LIMITS.maxChecks * 5_000
+    );
+    finiteNumber(
+      policy.maximum_aa_discordance_rate,
+      `${path}.qualification_policy.maximum_aa_discordance_rate`,
+      errors,
+      0,
+      1
+    );
+  }
+  stringArray(value.limitations, `${path}.limitations`, errors, { max: 50, itemMax: 500 });
+}
+
+function validateEvaluationContext(value, path, errors) {
+  const fields = ['structural_context_enabled', 'policy_identity', 'graph', 'allowed_graph_tools'];
+  if (!closedObject(value, path, fields, fields, errors)) return;
+  boolean(value.structural_context_enabled, `${path}.structural_context_enabled`, errors);
+  id(value.policy_identity, `${path}.policy_identity`, errors);
+  stringArray(value.allowed_graph_tools, `${path}.allowed_graph_tools`, errors, {
+    max: 100,
+    itemMax: 200,
+  });
+  if (Array.isArray(value.allowed_graph_tools)) {
+    unique(value.allowed_graph_tools, `${path}.allowed_graph_tools`, errors);
+    sorted(value.allowed_graph_tools, `${path}.allowed_graph_tools`, errors);
+  }
+  if (value.graph === null) return;
+  const graphFields = ['engine_id', 'engine_version', 'snapshot_id', 'indexed_revision'];
+  if (!closedObject(value.graph, `${path}.graph`, graphFields, graphFields, errors)) return;
+  id(value.graph.engine_id, `${path}.graph.engine_id`, errors);
+  boundedString(value.graph.engine_version, `${path}.graph.engine_version`, errors, 1, 80);
+  id(value.graph.snapshot_id, `${path}.graph.snapshot_id`, errors);
+  revision(value.graph.indexed_revision, `${path}.graph.indexed_revision`, errors);
+}
+
+function validateEvaluationScore(value, path, errors) {
+  const fields = ['schema_version', 'score_id', 'scorer', 'evidence', 'scorecard'];
+  if (!closedObject(value, path, fields, fields, errors)) return;
+  exact(
+    value.schema_version,
+    CONTRACT_SCHEMA_VERSIONS['evaluation-score'],
+    `${path}.schema_version`,
+    errors
+  );
+  id(value.score_id, `${path}.score_id`, errors);
+  if (
+    closedObject(
+      value.scorer,
+      `${path}.scorer`,
+      ['version', 'sha256'],
+      ['version', 'sha256'],
+      errors
+    )
+  ) {
+    boundedString(value.scorer.version, `${path}.scorer.version`, errors, 1, 80);
+    sha256(value.scorer.sha256, `${path}.scorer.sha256`, errors);
+  }
+  const evidenceFields = [
+    'bundle_sha256',
+    'corpus_sha256',
+    'ground_truth_sha256',
+    'projected_manifest_sha256',
+    'receipts',
+  ];
+  if (closedObject(value.evidence, `${path}.evidence`, evidenceFields, evidenceFields, errors)) {
+    for (const field of evidenceFields.slice(0, -1)) {
+      sha256(value.evidence[field], `${path}.evidence.${field}`, errors);
+    }
+    array(value.evidence.receipts, `${path}.evidence.receipts`, errors, { min: 2, max: 5_000 });
+    const receiptPaths = [];
+    const receiptHashes = [];
+    const runIds = [];
+    for (const [index, receipt] of (Array.isArray(value.evidence.receipts)
+      ? value.evidence.receipts
+      : []
+    ).entries()) {
+      const receiptPath = `${path}.evidence.receipts[${index}]`;
+      if (
+        !closedObject(
+          receipt,
+          receiptPath,
+          ['path', 'sha256', 'run_id'],
+          ['path', 'sha256', 'run_id'],
+          errors
+        )
+      ) {
+        continue;
+      }
+      relativePath(receipt.path, `${receiptPath}.path`, errors);
+      sha256(receipt.sha256, `${receiptPath}.sha256`, errors);
+      id(receipt.run_id, `${receiptPath}.run_id`, errors);
+      receiptPaths.push(receipt.path);
+      receiptHashes.push(receipt.sha256);
+      runIds.push(receipt.run_id);
+    }
+    unique(receiptPaths, `${path}.evidence.receipts path`, errors);
+    unique(receiptHashes, `${path}.evidence.receipts sha256`, errors);
+    unique(runIds, `${path}.evidence.receipts run_id`, errors);
+    sorted(receiptPaths, `${path}.evidence.receipts`, errors);
+  }
+  if (!value.scorecard || typeof value.scorecard !== 'object' || Array.isArray(value.scorecard)) {
+    errors.push(`${path}.scorecard: expected an object`);
+  }
+  if (typeof value.score_id === 'string') {
+    const { score_id: _scoreId, ...identity } = value;
+    const expected = `score-${sha256Bytes(Buffer.from(canonicalJson(identity))).slice(0, 32)}`;
+    if (value.score_id !== expected) {
+      errors.push(`${path}.score_id: does not match the canonical score identity`);
+    }
+  }
+}
+
 function validateDiagnostics(value, path, errors) {
   if (value === undefined) return;
   const fields = [
@@ -1251,6 +1501,10 @@ function sha256(value, path, errors) {
   stringPattern(value, SHA256_PATTERN, path, errors, 64);
 }
 
+function revision(value, path, errors) {
+  stringPattern(value, REVISION_PATTERN, path, errors, 64);
+}
+
 function httpsUrl(value, path, errors) {
   boundedString(value, path, errors, 1, 500);
   if (typeof value !== 'string') return;
@@ -1351,6 +1605,8 @@ const validators = Object.freeze({
   'agent-adapter': validateAgentAdapter,
   'check-result': validateCheckResult,
   'corpus-index': validateCorpusIndex,
+  'evaluation-bundle': validateEvaluationBundle,
+  'evaluation-score': validateEvaluationScore,
   'fixture-bundle': validateFixtureBundle,
   'known-good-change': validateKnownGoodChange,
   'qualification-receipt': validateQualificationReceipt,

--- a/scripts/agent-task-corpus/evaluate-cli.mjs
+++ b/scripts/agent-task-corpus/evaluate-cli.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+
+import { pathToFileURL } from 'node:url';
+
+import { evaluateReceiptBundle, writeEvaluationScore } from './evaluate-receipts.mjs';
+
+export async function runEvaluationCli(args = process.argv.slice(2)) {
+  const wantsJson = args.includes('--json');
+  try {
+    const options = parseArgs(args);
+    const result = await evaluateReceiptBundle({
+      bundlePath: options.bundlePath,
+      root: options.root,
+    });
+    if (options.out) await writeEvaluationScore(options.out, result.score);
+    return {
+      ...result,
+      exitCode: 0,
+      output: wantsJson
+        ? `${JSON.stringify(result.score)}\n`
+        : humanOutput(result.score, options.out),
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      exitCode: 2,
+      output: wantsJson
+        ? `${JSON.stringify({ error: message })}\n`
+        : `Agent-task evaluation failed: ${message}\n`,
+      manifest: null,
+      score: null,
+    };
+  }
+}
+
+function parseArgs(args) {
+  const options = { bundlePath: undefined, root: undefined, out: undefined };
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    if (argument === '--json') continue;
+    if (['--bundle', '--root', '--out'].includes(argument)) {
+      const value = args[index + 1];
+      if (!value || value.startsWith('--')) throw new Error(`${argument} requires a value`);
+      index += 1;
+      if (argument === '--bundle') options.bundlePath = value;
+      if (argument === '--root') options.root = value;
+      if (argument === '--out') options.out = value;
+      continue;
+    }
+    throw new Error(`unknown argument: ${argument}`);
+  }
+  if (!options.bundlePath) throw new Error('--bundle is required');
+  return options;
+}
+
+function humanOutput(score, outputPath) {
+  const lines = [
+    `Score: ${score.score_id}`,
+    `Qualification: ${score.scorecard.qualification.state}`,
+    `A/B pairs: ${score.scorecard.ab.complete_pairs}`,
+    `A/A pairs: ${score.scorecard.aa.complete_pairs}`,
+    `Scorer: ${score.scorer.version} (${score.scorer.sha256})`,
+    `Ground truth: ${score.evidence.ground_truth_sha256}`,
+  ];
+  if (outputPath) lines.push(`Derived score: ${outputPath}`);
+  return `${lines.join('\n')}\n`;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const result = await runEvaluationCli();
+  process.stdout.write(result.output);
+  process.exitCode = result.exitCode;
+}

--- a/scripts/agent-task-corpus/evaluate-receipts.mjs
+++ b/scripts/agent-task-corpus/evaluate-receipts.mjs
@@ -1,0 +1,334 @@
+import { lstat, mkdir, readFile, rename, writeFile } from 'node:fs/promises';
+import { dirname, relative, resolve, sep } from 'node:path';
+
+import {
+  STRUCTURAL_CONTEXT_SCORER_VERSION,
+  scoreManifest,
+  validateManifest,
+} from '../run-structural-context-evaluation.mjs';
+import {
+  CONTRACT_SCHEMA_VERSIONS,
+  CORPUS_LIMITS,
+  canonicalJson,
+  sha256Bytes,
+  validateContract,
+} from './contracts.mjs';
+import { loadTaskPackage } from './qualify-task.mjs';
+import { validateCorpus } from './validate-corpus.mjs';
+
+const MAX_BUNDLE_BYTES = 5 * 1024 * 1024;
+const MAX_RECEIPT_BYTES = CORPUS_LIMITS.maxDocumentBytes;
+const SCORER_PATH = new URL('../run-structural-context-evaluation.mjs', import.meta.url);
+
+export async function evaluateReceiptBundle({
+  bundlePath,
+  root = process.cwd(),
+  scorerPath = SCORER_PATH,
+} = {}) {
+  if (typeof bundlePath !== 'string' || bundlePath.length === 0) {
+    throw new Error('bundlePath is required');
+  }
+  const bundleDocument = await readExplicitJson(bundlePath, MAX_BUNDLE_BYTES);
+  const bundleErrors = validateContract('evaluation-bundle', bundleDocument.value);
+  if (bundleErrors.length > 0) {
+    throw new Error(`invalid evaluation bundle:\n${bundleErrors.join('\n')}`);
+  }
+
+  const workspaceRoot = resolve(root);
+  const corpusDocument = await readDeclaredArtifact(
+    workspaceRoot,
+    bundleDocument.value.corpus,
+    CORPUS_LIMITS.maxDocumentBytes
+  );
+  if (!corpusDocument.path.endsWith(`${sep}corpus.json`)) {
+    throw new Error('evaluation bundle corpus path must name corpus.json');
+  }
+  const corpusRoot = dirname(corpusDocument.path);
+  const corpusValidation = validateCorpus({ root: corpusRoot, ignoreQualification: true });
+  if (!corpusValidation.valid) {
+    throw new Error(`corpus validation failed:\n${corpusValidation.errors.join('\n')}`);
+  }
+
+  const tasks = await loadEvaluationTasks(bundleDocument.value.tasks, corpusRoot);
+  const runs = await loadEvaluationRuns(bundleDocument.value.runs, workspaceRoot, tasks);
+  const manifest = projectManifest(bundleDocument.value, tasks, runs);
+  const manifestErrors = validateManifest(manifest);
+  if (manifestErrors.length > 0) {
+    throw new Error(`invalid projected evaluator manifest:\n${manifestErrors.join('\n')}`);
+  }
+
+  const scorecard = scoreManifest(manifest, `receipt-bundle:${bundleDocument.value.experiment.id}`);
+  if (scorecard.invalid_pairs.length > 0) {
+    const reasons = scorecard.invalid_pairs
+      .map((pair) => `${pair.comparison}:${pair.pair_id}: ${pair.reasons.join(', ')}`)
+      .join('\n');
+    throw new Error(`evaluation export rejected invalid evidence:\n${reasons}`);
+  }
+
+  const scorerBytes = await readFile(scorerPath);
+  const groundTruth = [...tasks.values()]
+    .map((task) => ({
+      task_id: task.taskId,
+      acceptance_contract_sha256: task.identities.acceptance,
+      checks: allAcceptanceChecks(task).map((check) => ({ id: check.id, label: check.label })),
+    }))
+    .sort((left, right) => left.task_id.localeCompare(right.task_id));
+  const receiptEvidence = runs
+    .map((run) => ({
+      path: run.descriptor.receipt.path,
+      sha256: run.descriptor.receipt.sha256,
+      run_id: run.receipt.run_id,
+    }))
+    .sort((left, right) => left.path.localeCompare(right.path));
+  const draft = {
+    schema_version: CONTRACT_SCHEMA_VERSIONS['evaluation-score'],
+    scorer: {
+      version: STRUCTURAL_CONTEXT_SCORER_VERSION,
+      sha256: sha256Bytes(scorerBytes),
+    },
+    evidence: {
+      bundle_sha256: bundleDocument.sha256,
+      corpus_sha256: corpusDocument.sha256,
+      ground_truth_sha256: sha256Bytes(Buffer.from(canonicalJson(groundTruth))),
+      projected_manifest_sha256: sha256Bytes(Buffer.from(canonicalJson(manifest))),
+      receipts: receiptEvidence,
+    },
+    scorecard,
+  };
+  const score = {
+    ...draft,
+    score_id: `score-${sha256Bytes(Buffer.from(canonicalJson(draft))).slice(0, 32)}`,
+  };
+  const scoreErrors = validateContract('evaluation-score', score);
+  if (scoreErrors.length > 0) {
+    throw new Error(`invalid derived evaluation score:\n${scoreErrors.join('\n')}`);
+  }
+  return { manifest, score };
+}
+
+async function loadEvaluationTasks(taskDescriptors, corpusRoot) {
+  const tasks = new Map();
+  for (const descriptor of taskDescriptors) {
+    const task = await loadTaskPackage(corpusRoot, descriptor.task_id);
+    if (task.manifest.provenance.revision !== descriptor.repository_revision) {
+      throw new Error(`task "${descriptor.task_id}" repository revision does not match corpus`);
+    }
+    tasks.set(descriptor.task_id, {
+      ...task,
+      repositoryRevision: descriptor.repository_revision,
+    });
+  }
+  return tasks;
+}
+
+async function loadEvaluationRuns(runDescriptors, workspaceRoot, tasks) {
+  const runs = [];
+  const runIds = new Set();
+  for (const descriptor of runDescriptors) {
+    const task = tasks.get(descriptor.task_id);
+    const receiptDocument = await readDeclaredArtifact(
+      workspaceRoot,
+      descriptor.receipt,
+      MAX_RECEIPT_BYTES
+    );
+    const receipt = parseJson(receiptDocument.bytes, descriptor.receipt.path);
+    const receiptErrors = validateContract('run-receipt', receipt);
+    if (receiptErrors.length > 0) {
+      throw new Error(
+        `invalid run receipt "${descriptor.receipt.path}":\n${receiptErrors.join('\n')}`
+      );
+    }
+    if (receipt.schema_version !== CONTRACT_SCHEMA_VERSIONS['run-receipt-v2']) {
+      throw new Error(`run receipt "${descriptor.receipt.path}" must use the v2 contract`);
+    }
+    if (runIds.has(receipt.run_id)) {
+      throw new Error(`duplicate raw run identity "${receipt.run_id}"`);
+    }
+    runIds.add(receipt.run_id);
+
+    const adapterDocument = await readDeclaredArtifact(
+      workspaceRoot,
+      descriptor.adapter,
+      MAX_RECEIPT_BYTES
+    );
+    const adapter = parseJson(adapterDocument.bytes, descriptor.adapter.path);
+    const adapterErrors = validateContract('agent-adapter', adapter);
+    if (adapterErrors.length > 0) {
+      throw new Error(
+        `invalid agent adapter "${descriptor.adapter.path}":\n${adapterErrors.join('\n')}`
+      );
+    }
+    if (adapter.schema_version !== CONTRACT_SCHEMA_VERSIONS['agent-adapter-v2']) {
+      throw new Error(`agent adapter "${descriptor.adapter.path}" must use the v2 contract`);
+    }
+    validateReceiptIdentity(receipt, adapterDocument.sha256, task, descriptor.receipt.path);
+    validateReceiptChecks(receipt, task, descriptor.receipt.path);
+    runs.push({ descriptor, receipt, adapter });
+  }
+  return runs;
+}
+
+function validateReceiptIdentity(receipt, adapterSha256, task, label) {
+  const expected = {
+    task_id: task.taskId,
+    manifest_sha256: task.identities.manifest,
+    fixture_sha256: task.identities.fixture,
+    acceptance_contract_sha256: task.identities.acceptance,
+    adapter_sha256: adapterSha256,
+  };
+  for (const [field, value] of Object.entries(expected)) {
+    if (receipt[field] !== value) {
+      throw new Error(`run receipt "${label}" ${field} does not match immutable evidence`);
+    }
+  }
+}
+
+function validateReceiptChecks(receipt, task, label) {
+  const expected = allAcceptanceChecks(task)
+    .map((check) => check.id)
+    .sort();
+  const observed = receipt.checks.map((check) => check.id).sort();
+  const checksStarted = receipt.lifecycle.includes('checks_started');
+  if (!checksStarted && observed.length > 0) {
+    throw new Error(`run receipt "${label}" reports checks before checks_started`);
+  }
+  if (checksStarted && JSON.stringify(observed) !== JSON.stringify(expected)) {
+    throw new Error(`run receipt "${label}" is missing or adds acceptance checks`);
+  }
+}
+
+function projectManifest(bundle, tasks, runs) {
+  return {
+    schema_version: 1,
+    experiment: {
+      id: bundle.experiment.id,
+      title: bundle.experiment.title,
+      evidence_kind: bundle.experiment.evidence_kind,
+      qualification_policy: { ...bundle.experiment.qualification_policy },
+      limitations: [...bundle.experiment.limitations],
+    },
+    tasks: [...tasks.values()]
+      .map((task) => ({
+        id: task.taskId,
+        title: task.manifest.title,
+        repository_revision: task.repositoryRevision,
+        task_packet_sha256: task.identities.taskPacket,
+        acceptance_contract_sha256: task.identities.acceptance,
+        required_checks: allAcceptanceChecks(task).map((check) => ({
+          id: check.id,
+          label: check.label,
+        })),
+      }))
+      .sort((left, right) => left.id.localeCompare(right.id)),
+    runs: runs.map((run) => projectRun(run, tasks)).sort(compareProjectedRuns),
+  };
+}
+
+function projectRun({ descriptor, receipt, adapter }, tasks) {
+  const task = tasks.get(descriptor.task_id);
+  const diagnostics = projectDiagnostics(receipt.diagnostics);
+  return {
+    pair_id: descriptor.pair_id,
+    comparison: descriptor.comparison,
+    arm: descriptor.arm,
+    task_id: descriptor.task_id,
+    trial_index: descriptor.trial_index,
+    execution_order: descriptor.execution_order,
+    identities: {
+      repository_revision: task.repositoryRevision,
+      task_packet_sha256: task.identities.taskPacket,
+      acceptance_contract_sha256: receipt.acceptance_contract_sha256,
+      agent: adapter.agent,
+      model: adapter.model,
+      configuration_sha256: receipt.adapter_sha256,
+      environment_sha256: receipt.environment_sha256,
+    },
+    context: structuredClone(descriptor.context),
+    outcome: {
+      status: projectTerminalStatus(receipt.terminal_status),
+      regression_count: receipt.regression_count,
+      checks: receipt.lifecycle.includes('checks_started')
+        ? receipt.checks.map((check) => ({ id: check.id, status: check.status }))
+        : allAcceptanceChecks(task).map((check) => ({ id: check.id, status: 'skipped' })),
+    },
+    ...(diagnostics === undefined ? {} : { diagnostics }),
+  };
+}
+
+function projectTerminalStatus(status) {
+  if (status === 'setup_failure') return 'setup_failed';
+  if (status === 'agent_failure') return 'agent_failed';
+  if (status === 'timeout') return 'timed_out';
+  if (['cancelled', 'check_error', 'cleanup_failure'].includes(status)) return status;
+  return 'completed';
+}
+
+function projectDiagnostics(diagnostics) {
+  if (diagnostics === undefined) return undefined;
+  const projected = {};
+  for (const field of ['input_tokens', 'output_tokens', 'cost_usd']) {
+    if (diagnostics[field] !== undefined) projected[field] = diagnostics[field];
+  }
+  for (const field of ['tool_calls', 'files_inspected', 'files_modified']) {
+    if (diagnostics[field] !== undefined) projected[field] = [...diagnostics[field]];
+  }
+  return Object.keys(projected).length === 0 ? undefined : projected;
+}
+
+function allAcceptanceChecks(task) {
+  return [...task.acceptance.required_checks, ...task.acceptance.regression_checks].sort(
+    (left, right) => left.id.localeCompare(right.id)
+  );
+}
+
+function compareProjectedRuns(left, right) {
+  return (
+    left.comparison.localeCompare(right.comparison) ||
+    left.pair_id.localeCompare(right.pair_id) ||
+    left.execution_order - right.execution_order ||
+    left.arm.localeCompare(right.arm)
+  );
+}
+
+async function readExplicitJson(path, maxBytes) {
+  const absolute = resolve(path);
+  const document = await readFileDocument(absolute, maxBytes, path);
+  return { ...document, value: parseJson(document.bytes, path) };
+}
+
+async function readDeclaredArtifact(root, artifact, maxBytes) {
+  const absolute = resolve(root, artifact.path);
+  const parent = relative(root, absolute);
+  if (parent === '..' || parent.startsWith(`..${sep}`)) {
+    throw new Error(`artifact escapes the evaluation root: ${artifact.path}`);
+  }
+  const document = await readFileDocument(absolute, maxBytes, artifact.path);
+  if (document.sha256 !== artifact.sha256) {
+    throw new Error(`artifact SHA-256 mismatch: ${artifact.path}`);
+  }
+  return document;
+}
+
+async function readFileDocument(path, maxBytes, label) {
+  const stat = await lstat(path);
+  if (!stat.isFile()) throw new Error(`artifact is not a regular file: ${label}`);
+  if (stat.size > maxBytes) throw new Error(`artifact exceeds ${maxBytes} bytes: ${label}`);
+  const bytes = await readFile(path);
+  return { path, bytes, sha256: sha256Bytes(bytes) };
+}
+
+function parseJson(bytes, label) {
+  try {
+    return JSON.parse(bytes.toString('utf8'));
+  } catch {
+    throw new Error(`artifact is not valid JSON: ${label}`);
+  }
+}
+
+export async function writeEvaluationScore(path, score) {
+  const destination = resolve(path);
+  await mkdir(dirname(destination), { recursive: true });
+  const temporary = `${destination}.tmp-${process.pid}`;
+  await writeFile(temporary, `${JSON.stringify(score, null, 2)}\n`, { flag: 'wx' });
+  await rename(temporary, destination);
+}

--- a/scripts/agent-task-corpus/evaluate-receipts.test.mjs
+++ b/scripts/agent-task-corpus/evaluate-receipts.test.mjs
@@ -1,0 +1,355 @@
+import assert from 'node:assert/strict';
+import { cp, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import test from 'node:test';
+
+import { runEvaluationCli } from './evaluate-cli.mjs';
+import {
+  CONTRACT_SCHEMA_VERSIONS,
+  canonicalJson,
+  sha256Bytes,
+  validateContract,
+} from './contracts.mjs';
+import { evaluateReceiptBundle } from './evaluate-receipts.mjs';
+
+const SAMPLE_ROOT = resolve('benchmarks/agent-tasks/sample');
+const TASK_ID = 'preserve-explicit-false';
+const REVISION = '8b2c3a978ad98d642d4bb4b1df49eb6c23278124';
+const HASH = 'a'.repeat(64);
+
+async function fixture(t) {
+  const root = await mkdtemp(join(tmpdir(), 'codevetter-evaluation-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  await cp(SAMPLE_ROOT, join(root, 'corpus'), { recursive: true });
+  const corpus = await artifact(root, 'corpus/corpus.json');
+  const adapter = await artifact(root, 'corpus/adapters/synthetic-false-fix.json');
+  const task = JSON.parse(
+    await readFile(join(root, 'corpus/tasks/preserve-explicit-false/task.json'), 'utf8')
+  );
+  const identities = {
+    manifest: taskFileHash(root),
+    fixture: task.artifacts.fixture.sha256,
+    acceptance: task.artifacts.acceptance_contract.sha256,
+    adapter: adapter.sha256,
+  };
+  identities.manifest = await identities.manifest;
+
+  const receipts = {};
+  for (const [name, status] of [
+    ['ab-control', 'check_failure'],
+    ['ab-treatment', 'success'],
+    ['aa-a', 'success'],
+    ['aa-b', 'success'],
+  ]) {
+    const value = receipt(name, status, identities);
+    receipts[name] = await writeJson(root, `receipts/${name}.json`, value);
+  }
+  const bundle = {
+    schema_version: CONTRACT_SCHEMA_VERSIONS['evaluation-bundle'],
+    experiment: {
+      id: 'synthetic-receipt-composition',
+      title: 'Synthetic receipt composition',
+      evidence_kind: 'synthetic',
+      qualification_policy: {
+        minimum_complete_pairs: 1,
+        minimum_distinct_tasks: 1,
+        minimum_aa_pairs: 1,
+        minimum_success_rate_delta: 0,
+        maximum_regression_delta: 0,
+        maximum_aa_discordance_rate: 0,
+      },
+      limitations: ['Synthetic receipts prove composition only.'],
+    },
+    corpus,
+    tasks: [{ task_id: TASK_ID, repository_revision: REVISION }],
+    runs: [
+      run('ab-pair', 'ab', 'control', 1, receipts['ab-control'], adapter, noGraph()),
+      run('ab-pair', 'ab', 'treatment', 2, receipts['ab-treatment'], adapter, graph()),
+      run('aa-pair', 'aa', 'a', 1, receipts['aa-a'], adapter, noGraph()),
+      run('aa-pair', 'aa', 'b', 2, receipts['aa-b'], adapter, noGraph()),
+    ],
+  };
+  const bundlePath = join(root, 'bundle.json');
+  await writeFile(bundlePath, `${JSON.stringify(bundle, null, 2)}\n`);
+  return { root, bundle, bundlePath, receipts };
+}
+
+function receipt(name, status, identities) {
+  const checks = [
+    {
+      id: 'explicit-false-preserved',
+      status: status === 'check_failure' ? 'fail' : 'pass',
+    },
+    { id: 'label-preserved', status: 'pass' },
+    { id: 'public-inputs-only', status: 'pass' },
+  ];
+  return {
+    schema_version: CONTRACT_SCHEMA_VERSIONS['run-receipt-v2'],
+    run_id: `run-${name}`,
+    plan_id: `plan-${name}`,
+    task_id: TASK_ID,
+    manifest_sha256: identities.manifest,
+    fixture_sha256: identities.fixture,
+    acceptance_contract_sha256: identities.acceptance,
+    adapter_sha256: identities.adapter,
+    environment_sha256: HASH,
+    workspace_policy: 'public_fixture_and_task_packet_v1',
+    terminal_status: status,
+    lifecycle: [
+      'workspace_prepared',
+      'agent_started',
+      'agent_terminated',
+      'checks_started',
+      'checks_finished',
+      'cleanup_complete',
+    ],
+    agent: {
+      status: 'exited',
+      exit_code: 0,
+      stdout_sha256: HASH,
+      stderr_sha256: HASH,
+      stdout_bytes: 0,
+      stderr_bytes: 0,
+      output_truncated: false,
+    },
+    checks,
+    regression_count: 0,
+    cleanup: { status: 'complete' },
+    limitations: ['Synthetic receipt.'],
+  };
+}
+
+function run(pairId, comparison, arm, executionOrder, receiptArtifact, adapter, context) {
+  return {
+    pair_id: pairId,
+    comparison,
+    arm,
+    task_id: TASK_ID,
+    trial_index: 1,
+    execution_order: executionOrder,
+    receipt: receiptArtifact,
+    adapter,
+    context,
+  };
+}
+
+function noGraph() {
+  return {
+    structural_context_enabled: false,
+    policy_identity: 'no-graph-v1',
+    graph: null,
+    allowed_graph_tools: [],
+  };
+}
+
+function graph() {
+  return {
+    structural_context_enabled: true,
+    policy_identity: 'graph-v1',
+    graph: {
+      engine_id: 'codevetter-graph',
+      engine_version: '1',
+      snapshot_id: 'synthetic-snapshot',
+      indexed_revision: REVISION,
+    },
+    allowed_graph_tools: ['graph_query'],
+  };
+}
+
+async function taskFileHash(root) {
+  return sha256Bytes(await readFile(join(root, 'corpus/tasks/preserve-explicit-false/task.json')));
+}
+
+async function artifact(root, path) {
+  return { path, sha256: sha256Bytes(await readFile(join(root, path))) };
+}
+
+async function writeJson(root, path, value) {
+  const bytes = Buffer.from(`${JSON.stringify(value, null, 2)}\n`);
+  const destination = join(root, path);
+  await mkdir(dirname(destination), { recursive: true });
+  await writeFile(destination, bytes);
+  return { path, sha256: sha256Bytes(bytes) };
+}
+
+async function rewriteBundle(context) {
+  await writeFile(context.bundlePath, `${JSON.stringify(context.bundle, null, 2)}\n`);
+}
+
+async function mutateReceipt(context, name, mutate) {
+  const descriptor = context.bundle.runs.find((entry) =>
+    entry.receipt.path.endsWith(`${name}.json`)
+  );
+  const absolute = join(context.root, descriptor.receipt.path);
+  const value = JSON.parse(await readFile(absolute, 'utf8'));
+  mutate(value);
+  const bytes = Buffer.from(`${JSON.stringify(value, null, 2)}\n`);
+  await writeFile(absolute, bytes);
+  descriptor.receipt.sha256 = sha256Bytes(bytes);
+  await rewriteBundle(context);
+}
+
+test('validates closed bundle and derived score contracts', async (t) => {
+  const context = await fixture(t);
+  assert.deepEqual(validateContract('evaluation-bundle', context.bundle), []);
+  context.bundle.unknown = true;
+  assert.match(validateContract('evaluation-bundle', context.bundle).join('\n'), /unknown field/);
+});
+
+test('projects immutable receipts and rescoring is byte-deterministic', async (t) => {
+  const context = await fixture(t);
+  const rawBefore = await readFile(join(context.root, context.receipts['ab-treatment'].path));
+  const first = await evaluateReceiptBundle({
+    bundlePath: context.bundlePath,
+    root: context.root,
+  });
+  const second = await evaluateReceiptBundle({
+    bundlePath: context.bundlePath,
+    root: context.root,
+  });
+
+  assert.deepEqual(second, first);
+  assert.equal(canonicalJson(second.score), canonicalJson(first.score));
+  assert.match(first.score.score_id, /^score-[a-f0-9]{32}$/);
+  assert.equal(first.score.scorer.version, 'codevetter.structural-context.v1');
+  assert.equal(first.score.evidence.receipts.length, 4);
+  assert.equal(first.score.scorecard.ab.complete_pairs, 1);
+  assert.equal(first.score.scorecard.ab.treatment_wins, 1);
+  assert.equal(first.score.scorecard.aa.complete_pairs, 1);
+  assert.deepEqual(first.score.scorecard.invalid_pairs, []);
+  assert.equal(first.score.scorecard.qualification.state, 'unqualified');
+  assert.equal(validateContract('evaluation-score', first.score).length, 0);
+  assert.deepEqual(
+    await readFile(join(context.root, context.receipts['ab-treatment'].path)),
+    rawBefore
+  );
+  assert.equal(first.manifest.runs[0].diagnostics, undefined);
+});
+
+test('rejects receipt hash drift and immutable identity drift', async (t) => {
+  const context = await fixture(t);
+  const path = join(context.root, context.receipts['ab-control'].path);
+  await writeFile(path, `${await readFile(path, 'utf8')}\n`);
+  await assert.rejects(
+    evaluateReceiptBundle({ bundlePath: context.bundlePath, root: context.root }),
+    /artifact SHA-256 mismatch/
+  );
+
+  const identityContext = await fixture(t);
+  await mutateReceipt(identityContext, 'ab-control', (value) => {
+    value.environment_sha256 = 'b'.repeat(64);
+  });
+  await assert.rejects(
+    evaluateReceiptBundle({
+      bundlePath: identityContext.bundlePath,
+      root: identityContext.root,
+    }),
+    /arms use different common identities/
+  );
+});
+
+test('rejects missing checks after check execution', async (t) => {
+  const context = await fixture(t);
+  await mutateReceipt(context, 'ab-control', (value) => {
+    value.checks.pop();
+  });
+  await assert.rejects(
+    evaluateReceiptBundle({ bundlePath: context.bundlePath, root: context.root }),
+    /missing or adds acceptance checks/
+  );
+});
+
+test('rejects incomplete, misordered, stale, and contaminated pairs', async (t) => {
+  const incomplete = await fixture(t);
+  incomplete.bundle.runs.pop();
+  await rewriteBundle(incomplete);
+  await assert.rejects(
+    evaluateReceiptBundle({ bundlePath: incomplete.bundlePath, root: incomplete.root }),
+    /missing b arm/
+  );
+
+  const misordered = await fixture(t);
+  misordered.bundle.runs[1].execution_order = 1;
+  await rewriteBundle(misordered);
+  await assert.rejects(
+    evaluateReceiptBundle({ bundlePath: misordered.bundlePath, root: misordered.root }),
+    /same execution order/
+  );
+
+  const stale = await fixture(t);
+  stale.bundle.runs[1].context.graph.indexed_revision = 'b'.repeat(40);
+  await rewriteBundle(stale);
+  await assert.rejects(
+    evaluateReceiptBundle({ bundlePath: stale.bundlePath, root: stale.root }),
+    /treatment graph snapshot is stale/
+  );
+
+  const contaminated = await fixture(t);
+  contaminated.bundle.runs[0].context.structural_context_enabled = true;
+  contaminated.bundle.runs[0].context.graph = graph().graph;
+  await rewriteBundle(contaminated);
+  await assert.rejects(
+    evaluateReceiptBundle({
+      bundlePath: contaminated.bundlePath,
+      root: contaminated.root,
+    }),
+    /control enabled structural context/
+  );
+});
+
+test('projects pre-check failures as explicit skipped evidence', async (t) => {
+  const context = await fixture(t);
+  await mutateReceipt(context, 'ab-control', (value) => {
+    value.terminal_status = 'agent_failure';
+    value.lifecycle = [
+      'workspace_prepared',
+      'agent_started',
+      'agent_terminated',
+      'cleanup_complete',
+    ];
+    value.agent.status = 'failed';
+    value.agent.exit_code = 1;
+    value.checks = [];
+  });
+  const result = await evaluateReceiptBundle({
+    bundlePath: context.bundlePath,
+    root: context.root,
+  });
+  const control = result.manifest.runs.find((run) => run.arm === 'control');
+  assert.equal(control.outcome.status, 'agent_failed');
+  assert.ok(control.outcome.checks.every((check) => check.status === 'skipped'));
+});
+
+test('CLI writes a separate derived score and reports errors without partial output', async (t) => {
+  const context = await fixture(t);
+  const outputPath = join(context.root, 'derived', 'score.json');
+  const result = await runEvaluationCli([
+    '--bundle',
+    context.bundlePath,
+    '--root',
+    context.root,
+    '--out',
+    outputPath,
+    '--json',
+  ]);
+  assert.equal(result.exitCode, 0);
+  assert.deepEqual(JSON.parse(result.output), result.score);
+  assert.deepEqual(JSON.parse(await readFile(outputPath, 'utf8')), result.score);
+
+  const rejectedPath = join(context.root, 'derived', 'rejected.json');
+  context.bundle.runs[1].execution_order = 1;
+  await rewriteBundle(context);
+  const rejected = await runEvaluationCli([
+    '--bundle',
+    context.bundlePath,
+    '--root',
+    context.root,
+    '--out',
+    rejectedPath,
+    '--json',
+  ]);
+  assert.equal(rejected.exitCode, 2);
+  assert.match(JSON.parse(rejected.output).error, /same execution order/);
+  await assert.rejects(readFile(rejectedPath), /ENOENT/);
+});

--- a/scripts/agent-task-corpus/qualify-task.mjs
+++ b/scripts/agent-task-corpus/qualify-task.mjs
@@ -122,6 +122,7 @@ export async function loadTaskPackage(root, taskId) {
   return {
     taskId,
     taskRoot,
+    manifest,
     fixture: fixture.value,
     acceptance: acceptance.value,
     knownGood: knownGood.value,
@@ -132,6 +133,7 @@ export async function loadTaskPackage(root, taskId) {
       fixture: fixture.sha256,
       acceptance: acceptance.sha256,
       knownGood: knownGood.sha256,
+      taskPacket: manifest.artifacts.task_packet.sha256,
     },
   };
 }

--- a/scripts/run-structural-context-evaluation.mjs
+++ b/scripts/run-structural-context-evaluation.mjs
@@ -10,9 +10,20 @@ const MAX_RUNS = 5_000;
 const MAX_ITEMS = 1_000;
 const MAX_TEXT = 2_000;
 const HASH = /^[0-9a-f]{64}$/;
-const RUN_STATUSES = new Set(['completed', 'setup_failed', 'agent_failed', 'timed_out']);
+const REVISION = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/;
+const RUN_STATUSES = new Set([
+  'completed',
+  'setup_failed',
+  'agent_failed',
+  'timed_out',
+  'cancelled',
+  'check_error',
+  'cleanup_failure',
+]);
 const CHECK_STATUSES = new Set(['pass', 'fail', 'error', 'skipped']);
 const GRAPH_TOOL_PREFIXES = ['graph_', 'structural_graph_'];
+
+export const STRUCTURAL_CONTEXT_SCORER_VERSION = 'codevetter.structural-context.v1';
 
 function parseArgs(argv) {
   const positional = argv.find((argument) => !argument.startsWith('--'));
@@ -43,11 +54,14 @@ function add(errors, condition, message) {
   if (!condition) errors.push(message);
 }
 
-function stringValue(errors, value, label, { hash = false } = {}) {
+function stringValue(errors, value, label, { hash = false, revision = false } = {}) {
   add(errors, typeof value === 'string' && value.trim().length > 0, `${label} is required`);
   if (typeof value === 'string') {
     add(errors, value.length <= MAX_TEXT, `${label} exceeds ${MAX_TEXT} characters`);
     if (hash) add(errors, HASH.test(value), `${label} must be a lowercase sha256`);
+    if (revision) {
+      add(errors, REVISION.test(value), `${label} must be a lowercase git or sha256 revision`);
+    }
   }
 }
 
@@ -135,7 +149,9 @@ function validateTask(errors, task, index, taskIds) {
   }
   stringValue(errors, task.id, `${label}.id`);
   stringValue(errors, task.title, `${label}.title`);
-  stringValue(errors, task.repository_revision, `${label}.repository_revision`, { hash: true });
+  stringValue(errors, task.repository_revision, `${label}.repository_revision`, {
+    revision: true,
+  });
   stringValue(errors, task.task_packet_sha256, `${label}.task_packet_sha256`, { hash: true });
   stringValue(errors, task.acceptance_contract_sha256, `${label}.acceptance_contract_sha256`, {
     hash: true,
@@ -201,7 +217,7 @@ function validateRun(errors, run, index, tasks) {
       errors,
       run.identities.repository_revision,
       `${label}.identities.repository_revision`,
-      { hash: true }
+      { revision: true }
     );
     stringValue(
       errors,
@@ -277,7 +293,7 @@ function validateRun(errors, run, index, tasks) {
           errors,
           run.context.graph.indexed_revision,
           `${label}.context.graph.indexed_revision`,
-          { hash: true }
+          { revision: true }
         );
       }
     }

--- a/scripts/run-structural-context-evaluation.test.mjs
+++ b/scripts/run-structural-context-evaluation.test.mjs
@@ -223,7 +223,21 @@ test('manifest validation rejects malformed immutable identities and policies', 
 
   const errors = validateManifest(data);
   assert.ok(
-    errors.some((error) => error.includes('repository_revision must be a lowercase sha256'))
+    errors.some((error) =>
+      error.includes('repository_revision must be a lowercase git or sha256 revision')
+    )
   );
   assert.ok(errors.some((error) => error.includes('minimum_complete_pairs must be at least 1')));
+});
+
+test('manifest validation accepts immutable 40-character git revisions', () => {
+  const data = fixture();
+  const revision = 'a'.repeat(40);
+  data.tasks[0].repository_revision = revision;
+  for (const run of data.runs.filter((entry) => entry.task_id === data.tasks[0].id)) {
+    run.identities.repository_revision = revision;
+    if (run.context.graph) run.context.graph.indexed_revision = revision;
+  }
+
+  assert.deepEqual(validateManifest(data), []);
 });


### PR DESCRIPTION
## Summary
- add closed evaluation-bundle and derived-score contracts for immutable v2 runner receipts
- project validated receipt evidence into the existing structural-context scorer and reject incomplete, drifted, stale, contaminated, or misordered pairs before export
- keep raw receipts separate and stamp deterministic scores with scorer, bundle, corpus, ground-truth, projection, and receipt identities
- document and archive the spec-driven change

## Validation
- `pnpm run test:corpus-contracts` (35 passing)
- `pnpm run test:benchmark` (28 passing)
- `pnpm run test:automation` (6 passing)
- repository Biome check (pass; pre-existing warnings only)
- `node scripts/check-docs.mjs` (74 files)
- `pnpm run corpus:validate --json` (valid; intentionally not publishable)
- `openspec validate --all --strict` (41 passing)
- `git diff --check`

## Boundaries
- synthetic receipt proof only
- no model/provider launch, paid run, hidden-check execution, network request, deployment, or production change

Refs #53