### PR TITLE
feat: add qualified agent task seed cohort

### DIFF
--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -38,6 +38,16 @@ Internal (fleet):
 
 ## Timeline
 
+- **2026-07-31 — Eight-category qualified agent-task seeds:** expanded the
+  owned corpus from one to eight deterministic tasks covering browser state,
+  authorization, API contracts, validation, concurrency, persistence,
+  integration, and regression behavior across browser/API lanes and
+  Node/TypeScript runtimes. Every task now has repeated intended baseline
+  failure, repeated regression-free known-good success, immutable receipt
+  linkage, and cleanup proof. Validation reports 8/8 qualified with lane,
+  runtime, and category gates green; publication remains correctly closed on
+  the 30-task minimum. These are compact synthetic seeds, not real-agent or
+  product-value evidence.
 - **2026-07-31 — Immutable receipt-to-evaluator composition:** added a closed
   local evaluation bundle that binds corpus, task revision, adapter, raw v2
   receipt, pair/order, and structural-context identities. A dependency-free

--- a/benchmarks/agent-tasks/sample/corpus.json
+++ b/benchmarks/agent-tasks/sample/corpus.json
@@ -1,17 +1,94 @@
 {
   "schema_version": "codevetter.agent-task-corpus.v1",
   "corpus_id": "codevetter-agent-task-contract-sample",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "tasks": [
+    {
+      "task_id": "enforce-tenant-resource-access",
+      "manifest": {
+        "path": "tasks/enforce-tenant-resource-access/task.json",
+        "sha256": "a597d5021ec163d8a18721f1abd949c5b8e100cc47d2cdffc01bc40174e73762"
+      },
+      "qualification": {
+        "path": "qualifications/enforce-tenant-resource-access.json",
+        "sha256": "9a3396a6c4eb0b59638772d50b2bb08c9f7782f1cade7b5aa38c0afd66a49c0b"
+      }
+    },
+    {
+      "task_id": "forward-integration-abort-signal",
+      "manifest": {
+        "path": "tasks/forward-integration-abort-signal/task.json",
+        "sha256": "7a6cf7e15bace9648be2401294431fa5bcbe3332f297410f76fcaf4cef62a32b"
+      },
+      "qualification": {
+        "path": "qualifications/forward-integration-abort-signal.json",
+        "sha256": "39731d1495b9d7ac3245579c07e7395324b87f9b3d83332228df7bef388bcd36"
+      }
+    },
     {
       "task_id": "preserve-explicit-false",
       "manifest": {
         "path": "tasks/preserve-explicit-false/task.json",
-        "sha256": "650229cec888569d5a0d6823b7dc1619f7f214bde8b66d4f9695d5fcb6844b08"
+        "sha256": "9dc4ab47e44f70c03cfadf3f18b8650b5381918d0dcd96a16107ec9402adc413"
       },
       "qualification": {
         "path": "qualification.json",
-        "sha256": "80c12293033d3e24023c885e164a7df4b24d5c4dd3604ded98cabe091a1b2ac2"
+        "sha256": "c17aca7559dd26c238c301180ceb05d86247347667e1746c8e0665019043c07b"
+      }
+    },
+    {
+      "task_id": "preserve-upstream-http-status",
+      "manifest": {
+        "path": "tasks/preserve-upstream-http-status/task.json",
+        "sha256": "923c207c42065b733ae00e770164731e601156a34b56181a812faf22e0a8f71b"
+      },
+      "qualification": {
+        "path": "qualifications/preserve-upstream-http-status.json",
+        "sha256": "315ae797bc6fcff231241751836e1648567a9b2fdfa5a76b2776aaac13fd7bba"
+      }
+    },
+    {
+      "task_id": "restore-zero-scroll-position",
+      "manifest": {
+        "path": "tasks/restore-zero-scroll-position/task.json",
+        "sha256": "71d5f01cf41e1ae651004c882d2b0e50695b8a1cfaf02aacbdd202e8b72ba35e"
+      },
+      "qualification": {
+        "path": "qualifications/restore-zero-scroll-position.json",
+        "sha256": "6c8f97d4ca1f39ce03b9219b8ada1c393fbb0c834758f397c7d09cc1eba0a3c2"
+      }
+    },
+    {
+      "task_id": "save-settings-after-durable-write",
+      "manifest": {
+        "path": "tasks/save-settings-after-durable-write/task.json",
+        "sha256": "0673b84beccd53fca31cb86f499b84ad0a5bc59ed17a0a4d42d20795ab197638"
+      },
+      "qualification": {
+        "path": "qualifications/save-settings-after-durable-write.json",
+        "sha256": "06289f216a8bac41efcfe8d8d218c53b715d74b71a07232fe8ca13341e1f2f03"
+      }
+    },
+    {
+      "task_id": "share-inflight-profile-load",
+      "manifest": {
+        "path": "tasks/share-inflight-profile-load/task.json",
+        "sha256": "b03c11b278469300fccf40971bf6041f2843b794bd47159540b83205ebbc8542"
+      },
+      "qualification": {
+        "path": "qualifications/share-inflight-profile-load.json",
+        "sha256": "5926322248e066d34961356083e0a9f635e44861a15184c366ed02a0a9ae42ba"
+      }
+    },
+    {
+      "task_id": "sort-suggestions-without-mutation",
+      "manifest": {
+        "path": "tasks/sort-suggestions-without-mutation/task.json",
+        "sha256": "e5812168d8c9443c6630a154d7532d895cdf45a6141cee923447b0dfb430bd09"
+      },
+      "qualification": {
+        "path": "qualifications/sort-suggestions-without-mutation.json",
+        "sha256": "1ed111f4675fe68ae4bda91dd8798d4388ff40f373371b5e4078322672883992"
       }
     }
   ]

--- a/benchmarks/agent-tasks/sample/qualification.json
+++ b/benchmarks/agent-tasks/sample/qualification.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "codevetter.agent-task-qualification.v2",
   "task_id": "preserve-explicit-false",
-  "manifest_sha256": "650229cec888569d5a0d6823b7dc1619f7f214bde8b66d4f9695d5fcb6844b08",
+  "manifest_sha256": "9dc4ab47e44f70c03cfadf3f18b8650b5381918d0dcd96a16107ec9402adc413",
   "fixture_sha256": "7573b5ca83bdc7286cf35693f070d12c6b6bddd99f1f7ef0659986f91d13fa0a",
   "acceptance_contract_sha256": "ad86ac07ef32973d4df25a25b45721b3b32d717466fe5d61f7fe43396da51b81",
   "known_good_sha256": "27a1390fa4048248c610afa469dbf0871c9dd80730116fd5ab9ec8679e2d8b62",

--- a/benchmarks/agent-tasks/sample/qualifications/enforce-tenant-resource-access.json
+++ b/benchmarks/agent-tasks/sample/qualifications/enforce-tenant-resource-access.json
@@ -1,0 +1,46 @@
+{
+  "schema_version": "codevetter.agent-task-qualification.v2",
+  "task_id": "enforce-tenant-resource-access",
+  "manifest_sha256": "a597d5021ec163d8a18721f1abd949c5b8e100cc47d2cdffc01bc40174e73762",
+  "fixture_sha256": "20d489cb7aa8e973097b2b7d0910ab41c6adc083df1f9cf620f3e1f5a23d4ff1",
+  "acceptance_contract_sha256": "1e72d44fbb481e1ddc0e168376d5f32de00f51cb639efab41cd2cb294ac3abe1",
+  "known_good_sha256": "a8782e1629480a170819639872e393af3b8b1aa010cde51f5b9e8c702618d00c",
+  "workspace_policy": "public_fixture_and_task_packet_v1",
+  "qualified": true,
+  "baseline": {
+    "status": "intended_failure",
+    "attempts": [
+      {
+        "attempt": 1,
+        "outcome": "intended_failure",
+        "result_sha256": "3e6d2935c48aa3006b221bd1d33f426bb7515eebfef5d1dc59cc983b768299e5"
+      },
+      {
+        "attempt": 2,
+        "outcome": "intended_failure",
+        "result_sha256": "3e6d2935c48aa3006b221bd1d33f426bb7515eebfef5d1dc59cc983b768299e5"
+      }
+    ]
+  },
+  "known_good": {
+    "status": "pass",
+    "attempts": [
+      {
+        "attempt": 1,
+        "outcome": "pass",
+        "result_sha256": "04219730155d6893e6f3e57bf109f80bbf468bb0c36ed0530eef68fcf5019ac8"
+      },
+      {
+        "attempt": 2,
+        "outcome": "pass",
+        "result_sha256": "04219730155d6893e6f3e57bf109f80bbf468bb0c36ed0530eef68fcf5019ac8"
+      }
+    ]
+  },
+  "cleanup": {
+    "status": "complete"
+  },
+  "limitations": [
+    "Qualification executes trusted corpus check code without an operating-system sandbox."
+  ]
+}

--- a/benchmarks/agent-tasks/sample/qualifications/forward-integration-abort-signal.json
+++ b/benchmarks/agent-tasks/sample/qualifications/forward-integration-abort-signal.json
@@ -1,0 +1,46 @@
+{
+  "schema_version": "codevetter.agent-task-qualification.v2",
+  "task_id": "forward-integration-abort-signal",
+  "manifest_sha256": "7a6cf7e15bace9648be2401294431fa5bcbe3332f297410f76fcaf4cef62a32b",
+  "fixture_sha256": "29f4ef386a1ee6137315d2a4b05babe43dd62d72f53e52ed407f9570e1a7ff97",
+  "acceptance_contract_sha256": "ea773f83d55be7c9398a66e106d974b23fb1ecd66b84e28b08ec877be24a4811",
+  "known_good_sha256": "d94e6e074c3c985154927561f80caa94acbe721cc2dc48dda6d8e3514f4c6178",
+  "workspace_policy": "public_fixture_and_task_packet_v1",
+  "qualified": true,
+  "baseline": {
+    "status": "intended_failure",
+    "attempts": [
+      {
+        "attempt": 1,
+        "outcome": "intended_failure",
+        "result_sha256": "5a245cb9e8e59770e74592c3b70c2b8dd7ad33c30775d46a29384129a4408f97"
+      },
+      {
+        "attempt": 2,
+        "outcome": "intended_failure",
+        "result_sha256": "5a245cb9e8e59770e74592c3b70c2b8dd7ad33c30775d46a29384129a4408f97"
+      }
+    ]
+  },
+  "known_good": {
+    "status": "pass",
+    "attempts": [
+      {
+        "attempt": 1,
+        "outcome": "pass",
+        "result_sha256": "c9224112846d59480f7957cabb1fda006919dad0ffa29d59615ae8d50c242706"
+      },
+      {
+        "attempt": 2,
+        "outcome": "pass",
+        "result_sha256": "c9224112846d59480f7957cabb1fda006919dad0ffa29d59615ae8d50c242706"
+      }
+    ]
+  },
+  "cleanup": {
+    "status": "complete"
+  },
+  "limitations": [
+    "Qualification executes trusted corpus check code without an operating-system sandbox."
+  ]
+}

--- a/benchmarks/agent-tasks/sample/qualifications/preserve-upstream-http-status.json
+++ b/benchmarks/agent-tasks/sample/qualifications/preserve-upstream-http-status.json
@@ -1,0 +1,46 @@
+{
+  "schema_version": "codevetter.agent-task-qualification.v2",
+  "task_id": "preserve-upstream-http-status",
+  "manifest_sha256": "923c207c42065b733ae00e770164731e601156a34b56181a812faf22e0a8f71b",
+  "fixture_sha256": "4f3383cc7b3e96907a3ce47b12e35a529f8e14ed4c63ef86ed65d273e666c46c",
+  "acceptance_contract_sha256": "f406bae46d7e18dbff5a83db9ee0625468da4683f7882b05b3f4ef6f8ac141a7",
+  "known_good_sha256": "896de0d1db769e114997a2001927c4200200628c276a5a10acf3b675ba946800",
+  "workspace_policy": "public_fixture_and_task_packet_v1",
+  "qualified": true,
+  "baseline": {
+    "status": "intended_failure",
+    "attempts": [
+      {
+        "attempt": 1,
+        "outcome": "intended_failure",
+        "result_sha256": "45849b0ed6ba062c9c700d9d89e1e7a626b2e69605565ac3c983f8d5482ccf83"
+      },
+      {
+        "attempt": 2,
+        "outcome": "intended_failure",
+        "result_sha256": "45849b0ed6ba062c9c700d9d89e1e7a626b2e69605565ac3c983f8d5482ccf83"
+      }
+    ]
+  },
+  "known_good": {
+    "status": "pass",
+    "attempts": [
+      {
+        "attempt": 1,
+        "outcome": "pass",
+        "result_sha256": "6b8b7d22cbe4af4111cf86ddd37d0a05925815c5fe675b12358f9119be817c66"
+      },
+      {
+        "attempt": 2,
+        "outcome": "pass",
+        "result_sha256": "6b8b7d22cbe4af4111cf86ddd37d0a05925815c5fe675b12358f9119be817c66"
+      }
+    ]
+  },
+  "cleanup": {
+    "status": "complete"
+  },
+  "limitations": [
+    "Qualification executes trusted corpus check code without an operating-system sandbox."
+  ]
+}

--- a/benchmarks/agent-tasks/sample/qualifications/restore-zero-scroll-position.json
+++ b/benchmarks/agent-tasks/sample/qualifications/restore-zero-scroll-position.json
@@ -1,0 +1,46 @@
+{
+  "schema_version": "codevetter.agent-task-qualification.v2",
+  "task_id": "restore-zero-scroll-position",
+  "manifest_sha256": "71d5f01cf41e1ae651004c882d2b0e50695b8a1cfaf02aacbdd202e8b72ba35e",
+  "fixture_sha256": "40df56eacc4edaed3ac0361557bd7e6381d25669091c328303497e4e771f0d85",
+  "acceptance_contract_sha256": "ae760bcd3629a2e9d8105e440f0327b8809239e6475b8e44f1dd1e44d6247038",
+  "known_good_sha256": "69086544f528a9d9e1240e3844373c6405caf6a36edd4c1d5637a09b0b474c82",
+  "workspace_policy": "public_fixture_and_task_packet_v1",
+  "qualified": true,
+  "baseline": {
+    "status": "intended_failure",
+    "attempts": [
+      {
+        "attempt": 1,
+        "outcome": "intended_failure",
+        "result_sha256": "3245f9cca741c43bca343732e91b81cd1c2e9700e013e6427b10de1de4932442"
+      },
+      {
+        "attempt": 2,
+        "outcome": "intended_failure",
+        "result_sha256": "3245f9cca741c43bca343732e91b81cd1c2e9700e013e6427b10de1de4932442"
+      }
+    ]
+  },
+  "known_good": {
+    "status": "pass",
+    "attempts": [
+      {
+        "attempt": 1,
+        "outcome": "pass",
+        "result_sha256": "0b663d081aff79b87b2f321c591dadb9b44f8071b443bdedd02fd3fc6c556f4d"
+      },
+      {
+        "attempt": 2,
+        "outcome": "pass",
+        "result_sha256": "0b663d081aff79b87b2f321c591dadb9b44f8071b443bdedd02fd3fc6c556f4d"
+      }
+    ]
+  },
+  "cleanup": {
+    "status": "complete"
+  },
+  "limitations": [
+    "Qualification executes trusted corpus check code without an operating-system sandbox."
+  ]
+}

--- a/benchmarks/agent-tasks/sample/qualifications/save-settings-after-durable-write.json
+++ b/benchmarks/agent-tasks/sample/qualifications/save-settings-after-durable-write.json
@@ -1,0 +1,46 @@
+{
+  "schema_version": "codevetter.agent-task-qualification.v2",
+  "task_id": "save-settings-after-durable-write",
+  "manifest_sha256": "0673b84beccd53fca31cb86f499b84ad0a5bc59ed17a0a4d42d20795ab197638",
+  "fixture_sha256": "03cfaf623121af3e824df7559f225781a187630b50a23aa2f4d9953961d55bc4",
+  "acceptance_contract_sha256": "9bde1c4b3ec6176664cc08589404e3dddbfef22a44aaaa5f49afc09f4b8a58ad",
+  "known_good_sha256": "ecf9d0a654b8cb57f616ee3f7976b5869a7df73504b7b120bbfa41258a945dd1",
+  "workspace_policy": "public_fixture_and_task_packet_v1",
+  "qualified": true,
+  "baseline": {
+    "status": "intended_failure",
+    "attempts": [
+      {
+        "attempt": 1,
+        "outcome": "intended_failure",
+        "result_sha256": "66bc436fb3aa8dc64a4c7c7749b421d1acce2ab8aa3741d58d25f4fe4a5b054a"
+      },
+      {
+        "attempt": 2,
+        "outcome": "intended_failure",
+        "result_sha256": "66bc436fb3aa8dc64a4c7c7749b421d1acce2ab8aa3741d58d25f4fe4a5b054a"
+      }
+    ]
+  },
+  "known_good": {
+    "status": "pass",
+    "attempts": [
+      {
+        "attempt": 1,
+        "outcome": "pass",
+        "result_sha256": "242b2a1285a77d773e398e71081d22a144ea5d178f3698ef860fe9803e4def52"
+      },
+      {
+        "attempt": 2,
+        "outcome": "pass",
+        "result_sha256": "242b2a1285a77d773e398e71081d22a144ea5d178f3698ef860fe9803e4def52"
+      }
+    ]
+  },
+  "cleanup": {
+    "status": "complete"
+  },
+  "limitations": [
+    "Qualification executes trusted corpus check code without an operating-system sandbox."
+  ]
+}

--- a/benchmarks/agent-tasks/sample/qualifications/share-inflight-profile-load.json
+++ b/benchmarks/agent-tasks/sample/qualifications/share-inflight-profile-load.json
@@ -1,0 +1,46 @@
+{
+  "schema_version": "codevetter.agent-task-qualification.v2",
+  "task_id": "share-inflight-profile-load",
+  "manifest_sha256": "b03c11b278469300fccf40971bf6041f2843b794bd47159540b83205ebbc8542",
+  "fixture_sha256": "05a4f2d4c0b19e26a61116b58002f257081e4ed709697b4c05a60e02a5b262ac",
+  "acceptance_contract_sha256": "f98c7518d45ec395bfec971dfde79b974d9201317da18f782690dd6014554949",
+  "known_good_sha256": "336e6496f35992846a8b97f20f334b208ee3923f72fbaa30bf5000705b417e44",
+  "workspace_policy": "public_fixture_and_task_packet_v1",
+  "qualified": true,
+  "baseline": {
+    "status": "intended_failure",
+    "attempts": [
+      {
+        "attempt": 1,
+        "outcome": "intended_failure",
+        "result_sha256": "961560330cc44491815821a42fc09c231e5f8a6e1b7f102c860cfcf7d5776c3b"
+      },
+      {
+        "attempt": 2,
+        "outcome": "intended_failure",
+        "result_sha256": "961560330cc44491815821a42fc09c231e5f8a6e1b7f102c860cfcf7d5776c3b"
+      }
+    ]
+  },
+  "known_good": {
+    "status": "pass",
+    "attempts": [
+      {
+        "attempt": 1,
+        "outcome": "pass",
+        "result_sha256": "baf0e469309861050b324b8c7b3a111531662a9b85d3059766f82ec7956f08a4"
+      },
+      {
+        "attempt": 2,
+        "outcome": "pass",
+        "result_sha256": "baf0e469309861050b324b8c7b3a111531662a9b85d3059766f82ec7956f08a4"
+      }
+    ]
+  },
+  "cleanup": {
+    "status": "complete"
+  },
+  "limitations": [
+    "Qualification executes trusted corpus check code without an operating-system sandbox."
+  ]
+}

--- a/benchmarks/agent-tasks/sample/qualifications/sort-suggestions-without-mutation.json
+++ b/benchmarks/agent-tasks/sample/qualifications/sort-suggestions-without-mutation.json
@@ -1,0 +1,46 @@
+{
+  "schema_version": "codevetter.agent-task-qualification.v2",
+  "task_id": "sort-suggestions-without-mutation",
+  "manifest_sha256": "e5812168d8c9443c6630a154d7532d895cdf45a6141cee923447b0dfb430bd09",
+  "fixture_sha256": "4270850fb15d9365847020cf2f26e2e70330a81eb16fb209493dd177e8b9ccb0",
+  "acceptance_contract_sha256": "9fb7898e7d5b6fce6c07af72c95829df3220b6ee1f1d3382eea200821342e2ea",
+  "known_good_sha256": "d29cb7d94b30057dcc5764bc4640f2e202a2cd19132715e17047fd1e9a7d2638",
+  "workspace_policy": "public_fixture_and_task_packet_v1",
+  "qualified": true,
+  "baseline": {
+    "status": "intended_failure",
+    "attempts": [
+      {
+        "attempt": 1,
+        "outcome": "intended_failure",
+        "result_sha256": "08c637beff11eee5fa413ff228470cb7774d4904df9a252db2eae87daff290a1"
+      },
+      {
+        "attempt": 2,
+        "outcome": "intended_failure",
+        "result_sha256": "08c637beff11eee5fa413ff228470cb7774d4904df9a252db2eae87daff290a1"
+      }
+    ]
+  },
+  "known_good": {
+    "status": "pass",
+    "attempts": [
+      {
+        "attempt": 1,
+        "outcome": "pass",
+        "result_sha256": "7e6b1c77fc40a078031637404992302664bf675072df8134d83ff5a365ba7cef"
+      },
+      {
+        "attempt": 2,
+        "outcome": "pass",
+        "result_sha256": "7e6b1c77fc40a078031637404992302664bf675072df8134d83ff5a365ba7cef"
+      }
+    ]
+  },
+  "cleanup": {
+    "status": "complete"
+  },
+  "limitations": [
+    "Qualification executes trusted corpus check code without an operating-system sandbox."
+  ]
+}

--- a/benchmarks/agent-tasks/sample/tasks/enforce-tenant-resource-access/acceptance-contract.json
+++ b/benchmarks/agent-tasks/sample/tasks/enforce-tenant-resource-access/acceptance-contract.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": "codevetter.agent-task-acceptance.v1",
+  "task_id": "enforce-tenant-resource-access",
+  "task_defining_failures": ["cross-tenant-owner-denied"],
+  "required_checks": [
+    {
+      "id": "cross-tenant-owner-denied",
+      "label": "A matching owner ID from another tenant is denied"
+    }
+  ],
+  "regression_checks": [
+    {
+      "id": "same-tenant-admin-allowed",
+      "label": "A same-tenant administrator remains allowed"
+    },
+    {
+      "id": "same-tenant-owner-allowed",
+      "label": "A same-tenant owner remains allowed"
+    }
+  ],
+  "driver": {
+    "path": "checks.mjs",
+    "sha256": "2c47f00dc82350b04b8e4ea9917e1d808d96d26aaedeba5c34567f17a58b4eab",
+    "timeout_ms": 5000
+  },
+  "repetitions": 2
+}

--- a/benchmarks/agent-tasks/sample/tasks/enforce-tenant-resource-access/checks.mjs
+++ b/benchmarks/agent-tasks/sample/tasks/enforce-tenant-resource-access/checks.mjs
@@ -1,0 +1,35 @@
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const [workspace, taskId, acceptanceSha256, phase, attempt] = process.argv.slice(2);
+const moduleUrl = pathToFileURL(join(workspace, 'access.ts'));
+moduleUrl.searchParams.set('qualification', `${phase}-${attempt}`);
+const { canAccess } = await import(moduleUrl.href);
+
+const crossTenant = canAccess(
+  { id: 'user-1', tenantId: 'tenant-a', role: 'member' },
+  { ownerId: 'user-1', tenantId: 'tenant-b' }
+);
+const sameTenantOwner = canAccess(
+  { id: 'user-1', tenantId: 'tenant-a', role: 'member' },
+  { ownerId: 'user-1', tenantId: 'tenant-a' }
+);
+const sameTenantAdmin = canAccess(
+  { id: 'admin-1', tenantId: 'tenant-a', role: 'admin' },
+  { ownerId: 'user-2', tenantId: 'tenant-a' }
+);
+
+const results = [
+  { id: 'cross-tenant-owner-denied', status: crossTenant === false ? 'pass' : 'fail' },
+  { id: 'same-tenant-admin-allowed', status: sameTenantAdmin === true ? 'pass' : 'fail' },
+  { id: 'same-tenant-owner-allowed', status: sameTenantOwner === true ? 'pass' : 'fail' },
+];
+
+process.stdout.write(
+  JSON.stringify({
+    schema_version: 'codevetter.agent-task-check-result.v1',
+    task_id: taskId,
+    acceptance_contract_sha256: acceptanceSha256,
+    results,
+  })
+);

--- a/benchmarks/agent-tasks/sample/tasks/enforce-tenant-resource-access/fixture.json
+++ b/benchmarks/agent-tasks/sample/tasks/enforce-tenant-resource-access/fixture.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "codevetter.agent-task-fixture.v1",
+  "files": [
+    {
+      "path": "access.ts",
+      "content_base64": "ZXhwb3J0IGludGVyZmFjZSBVc2VyIHsKICBpZDogc3RyaW5nOwogIHRlbmFudElkOiBzdHJpbmc7CiAgcm9sZTogJ2FkbWluJyB8ICdtZW1iZXInOwp9CgpleHBvcnQgaW50ZXJmYWNlIFJlc291cmNlIHsKICBvd25lcklkOiBzdHJpbmc7CiAgdGVuYW50SWQ6IHN0cmluZzsKfQoKZXhwb3J0IGZ1bmN0aW9uIGNhbkFjY2Vzcyh1c2VyOiBVc2VyLCByZXNvdXJjZTogUmVzb3VyY2UpOiBib29sZWFuIHsKICByZXR1cm4gdXNlci5yb2xlID09PSAnYWRtaW4nIHx8IHJlc291cmNlLm93bmVySWQgPT09IHVzZXIuaWQ7Cn0K",
+      "sha256": "4c2615bab1a4150bfb80e8ada9db7d7a5b940224bea03f69fa7073d2da2689bc"
+    }
+  ]
+}

--- a/benchmarks/agent-tasks/sample/tasks/enforce-tenant-resource-access/known-good.json
+++ b/benchmarks/agent-tasks/sample/tasks/enforce-tenant-resource-access/known-good.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "codevetter.agent-task-known-good.v1",
+  "task_id": "enforce-tenant-resource-access",
+  "files": [
+    {
+      "path": "access.ts",
+      "before_sha256": "4c2615bab1a4150bfb80e8ada9db7d7a5b940224bea03f69fa7073d2da2689bc",
+      "after_base64": "ZXhwb3J0IGludGVyZmFjZSBVc2VyIHsKICBpZDogc3RyaW5nOwogIHRlbmFudElkOiBzdHJpbmc7CiAgcm9sZTogJ2FkbWluJyB8ICdtZW1iZXInOwp9CgpleHBvcnQgaW50ZXJmYWNlIFJlc291cmNlIHsKICBvd25lcklkOiBzdHJpbmc7CiAgdGVuYW50SWQ6IHN0cmluZzsKfQoKZXhwb3J0IGZ1bmN0aW9uIGNhbkFjY2Vzcyh1c2VyOiBVc2VyLCByZXNvdXJjZTogUmVzb3VyY2UpOiBib29sZWFuIHsKICByZXR1cm4gKAogICAgdXNlci50ZW5hbnRJZCA9PT0gcmVzb3VyY2UudGVuYW50SWQgJiYKICAgICh1c2VyLnJvbGUgPT09ICdhZG1pbicgfHwgcmVzb3VyY2Uub3duZXJJZCA9PT0gdXNlci5pZCkKICApOwp9Cg==",
+      "after_sha256": "3b973ca26e41247631d5ca9ca6d61744fd878e7ac92bcd825b61631fe7b6db94"
+    }
+  ]
+}

--- a/benchmarks/agent-tasks/sample/tasks/enforce-tenant-resource-access/task.json
+++ b/benchmarks/agent-tasks/sample/tasks/enforce-tenant-resource-access/task.json
@@ -1,0 +1,38 @@
+{
+  "schema_version": "codevetter.agent-task.v1",
+  "task_id": "enforce-tenant-resource-access",
+  "title": "Enforce tenant boundaries for owned resources",
+  "lane": "api",
+  "runtime": "typescript",
+  "category": "authorization",
+  "failure_mode": "cross-tenant-ownership",
+  "artifacts": {
+    "fixture": {
+      "path": "fixture.json",
+      "sha256": "20d489cb7aa8e973097b2b7d0910ab41c6adc083df1f9cf620f3e1f5a23d4ff1"
+    },
+    "task_packet": {
+      "path": "task.md",
+      "sha256": "480ee7466d16975dc162198ede9f7c8bbef7d66906638e7f1d39c46b265a0416"
+    },
+    "acceptance_contract": {
+      "path": "acceptance-contract.json",
+      "sha256": "1e72d44fbb481e1ddc0e168376d5f32de00f51cb639efab41cd2cb294ac3abe1"
+    },
+    "known_good_patch": {
+      "path": "known-good.json",
+      "sha256": "a8782e1629480a170819639872e393af3b8b1aa010cde51f5b9e8c702618d00c"
+    }
+  },
+  "required_checks": ["cross-tenant-owner-denied"],
+  "regression_checks": ["same-tenant-admin-allowed", "same-tenant-owner-allowed"],
+  "provenance": {
+    "kind": "owned",
+    "repository": "Codevetter/codevetter",
+    "revision": "f7ad9c396883466b50c8123c06823ceb12223d5e"
+  },
+  "license": {
+    "spdx": "ISC",
+    "notice": "Owned synthetic seed fixture; repository license applies."
+  }
+}

--- a/benchmarks/agent-tasks/sample/tasks/enforce-tenant-resource-access/task.md
+++ b/benchmarks/agent-tasks/sample/tasks/enforce-tenant-resource-access/task.md
@@ -1,0 +1,5 @@
+# Enforce tenant boundaries for owned resources
+
+Update the access helper so ownership or administrator status grants access
+only inside the caller's tenant. Preserve same-tenant owner and administrator
+access.

--- a/benchmarks/agent-tasks/sample/tasks/forward-integration-abort-signal/acceptance-contract.json
+++ b/benchmarks/agent-tasks/sample/tasks/forward-integration-abort-signal/acceptance-contract.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": "codevetter.agent-task-acceptance.v1",
+  "task_id": "forward-integration-abort-signal",
+  "task_defining_failures": ["abort-signal-forwarded"],
+  "required_checks": [
+    {
+      "id": "abort-signal-forwarded",
+      "label": "The exact caller abort signal reaches the client"
+    }
+  ],
+  "regression_checks": [
+    {
+      "id": "issue-path-preserved",
+      "label": "The issue request path remains unchanged"
+    },
+    {
+      "id": "response-preserved",
+      "label": "The client response is returned unchanged"
+    }
+  ],
+  "driver": {
+    "path": "checks.mjs",
+    "sha256": "6697376a93e90e1173f744e07896a3d15d8128cf3eca7cf41b0ceac6afd0fdf4",
+    "timeout_ms": 5000
+  },
+  "repetitions": 2
+}

--- a/benchmarks/agent-tasks/sample/tasks/forward-integration-abort-signal/checks.mjs
+++ b/benchmarks/agent-tasks/sample/tasks/forward-integration-abort-signal/checks.mjs
@@ -1,0 +1,38 @@
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const [workspace, taskId, acceptanceSha256, phase, attempt] = process.argv.slice(2);
+const moduleUrl = pathToFileURL(join(workspace, 'issue-client.ts'));
+moduleUrl.searchParams.set('qualification', `${phase}-${attempt}`);
+const { fetchIssue } = await import(moduleUrl.href);
+
+const controller = new AbortController();
+const expected = { id: 42 };
+let capturedPath;
+let capturedOptions;
+const client = {
+  async get(path, options) {
+    capturedPath = path;
+    capturedOptions = options;
+    return expected;
+  },
+};
+const response = await fetchIssue(client, 42, controller.signal);
+
+const results = [
+  {
+    id: 'abort-signal-forwarded',
+    status: capturedOptions?.signal === controller.signal ? 'pass' : 'fail',
+  },
+  { id: 'issue-path-preserved', status: capturedPath === '/issues/42' ? 'pass' : 'fail' },
+  { id: 'response-preserved', status: response === expected ? 'pass' : 'fail' },
+];
+
+process.stdout.write(
+  JSON.stringify({
+    schema_version: 'codevetter.agent-task-check-result.v1',
+    task_id: taskId,
+    acceptance_contract_sha256: acceptanceSha256,
+    results,
+  })
+);

--- a/benchmarks/agent-tasks/sample/tasks/forward-integration-abort-signal/fixture.json
+++ b/benchmarks/agent-tasks/sample/tasks/forward-integration-abort-signal/fixture.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "codevetter.agent-task-fixture.v1",
+  "files": [
+    {
+      "path": "issue-client.ts",
+      "content_base64": "ZXhwb3J0IGludGVyZmFjZSBJc3N1ZUNsaWVudCB7CiAgZ2V0KHBhdGg6IHN0cmluZywgb3B0aW9ucz86IHsgc2lnbmFsPzogQWJvcnRTaWduYWwgfSk6IFByb21pc2U8dW5rbm93bj47Cn0KCmV4cG9ydCBhc3luYyBmdW5jdGlvbiBmZXRjaElzc3VlKAogIGNsaWVudDogSXNzdWVDbGllbnQsCiAgaXNzdWVOdW1iZXI6IG51bWJlciwKICBzaWduYWw6IEFib3J0U2lnbmFsCik6IFByb21pc2U8dW5rbm93bj4gewogIHJldHVybiBjbGllbnQuZ2V0KGAvaXNzdWVzLyR7aXNzdWVOdW1iZXJ9YCk7Cn0K",
+      "sha256": "9a39f03cc88ae7d02daf0f45b226c0f2fe9d592329c2b0a74ad2b4cb6334038e"
+    }
+  ]
+}

--- a/benchmarks/agent-tasks/sample/tasks/forward-integration-abort-signal/known-good.json
+++ b/benchmarks/agent-tasks/sample/tasks/forward-integration-abort-signal/known-good.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "codevetter.agent-task-known-good.v1",
+  "task_id": "forward-integration-abort-signal",
+  "files": [
+    {
+      "path": "issue-client.ts",
+      "before_sha256": "9a39f03cc88ae7d02daf0f45b226c0f2fe9d592329c2b0a74ad2b4cb6334038e",
+      "after_base64": "ZXhwb3J0IGludGVyZmFjZSBJc3N1ZUNsaWVudCB7CiAgZ2V0KHBhdGg6IHN0cmluZywgb3B0aW9ucz86IHsgc2lnbmFsPzogQWJvcnRTaWduYWwgfSk6IFByb21pc2U8dW5rbm93bj47Cn0KCmV4cG9ydCBhc3luYyBmdW5jdGlvbiBmZXRjaElzc3VlKAogIGNsaWVudDogSXNzdWVDbGllbnQsCiAgaXNzdWVOdW1iZXI6IG51bWJlciwKICBzaWduYWw6IEFib3J0U2lnbmFsCik6IFByb21pc2U8dW5rbm93bj4gewogIHJldHVybiBjbGllbnQuZ2V0KGAvaXNzdWVzLyR7aXNzdWVOdW1iZXJ9YCwgeyBzaWduYWwgfSk7Cn0K",
+      "after_sha256": "2bb68eff093d64d227cfb3fc4d0467b6037f31c146ce719210c6f1b02ff45e3d"
+    }
+  ]
+}

--- a/benchmarks/agent-tasks/sample/tasks/forward-integration-abort-signal/task.json
+++ b/benchmarks/agent-tasks/sample/tasks/forward-integration-abort-signal/task.json
@@ -1,0 +1,38 @@
+{
+  "schema_version": "codevetter.agent-task.v1",
+  "task_id": "forward-integration-abort-signal",
+  "title": "Forward cancellation to an integration client",
+  "lane": "api",
+  "runtime": "typescript",
+  "category": "integration",
+  "failure_mode": "dropped-cancellation",
+  "artifacts": {
+    "fixture": {
+      "path": "fixture.json",
+      "sha256": "29f4ef386a1ee6137315d2a4b05babe43dd62d72f53e52ed407f9570e1a7ff97"
+    },
+    "task_packet": {
+      "path": "task.md",
+      "sha256": "8aabc325ec2ec158e21e2c95397c332868b2356898b93a1909f175c4b4161e79"
+    },
+    "acceptance_contract": {
+      "path": "acceptance-contract.json",
+      "sha256": "ea773f83d55be7c9398a66e106d974b23fb1ecd66b84e28b08ec877be24a4811"
+    },
+    "known_good_patch": {
+      "path": "known-good.json",
+      "sha256": "d94e6e074c3c985154927561f80caa94acbe721cc2dc48dda6d8e3514f4c6178"
+    }
+  },
+  "required_checks": ["abort-signal-forwarded"],
+  "regression_checks": ["issue-path-preserved", "response-preserved"],
+  "provenance": {
+    "kind": "owned",
+    "repository": "Codevetter/codevetter",
+    "revision": "f7ad9c396883466b50c8123c06823ceb12223d5e"
+  },
+  "license": {
+    "spdx": "ISC",
+    "notice": "Owned synthetic seed fixture; repository license applies."
+  }
+}

--- a/benchmarks/agent-tasks/sample/tasks/forward-integration-abort-signal/task.md
+++ b/benchmarks/agent-tasks/sample/tasks/forward-integration-abort-signal/task.md
@@ -1,0 +1,4 @@
+# Forward cancellation to an integration client
+
+Update the issue-fetching wrapper so the caller's abort signal reaches the
+underlying integration request. Preserve the issue path and returned response.

--- a/benchmarks/agent-tasks/sample/tasks/preserve-explicit-false/task.json
+++ b/benchmarks/agent-tasks/sample/tasks/preserve-explicit-false/task.json
@@ -13,7 +13,7 @@
     },
     "task_packet": {
       "path": "task.md",
-      "sha256": "59380e44067ef35db2862f5c3fae945ff218cc596d14a0371235743d7b869b2b"
+      "sha256": "b5ab5a3a5527fc5136bca5699c6c6021fc95693bac13b3908eb6d91e9743cc0d"
     },
     "acceptance_contract": {
       "path": "acceptance-contract.json",

--- a/benchmarks/agent-tasks/sample/tasks/preserve-explicit-false/task.md
+++ b/benchmarks/agent-tasks/sample/tasks/preserve-explicit-false/task.md
@@ -3,6 +3,3 @@
 Update the fixture transformer so an explicitly supplied `false` value remains
 false instead of being replaced by the default. Preserve the existing label
 behavior.
-
-This is a contract sample only. No executable fixture or qualification receipt
-is included in this slice.

--- a/benchmarks/agent-tasks/sample/tasks/preserve-upstream-http-status/acceptance-contract.json
+++ b/benchmarks/agent-tasks/sample/tasks/preserve-upstream-http-status/acceptance-contract.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": "codevetter.agent-task-acceptance.v1",
+  "task_id": "preserve-upstream-http-status",
+  "task_defining_failures": ["error-status-preserved"],
+  "required_checks": [
+    {
+      "id": "error-status-preserved",
+      "label": "A non-success upstream status remains unchanged"
+    }
+  ],
+  "regression_checks": [
+    {
+      "id": "body-preserved",
+      "label": "The response body remains unchanged"
+    },
+    {
+      "id": "headers-preserved",
+      "label": "The response headers remain unchanged"
+    }
+  ],
+  "driver": {
+    "path": "checks.mjs",
+    "sha256": "b8609ab31d98e25320960dd109dfa50054136e542ea28aa14bb5d5d8f1a532bf",
+    "timeout_ms": 5000
+  },
+  "repetitions": 2
+}

--- a/benchmarks/agent-tasks/sample/tasks/preserve-upstream-http-status/checks.mjs
+++ b/benchmarks/agent-tasks/sample/tasks/preserve-upstream-http-status/checks.mjs
@@ -1,0 +1,26 @@
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const [workspace, taskId, acceptanceSha256, phase, attempt] = process.argv.slice(2);
+const moduleUrl = pathToFileURL(join(workspace, 'response.mjs'));
+moduleUrl.searchParams.set('qualification', `${phase}-${attempt}`);
+const { normalizeResponse } = await import(moduleUrl.href);
+
+const headers = { 'content-type': 'application/json' };
+const body = { error: 'invalid' };
+const output = normalizeResponse({ status: 422, headers, body });
+
+const results = [
+  { id: 'error-status-preserved', status: output.status === 422 ? 'pass' : 'fail' },
+  { id: 'body-preserved', status: output.body === body ? 'pass' : 'fail' },
+  { id: 'headers-preserved', status: output.headers === headers ? 'pass' : 'fail' },
+];
+
+process.stdout.write(
+  JSON.stringify({
+    schema_version: 'codevetter.agent-task-check-result.v1',
+    task_id: taskId,
+    acceptance_contract_sha256: acceptanceSha256,
+    results,
+  })
+);

--- a/benchmarks/agent-tasks/sample/tasks/preserve-upstream-http-status/fixture.json
+++ b/benchmarks/agent-tasks/sample/tasks/preserve-upstream-http-status/fixture.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "codevetter.agent-task-fixture.v1",
+  "files": [
+    {
+      "path": "response.mjs",
+      "content_base64": "ZXhwb3J0IGZ1bmN0aW9uIG5vcm1hbGl6ZVJlc3BvbnNlKHJlc3BvbnNlKSB7CiAgcmV0dXJuIHsKICAgIHN0YXR1czogMjAwLAogICAgaGVhZGVyczogcmVzcG9uc2UuaGVhZGVycywKICAgIGJvZHk6IHJlc3BvbnNlLmJvZHksCiAgfTsKfQo=",
+      "sha256": "fa2de9c942c3eb7c7c5d69ddd37d18b3b6ccce4e132d34ec5dac3863c3542059"
+    }
+  ]
+}

--- a/benchmarks/agent-tasks/sample/tasks/preserve-upstream-http-status/known-good.json
+++ b/benchmarks/agent-tasks/sample/tasks/preserve-upstream-http-status/known-good.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "codevetter.agent-task-known-good.v1",
+  "task_id": "preserve-upstream-http-status",
+  "files": [
+    {
+      "path": "response.mjs",
+      "before_sha256": "fa2de9c942c3eb7c7c5d69ddd37d18b3b6ccce4e132d34ec5dac3863c3542059",
+      "after_base64": "ZXhwb3J0IGZ1bmN0aW9uIG5vcm1hbGl6ZVJlc3BvbnNlKHJlc3BvbnNlKSB7CiAgcmV0dXJuIHsKICAgIHN0YXR1czogcmVzcG9uc2Uuc3RhdHVzLAogICAgaGVhZGVyczogcmVzcG9uc2UuaGVhZGVycywKICAgIGJvZHk6IHJlc3BvbnNlLmJvZHksCiAgfTsKfQo=",
+      "after_sha256": "3e489270827c8d99c9b866c8cb0537f67761a31b313a2aab54aba34b4a6910b4"
+    }
+  ]
+}

--- a/benchmarks/agent-tasks/sample/tasks/preserve-upstream-http-status/task.json
+++ b/benchmarks/agent-tasks/sample/tasks/preserve-upstream-http-status/task.json
@@ -1,0 +1,38 @@
+{
+  "schema_version": "codevetter.agent-task.v1",
+  "task_id": "preserve-upstream-http-status",
+  "title": "Preserve upstream HTTP response status",
+  "lane": "api",
+  "runtime": "node",
+  "category": "api-contract",
+  "failure_mode": "status-normalization",
+  "artifacts": {
+    "fixture": {
+      "path": "fixture.json",
+      "sha256": "4f3383cc7b3e96907a3ce47b12e35a529f8e14ed4c63ef86ed65d273e666c46c"
+    },
+    "task_packet": {
+      "path": "task.md",
+      "sha256": "d65273c858f1118dae2a1c5e4530f87c18b09aa6d9ad94fe044f6fbc325d47f5"
+    },
+    "acceptance_contract": {
+      "path": "acceptance-contract.json",
+      "sha256": "f406bae46d7e18dbff5a83db9ee0625468da4683f7882b05b3f4ef6f8ac141a7"
+    },
+    "known_good_patch": {
+      "path": "known-good.json",
+      "sha256": "896de0d1db769e114997a2001927c4200200628c276a5a10acf3b675ba946800"
+    }
+  },
+  "required_checks": ["error-status-preserved"],
+  "regression_checks": ["body-preserved", "headers-preserved"],
+  "provenance": {
+    "kind": "owned",
+    "repository": "Codevetter/codevetter",
+    "revision": "f7ad9c396883466b50c8123c06823ceb12223d5e"
+  },
+  "license": {
+    "spdx": "ISC",
+    "notice": "Owned synthetic seed fixture; repository license applies."
+  }
+}

--- a/benchmarks/agent-tasks/sample/tasks/preserve-upstream-http-status/task.md
+++ b/benchmarks/agent-tasks/sample/tasks/preserve-upstream-http-status/task.md
@@ -1,0 +1,4 @@
+# Preserve upstream HTTP response status
+
+Update the response normalizer so non-success upstream statuses are preserved.
+Keep the existing body and header forwarding behavior.

--- a/benchmarks/agent-tasks/sample/tasks/restore-zero-scroll-position/acceptance-contract.json
+++ b/benchmarks/agent-tasks/sample/tasks/restore-zero-scroll-position/acceptance-contract.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": "codevetter.agent-task-acceptance.v1",
+  "task_id": "restore-zero-scroll-position",
+  "task_defining_failures": ["zero-position-restored"],
+  "required_checks": [
+    {
+      "id": "zero-position-restored",
+      "label": "A saved zero position restores to the page top"
+    }
+  ],
+  "regression_checks": [
+    {
+      "id": "missing-position-falls-back",
+      "label": "A missing position keeps the current scroll value"
+    },
+    {
+      "id": "positive-position-restored",
+      "label": "A positive saved position is restored"
+    }
+  ],
+  "driver": {
+    "path": "checks.mjs",
+    "sha256": "1a164d3db20808ae995ca901f0be12c06c8b5ff7c3bebfbc74dd10bf0d5720bd",
+    "timeout_ms": 5000
+  },
+  "repetitions": 2
+}

--- a/benchmarks/agent-tasks/sample/tasks/restore-zero-scroll-position/checks.mjs
+++ b/benchmarks/agent-tasks/sample/tasks/restore-zero-scroll-position/checks.mjs
@@ -1,0 +1,26 @@
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const [workspace, taskId, acceptanceSha256, phase, attempt] = process.argv.slice(2);
+const moduleUrl = pathToFileURL(join(workspace, 'scroll-state.ts'));
+moduleUrl.searchParams.set('qualification', `${phase}-${attempt}`);
+const { restoredScrollY } = await import(moduleUrl.href);
+
+const zero = restoredScrollY({ y: 0 }, 120);
+const positive = restoredScrollY({ y: 48 }, 120);
+const missing = restoredScrollY({ y: null }, 120);
+
+const results = [
+  { id: 'zero-position-restored', status: zero === 0 ? 'pass' : 'fail' },
+  { id: 'missing-position-falls-back', status: missing === 120 ? 'pass' : 'fail' },
+  { id: 'positive-position-restored', status: positive === 48 ? 'pass' : 'fail' },
+];
+
+process.stdout.write(
+  JSON.stringify({
+    schema_version: 'codevetter.agent-task-check-result.v1',
+    task_id: taskId,
+    acceptance_contract_sha256: acceptanceSha256,
+    results,
+  })
+);

--- a/benchmarks/agent-tasks/sample/tasks/restore-zero-scroll-position/fixture.json
+++ b/benchmarks/agent-tasks/sample/tasks/restore-zero-scroll-position/fixture.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "codevetter.agent-task-fixture.v1",
+  "files": [
+    {
+      "path": "scroll-state.ts",
+      "content_base64": "ZXhwb3J0IGludGVyZmFjZSBTY3JvbGxTbmFwc2hvdCB7CiAgeTogbnVtYmVyIHwgbnVsbDsKfQoKZXhwb3J0IGZ1bmN0aW9uIHJlc3RvcmVkU2Nyb2xsWShzbmFwc2hvdDogU2Nyb2xsU25hcHNob3QsIGN1cnJlbnRZOiBudW1iZXIpOiBudW1iZXIgewogIHJldHVybiBzbmFwc2hvdC55IHx8IGN1cnJlbnRZOwp9Cg==",
+      "sha256": "83be3efd06f74ebfb92ad8a29dd51f746dae261e2c605c1f499b60877fe823c2"
+    }
+  ]
+}

--- a/benchmarks/agent-tasks/sample/tasks/restore-zero-scroll-position/known-good.json
+++ b/benchmarks/agent-tasks/sample/tasks/restore-zero-scroll-position/known-good.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "codevetter.agent-task-known-good.v1",
+  "task_id": "restore-zero-scroll-position",
+  "files": [
+    {
+      "path": "scroll-state.ts",
+      "before_sha256": "83be3efd06f74ebfb92ad8a29dd51f746dae261e2c605c1f499b60877fe823c2",
+      "after_base64": "ZXhwb3J0IGludGVyZmFjZSBTY3JvbGxTbmFwc2hvdCB7CiAgeTogbnVtYmVyIHwgbnVsbDsKfQoKZXhwb3J0IGZ1bmN0aW9uIHJlc3RvcmVkU2Nyb2xsWShzbmFwc2hvdDogU2Nyb2xsU25hcHNob3QsIGN1cnJlbnRZOiBudW1iZXIpOiBudW1iZXIgewogIHJldHVybiBzbmFwc2hvdC55ID8/IGN1cnJlbnRZOwp9Cg==",
+      "after_sha256": "54f5ab5a187100503ef5a9eb1afbb2676b26d681b8f40e4366adb00805afd2bd"
+    }
+  ]
+}

--- a/benchmarks/agent-tasks/sample/tasks/restore-zero-scroll-position/task.json
+++ b/benchmarks/agent-tasks/sample/tasks/restore-zero-scroll-position/task.json
@@ -1,0 +1,38 @@
+{
+  "schema_version": "codevetter.agent-task.v1",
+  "task_id": "restore-zero-scroll-position",
+  "title": "Restore an explicit zero scroll position",
+  "lane": "browser",
+  "runtime": "typescript",
+  "category": "browser-state",
+  "failure_mode": "falsy-state-restore",
+  "artifacts": {
+    "fixture": {
+      "path": "fixture.json",
+      "sha256": "40df56eacc4edaed3ac0361557bd7e6381d25669091c328303497e4e771f0d85"
+    },
+    "task_packet": {
+      "path": "task.md",
+      "sha256": "2cd20f6425b170dd380a73090e2dbd17d452f94b30c0f06bab71f953cef184b9"
+    },
+    "acceptance_contract": {
+      "path": "acceptance-contract.json",
+      "sha256": "ae760bcd3629a2e9d8105e440f0327b8809239e6475b8e44f1dd1e44d6247038"
+    },
+    "known_good_patch": {
+      "path": "known-good.json",
+      "sha256": "69086544f528a9d9e1240e3844373c6405caf6a36edd4c1d5637a09b0b474c82"
+    }
+  },
+  "required_checks": ["zero-position-restored"],
+  "regression_checks": ["missing-position-falls-back", "positive-position-restored"],
+  "provenance": {
+    "kind": "owned",
+    "repository": "Codevetter/codevetter",
+    "revision": "f7ad9c396883466b50c8123c06823ceb12223d5e"
+  },
+  "license": {
+    "spdx": "ISC",
+    "notice": "Owned synthetic seed fixture; repository license applies."
+  }
+}

--- a/benchmarks/agent-tasks/sample/tasks/restore-zero-scroll-position/task.md
+++ b/benchmarks/agent-tasks/sample/tasks/restore-zero-scroll-position/task.md
@@ -1,0 +1,5 @@
+# Restore an explicit zero scroll position
+
+Update the browser-state helper so a saved position at the top of the page
+restores to zero. Preserve positive saved positions and fallback behavior when
+no position was saved.

--- a/benchmarks/agent-tasks/sample/tasks/save-settings-after-durable-write/acceptance-contract.json
+++ b/benchmarks/agent-tasks/sample/tasks/save-settings-after-durable-write/acceptance-contract.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": "codevetter.agent-task-acceptance.v1",
+  "task_id": "save-settings-after-durable-write",
+  "task_defining_failures": ["write-completes-before-return"],
+  "required_checks": [
+    {
+      "id": "write-completes-before-return",
+      "label": "Save does not resolve before persistence"
+    }
+  ],
+  "regression_checks": [
+    {
+      "id": "storage-arguments-preserved",
+      "label": "The original storage key and value are forwarded"
+    },
+    {
+      "id": "success-result-preserved",
+      "label": "The success result remains unchanged"
+    }
+  ],
+  "driver": {
+    "path": "checks.mjs",
+    "sha256": "a43cff54e5ea9dbbc01feaf658e4997141b966a7dc90116f68591e6015788e9c",
+    "timeout_ms": 5000
+  },
+  "repetitions": 2
+}

--- a/benchmarks/agent-tasks/sample/tasks/save-settings-after-durable-write/checks.mjs
+++ b/benchmarks/agent-tasks/sample/tasks/save-settings-after-durable-write/checks.mjs
@@ -1,0 +1,54 @@
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const [workspace, taskId, acceptanceSha256, phase, attempt] = process.argv.slice(2);
+const moduleUrl = pathToFileURL(join(workspace, 'settings.mjs'));
+moduleUrl.searchParams.set('qualification', `${phase}-${attempt}`);
+const { saveSettings } = await import(moduleUrl.href);
+
+let resolveWrite;
+const calls = [];
+const store = {
+  set(key, value) {
+    calls.push([key, value]);
+    return new Promise((resolve) => {
+      resolveWrite = resolve;
+    });
+  },
+};
+let settled = false;
+const pending = saveSettings(store, 'theme', { mode: 'dark' }).then((value) => {
+  settled = true;
+  return value;
+});
+await Promise.resolve();
+const settledBeforeWrite = settled;
+resolveWrite();
+const result = await pending;
+
+const results = [
+  {
+    id: 'write-completes-before-return',
+    status: settledBeforeWrite === false ? 'pass' : 'fail',
+  },
+  {
+    id: 'storage-arguments-preserved',
+    status:
+      calls.length === 1 && calls[0][0] === 'theme' && calls[0][1]?.mode === 'dark'
+        ? 'pass'
+        : 'fail',
+  },
+  {
+    id: 'success-result-preserved',
+    status: result?.saved === true ? 'pass' : 'fail',
+  },
+];
+
+process.stdout.write(
+  JSON.stringify({
+    schema_version: 'codevetter.agent-task-check-result.v1',
+    task_id: taskId,
+    acceptance_contract_sha256: acceptanceSha256,
+    results,
+  })
+);

--- a/benchmarks/agent-tasks/sample/tasks/save-settings-after-durable-write/fixture.json
+++ b/benchmarks/agent-tasks/sample/tasks/save-settings-after-durable-write/fixture.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "codevetter.agent-task-fixture.v1",
+  "files": [
+    {
+      "path": "settings.mjs",
+      "content_base64": "ZXhwb3J0IGFzeW5jIGZ1bmN0aW9uIHNhdmVTZXR0aW5ncyhzdG9yZSwga2V5LCB2YWx1ZSkgewogIHN0b3JlLnNldChrZXksIHZhbHVlKTsKICByZXR1cm4geyBzYXZlZDogdHJ1ZSB9Owp9Cg==",
+      "sha256": "4cc3c271f83dc428f2e1902f89b572574b528f37546e4a351ae339b89963a958"
+    }
+  ]
+}

--- a/benchmarks/agent-tasks/sample/tasks/save-settings-after-durable-write/known-good.json
+++ b/benchmarks/agent-tasks/sample/tasks/save-settings-after-durable-write/known-good.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "codevetter.agent-task-known-good.v1",
+  "task_id": "save-settings-after-durable-write",
+  "files": [
+    {
+      "path": "settings.mjs",
+      "before_sha256": "4cc3c271f83dc428f2e1902f89b572574b528f37546e4a351ae339b89963a958",
+      "after_base64": "ZXhwb3J0IGFzeW5jIGZ1bmN0aW9uIHNhdmVTZXR0aW5ncyhzdG9yZSwga2V5LCB2YWx1ZSkgewogIGF3YWl0IHN0b3JlLnNldChrZXksIHZhbHVlKTsKICByZXR1cm4geyBzYXZlZDogdHJ1ZSB9Owp9Cg==",
+      "after_sha256": "890b2d906864f0ee28767e8b85440356cb1b0cd5a506baa93a99a13ae24aedba"
+    }
+  ]
+}

--- a/benchmarks/agent-tasks/sample/tasks/save-settings-after-durable-write/task.json
+++ b/benchmarks/agent-tasks/sample/tasks/save-settings-after-durable-write/task.json
@@ -1,0 +1,38 @@
+{
+  "schema_version": "codevetter.agent-task.v1",
+  "task_id": "save-settings-after-durable-write",
+  "title": "Wait for a durable settings write",
+  "lane": "api",
+  "runtime": "node",
+  "category": "persistence",
+  "failure_mode": "missing-await",
+  "artifacts": {
+    "fixture": {
+      "path": "fixture.json",
+      "sha256": "03cfaf623121af3e824df7559f225781a187630b50a23aa2f4d9953961d55bc4"
+    },
+    "task_packet": {
+      "path": "task.md",
+      "sha256": "35b9150ab4a7f22f9c78c445a85ff5fc0d8e99249bf80a55c52c0be46fd5f7b6"
+    },
+    "acceptance_contract": {
+      "path": "acceptance-contract.json",
+      "sha256": "9bde1c4b3ec6176664cc08589404e3dddbfef22a44aaaa5f49afc09f4b8a58ad"
+    },
+    "known_good_patch": {
+      "path": "known-good.json",
+      "sha256": "ecf9d0a654b8cb57f616ee3f7976b5869a7df73504b7b120bbfa41258a945dd1"
+    }
+  },
+  "required_checks": ["write-completes-before-return"],
+  "regression_checks": ["storage-arguments-preserved", "success-result-preserved"],
+  "provenance": {
+    "kind": "owned",
+    "repository": "Codevetter/codevetter",
+    "revision": "f7ad9c396883466b50c8123c06823ceb12223d5e"
+  },
+  "license": {
+    "spdx": "ISC",
+    "notice": "Owned synthetic seed fixture; repository license applies."
+  }
+}

--- a/benchmarks/agent-tasks/sample/tasks/save-settings-after-durable-write/task.md
+++ b/benchmarks/agent-tasks/sample/tasks/save-settings-after-durable-write/task.md
@@ -1,0 +1,4 @@
+# Wait for a durable settings write
+
+Update the settings save helper so it resolves only after the storage write
+finishes. Preserve the storage arguments and success result.

--- a/benchmarks/agent-tasks/sample/tasks/share-inflight-profile-load/acceptance-contract.json
+++ b/benchmarks/agent-tasks/sample/tasks/share-inflight-profile-load/acceptance-contract.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": "codevetter.agent-task-acceptance.v1",
+  "task_id": "share-inflight-profile-load",
+  "task_defining_failures": ["concurrent-load-shared"],
+  "required_checks": [
+    {
+      "id": "concurrent-load-shared",
+      "label": "Concurrent same-profile requests use one operation"
+    }
+  ],
+  "regression_checks": [
+    {
+      "id": "profile-value-preserved",
+      "label": "The fetched profile value is returned unchanged"
+    },
+    {
+      "id": "settled-load-restarts",
+      "label": "A request after settlement starts a new operation"
+    }
+  ],
+  "driver": {
+    "path": "checks.mjs",
+    "sha256": "c7803e8dc67cd1cae75575c2fe19560be0413f909f5076bd5b994afbbe15a772",
+    "timeout_ms": 5000
+  },
+  "repetitions": 2
+}

--- a/benchmarks/agent-tasks/sample/tasks/share-inflight-profile-load/checks.mjs
+++ b/benchmarks/agent-tasks/sample/tasks/share-inflight-profile-load/checks.mjs
@@ -1,0 +1,44 @@
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const [workspace, taskId, acceptanceSha256, phase, attempt] = process.argv.slice(2);
+const moduleUrl = pathToFileURL(join(workspace, 'profiles.ts'));
+moduleUrl.searchParams.set('qualification', `${phase}-${attempt}`);
+const { loadProfile } = await import(moduleUrl.href);
+
+let calls = 0;
+const fetchProfile = async (id) => {
+  calls += 1;
+  return { id };
+};
+const [first, second] = await Promise.all([
+  loadProfile('profile-1', fetchProfile),
+  loadProfile('profile-1', fetchProfile),
+]);
+const concurrentCalls = calls;
+await Promise.resolve();
+const third = await loadProfile('profile-1', fetchProfile);
+
+const results = [
+  { id: 'concurrent-load-shared', status: concurrentCalls === 1 ? 'pass' : 'fail' },
+  {
+    id: 'profile-value-preserved',
+    status:
+      first?.id === 'profile-1' && second?.id === 'profile-1' && third?.id === 'profile-1'
+        ? 'pass'
+        : 'fail',
+  },
+  {
+    id: 'settled-load-restarts',
+    status: calls === concurrentCalls + 1 ? 'pass' : 'fail',
+  },
+];
+
+process.stdout.write(
+  JSON.stringify({
+    schema_version: 'codevetter.agent-task-check-result.v1',
+    task_id: taskId,
+    acceptance_contract_sha256: acceptanceSha256,
+    results,
+  })
+);

--- a/benchmarks/agent-tasks/sample/tasks/share-inflight-profile-load/fixture.json
+++ b/benchmarks/agent-tasks/sample/tasks/share-inflight-profile-load/fixture.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "codevetter.agent-task-fixture.v1",
+  "files": [
+    {
+      "path": "profiles.ts",
+      "content_base64": "Y29uc3QgaW5GbGlnaHQgPSBuZXcgTWFwPHN0cmluZywgUHJvbWlzZTx1bmtub3duPj4oKTsKCmV4cG9ydCBmdW5jdGlvbiBsb2FkUHJvZmlsZSgKICBpZDogc3RyaW5nLAogIGZldGNoUHJvZmlsZTogKGlkOiBzdHJpbmcpID0+IFByb21pc2U8dW5rbm93bj4KKTogUHJvbWlzZTx1bmtub3duPiB7CiAgY29uc3QgZXhpc3RpbmcgPSBpbkZsaWdodC5nZXQoaWQpOwogIGlmIChleGlzdGluZykgcmV0dXJuIGV4aXN0aW5nOwogIGNvbnN0IHJlcXVlc3QgPSBmZXRjaFByb2ZpbGUoaWQpOwogIGluRmxpZ2h0LnNldChpZCwgcmVxdWVzdCk7CiAgaW5GbGlnaHQuZGVsZXRlKGlkKTsKICByZXR1cm4gcmVxdWVzdDsKfQo=",
+      "sha256": "8ca5731e8c972b90ce6dbec66bc78a871c08b2832d4d13523970ad6f1fddba9e"
+    }
+  ]
+}

--- a/benchmarks/agent-tasks/sample/tasks/share-inflight-profile-load/known-good.json
+++ b/benchmarks/agent-tasks/sample/tasks/share-inflight-profile-load/known-good.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "codevetter.agent-task-known-good.v1",
+  "task_id": "share-inflight-profile-load",
+  "files": [
+    {
+      "path": "profiles.ts",
+      "before_sha256": "8ca5731e8c972b90ce6dbec66bc78a871c08b2832d4d13523970ad6f1fddba9e",
+      "after_base64": "Y29uc3QgaW5GbGlnaHQgPSBuZXcgTWFwPHN0cmluZywgUHJvbWlzZTx1bmtub3duPj4oKTsKCmV4cG9ydCBmdW5jdGlvbiBsb2FkUHJvZmlsZSgKICBpZDogc3RyaW5nLAogIGZldGNoUHJvZmlsZTogKGlkOiBzdHJpbmcpID0+IFByb21pc2U8dW5rbm93bj4KKTogUHJvbWlzZTx1bmtub3duPiB7CiAgY29uc3QgZXhpc3RpbmcgPSBpbkZsaWdodC5nZXQoaWQpOwogIGlmIChleGlzdGluZykgcmV0dXJuIGV4aXN0aW5nOwogIGNvbnN0IHJlcXVlc3QgPSBmZXRjaFByb2ZpbGUoaWQpOwogIGluRmxpZ2h0LnNldChpZCwgcmVxdWVzdCk7CiAgcmVxdWVzdC5maW5hbGx5KCgpID0+IGluRmxpZ2h0LmRlbGV0ZShpZCkpOwogIHJldHVybiByZXF1ZXN0Owp9Cg==",
+      "after_sha256": "0532cd1e5c6f6104fa8c95430a406ca62aea72782e158cc8d908b8020323259f"
+    }
+  ]
+}

--- a/benchmarks/agent-tasks/sample/tasks/share-inflight-profile-load/task.json
+++ b/benchmarks/agent-tasks/sample/tasks/share-inflight-profile-load/task.json
@@ -1,0 +1,38 @@
+{
+  "schema_version": "codevetter.agent-task.v1",
+  "task_id": "share-inflight-profile-load",
+  "title": "Share concurrent in-flight profile loads",
+  "lane": "api",
+  "runtime": "typescript",
+  "category": "concurrency",
+  "failure_mode": "inflight-deduplication",
+  "artifacts": {
+    "fixture": {
+      "path": "fixture.json",
+      "sha256": "05a4f2d4c0b19e26a61116b58002f257081e4ed709697b4c05a60e02a5b262ac"
+    },
+    "task_packet": {
+      "path": "task.md",
+      "sha256": "61251c13485c001aa83823b44a7b05d12cd68c3108bfa26196d2e1dcc41f47cd"
+    },
+    "acceptance_contract": {
+      "path": "acceptance-contract.json",
+      "sha256": "f98c7518d45ec395bfec971dfde79b974d9201317da18f782690dd6014554949"
+    },
+    "known_good_patch": {
+      "path": "known-good.json",
+      "sha256": "336e6496f35992846a8b97f20f334b208ee3923f72fbaa30bf5000705b417e44"
+    }
+  },
+  "required_checks": ["concurrent-load-shared"],
+  "regression_checks": ["profile-value-preserved", "settled-load-restarts"],
+  "provenance": {
+    "kind": "owned",
+    "repository": "Codevetter/codevetter",
+    "revision": "f7ad9c396883466b50c8123c06823ceb12223d5e"
+  },
+  "license": {
+    "spdx": "ISC",
+    "notice": "Owned synthetic seed fixture; repository license applies."
+  }
+}

--- a/benchmarks/agent-tasks/sample/tasks/share-inflight-profile-load/task.md
+++ b/benchmarks/agent-tasks/sample/tasks/share-inflight-profile-load/task.md
@@ -1,0 +1,5 @@
+# Share concurrent in-flight profile loads
+
+Update the profile loader so concurrent requests for the same profile share one
+in-flight operation. Once that operation settles, a later request must start a
+fresh load. Preserve returned profile values.

--- a/benchmarks/agent-tasks/sample/tasks/sort-suggestions-without-mutation/acceptance-contract.json
+++ b/benchmarks/agent-tasks/sample/tasks/sort-suggestions-without-mutation/acceptance-contract.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": "codevetter.agent-task-acceptance.v1",
+  "task_id": "sort-suggestions-without-mutation",
+  "task_defining_failures": ["input-order-preserved"],
+  "required_checks": [
+    {
+      "id": "input-order-preserved",
+      "label": "The caller-owned input order remains unchanged"
+    }
+  ],
+  "regression_checks": [
+    {
+      "id": "descending-order-preserved",
+      "label": "The returned suggestions remain score-sorted"
+    },
+    {
+      "id": "suggestion-identity-preserved",
+      "label": "The original suggestion objects are returned"
+    }
+  ],
+  "driver": {
+    "path": "checks.mjs",
+    "sha256": "7055f5309c86db64ac7af000bbad0a748156836a3f7e234265189aa7aa4dca36",
+    "timeout_ms": 5000
+  },
+  "repetitions": 2
+}

--- a/benchmarks/agent-tasks/sample/tasks/sort-suggestions-without-mutation/checks.mjs
+++ b/benchmarks/agent-tasks/sample/tasks/sort-suggestions-without-mutation/checks.mjs
@@ -1,0 +1,36 @@
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const [workspace, taskId, acceptanceSha256, phase, attempt] = process.argv.slice(2);
+const moduleUrl = pathToFileURL(join(workspace, 'suggestions.mjs'));
+moduleUrl.searchParams.set('qualification', `${phase}-${attempt}`);
+const { sortSuggestions } = await import(moduleUrl.href);
+
+const low = { id: 'low', score: 1 };
+const high = { id: 'high', score: 9 };
+const input = [low, high];
+const output = sortSuggestions(input);
+
+const results = [
+  {
+    id: 'input-order-preserved',
+    status: input[0] === low && input[1] === high ? 'pass' : 'fail',
+  },
+  {
+    id: 'descending-order-preserved',
+    status: output[0] === high && output[1] === low ? 'pass' : 'fail',
+  },
+  {
+    id: 'suggestion-identity-preserved',
+    status: output.includes(low) && output.includes(high) ? 'pass' : 'fail',
+  },
+];
+
+process.stdout.write(
+  JSON.stringify({
+    schema_version: 'codevetter.agent-task-check-result.v1',
+    task_id: taskId,
+    acceptance_contract_sha256: acceptanceSha256,
+    results,
+  })
+);

--- a/benchmarks/agent-tasks/sample/tasks/sort-suggestions-without-mutation/fixture.json
+++ b/benchmarks/agent-tasks/sample/tasks/sort-suggestions-without-mutation/fixture.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "codevetter.agent-task-fixture.v1",
+  "files": [
+    {
+      "path": "suggestions.mjs",
+      "content_base64": "ZXhwb3J0IGZ1bmN0aW9uIHNvcnRTdWdnZXN0aW9ucyhzdWdnZXN0aW9ucykgewogIHJldHVybiBzdWdnZXN0aW9ucy5zb3J0KChsZWZ0LCByaWdodCkgPT4gcmlnaHQuc2NvcmUgLSBsZWZ0LnNjb3JlKTsKfQo=",
+      "sha256": "f14fa59f7227736f424d83eb174701804783b80a2f2c56b798ce18dcc1eef5df"
+    }
+  ]
+}

--- a/benchmarks/agent-tasks/sample/tasks/sort-suggestions-without-mutation/known-good.json
+++ b/benchmarks/agent-tasks/sample/tasks/sort-suggestions-without-mutation/known-good.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "codevetter.agent-task-known-good.v1",
+  "task_id": "sort-suggestions-without-mutation",
+  "files": [
+    {
+      "path": "suggestions.mjs",
+      "before_sha256": "f14fa59f7227736f424d83eb174701804783b80a2f2c56b798ce18dcc1eef5df",
+      "after_base64": "ZXhwb3J0IGZ1bmN0aW9uIHNvcnRTdWdnZXN0aW9ucyhzdWdnZXN0aW9ucykgewogIHJldHVybiBbLi4uc3VnZ2VzdGlvbnNdLnNvcnQoKGxlZnQsIHJpZ2h0KSA9PiByaWdodC5zY29yZSAtIGxlZnQuc2NvcmUpOwp9Cg==",
+      "after_sha256": "7953f06a95d0140f07830fa190cf8af7a8a28ac4bb477e1368ae1e7fa362ec6f"
+    }
+  ]
+}

--- a/benchmarks/agent-tasks/sample/tasks/sort-suggestions-without-mutation/task.json
+++ b/benchmarks/agent-tasks/sample/tasks/sort-suggestions-without-mutation/task.json
@@ -1,0 +1,38 @@
+{
+  "schema_version": "codevetter.agent-task.v1",
+  "task_id": "sort-suggestions-without-mutation",
+  "title": "Sort suggestions without mutating caller state",
+  "lane": "browser",
+  "runtime": "node",
+  "category": "regression",
+  "failure_mode": "input-mutation",
+  "artifacts": {
+    "fixture": {
+      "path": "fixture.json",
+      "sha256": "4270850fb15d9365847020cf2f26e2e70330a81eb16fb209493dd177e8b9ccb0"
+    },
+    "task_packet": {
+      "path": "task.md",
+      "sha256": "e15f70cb9d7039547c8f8b7effcc0ba6bea1678c22fa51374fd9421b2f036e3b"
+    },
+    "acceptance_contract": {
+      "path": "acceptance-contract.json",
+      "sha256": "9fb7898e7d5b6fce6c07af72c95829df3220b6ee1f1d3382eea200821342e2ea"
+    },
+    "known_good_patch": {
+      "path": "known-good.json",
+      "sha256": "d29cb7d94b30057dcc5764bc4640f2e202a2cd19132715e17047fd1e9a7d2638"
+    }
+  },
+  "required_checks": ["input-order-preserved"],
+  "regression_checks": ["descending-order-preserved", "suggestion-identity-preserved"],
+  "provenance": {
+    "kind": "owned",
+    "repository": "Codevetter/codevetter",
+    "revision": "f7ad9c396883466b50c8123c06823ceb12223d5e"
+  },
+  "license": {
+    "spdx": "ISC",
+    "notice": "Owned synthetic seed fixture; repository license applies."
+  }
+}

--- a/benchmarks/agent-tasks/sample/tasks/sort-suggestions-without-mutation/task.md
+++ b/benchmarks/agent-tasks/sample/tasks/sort-suggestions-without-mutation/task.md
@@ -1,0 +1,4 @@
+# Sort suggestions without mutating caller state
+
+Update the suggestion sorter so it does not mutate the array owned by browser
+state. Preserve descending score order and the original suggestion objects.

--- a/docs/development/agent-task-corpus.md
+++ b/docs/development/agent-task-corpus.md
@@ -13,9 +13,10 @@ task packages inspectable and immutable, proves their baseline failure and
 known-good success, and gates one disposable adapter attempt behind a
 deterministic plan and explicit approval.
 
-The current owned sample is qualified through the real local path. It proves
-the machinery, not product value: one synthetic task remains far below corpus
-readiness.
+The current owned seed cohort is qualified through the real local path. It
+proves the machinery across eight failure categories, both lanes, and both
+runtimes, not product value: eight compact synthetic tasks remain below the
+30-task publication gate.
 
 ## Commands
 
@@ -98,6 +99,7 @@ benchmarks/agent-tasks/
     │   └── synthetic-false-fix.mjs
     ├── corpus.json
     ├── qualification.json
+    ├── qualifications/<task-id>.json
     └── tasks/<task-id>/
         ├── task.json
         ├── fixture.json
@@ -138,6 +140,44 @@ task definition. Strict readiness counts a task only when the receipt:
 V1 receipts remain readable. V2 additionally binds the fixture, acceptance
 contract, known-good change, public-input workspace policy, ordered attempt
 outcomes/result identities, and cleanup result.
+
+## Current owned seed snapshot
+
+Corpus version `0.2.0` has index identity
+`0b8466bfd8b2fce67e1e824dabaf5f89c9cf631f4a4eeaf4be131d2294e9bc95`.
+It contains eight structurally valid and qualified tasks:
+
+| Task | Category | Lane | Runtime |
+|---|---|---|---|
+| `enforce-tenant-resource-access` | authorization | API | TypeScript |
+| `forward-integration-abort-signal` | integration | API | TypeScript |
+| `preserve-explicit-false` | validation | API | Node |
+| `preserve-upstream-http-status` | API contract | API | Node |
+| `restore-zero-scroll-position` | browser state | browser | TypeScript |
+| `save-settings-after-durable-write` | persistence | API | Node |
+| `share-inflight-profile-load` | async/concurrency | API | TypeScript |
+| `sort-suggestions-without-mutation` | regression behavior | browser | Node |
+
+Every checked-in receipt can be reproduced from the exact task bytes:
+
+```bash
+for task in \
+  enforce-tenant-resource-access \
+  forward-integration-abort-signal \
+  preserve-explicit-false \
+  preserve-upstream-http-status \
+  restore-zero-scroll-position \
+  save-settings-after-durable-write \
+  share-inflight-profile-load \
+  sort-suggestions-without-mutation
+do
+  pnpm corpus:qualify --task "$task" --json
+done
+```
+
+The qualification, lane, runtime, and category gates pass. The task-count gate
+reports `8/30`, so `corpus:readiness` remains non-zero and
+`publishable: false`.
 
 ## Qualification boundary
 
@@ -209,6 +249,12 @@ inventory as `skipped`, never as fabricated passes or failures.
 - Include SPDX and human-readable license/notice metadata.
 - Keep externally observable acceptance behavior in the task packet; do not
   use style-only findings as task outcomes.
+- Give each seed at least one task-defining required check and one separate
+  preserved-behavior regression check.
+- Run qualification after any task-owned byte changes, then update the receipt
+  path/hash in `corpus.json`; never hand-author `qualified: true`.
+- Keep owned seeds small and hermetic. Broader repository-derived tasks need
+  immutable provenance, license review, and the same exact qualification proof.
 
 The validator enforces document and artifact size bounds before parsing or
 hashing. It rejects duplicate identities, unsafe paths, non-regular files,
@@ -232,6 +278,10 @@ Receipt evaluation is a separate read-only command and preserves the existing
 structural-context scorer as the only outcome and qualification authority. The
 repository-owned synthetic adapter and composition tests prove lifecycle and
 projection mechanics only; no real provider/model or paid adapter was run.
-Real provider evidence remains a later slice on issue #53. The sample reports
-`1 qualified` and `publishable: false`; task count, browser-lane,
-TypeScript-runtime, and category breadth gates remain closed.
+Real provider evidence remains a later slice on issue #53.
+
+The owned seeds are intentionally compact single-file behavior fixtures. The
+browser lane is DOM-independent and does not prove Chromium integration; the
+cohort does not measure task difficulty, agent success, framework setup, or
+statistical confidence. It reports `8 qualified` and `publishable: false`; only
+the 30–50 task-count gate remains closed.

--- a/openspec/changes/archive/2026-07-31-add-agent-task-seed-cohort/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-31-add-agent-task-seed-cohort/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-31

--- a/openspec/changes/archive/2026-07-31-add-agent-task-seed-cohort/design.md
+++ b/openspec/changes/archive/2026-07-31-add-agent-task-seed-cohort/design.md
@@ -1,0 +1,84 @@
+## Context
+
+The corpus currently has one qualified owned task and a reusable contract,
+qualification, runner, and evaluator pipeline. The seed cohort must reuse those
+boundaries unchanged: public fixture plus `TASK.md` inside the workspace,
+withheld repository-owned check code outside it, and exact known-good
+replacements used only during qualification.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Exercise eight failure categories with behaviorally distinct fixtures.
+- Make each baseline fail for one narrow intended reason while regressions pass.
+- Prove both Node and TypeScript execution and both API and browser lanes.
+- Keep every artifact small enough to audit manually and qualify quickly.
+
+**Non-Goals:**
+
+- Reaching the final 30–50 task publication gate in this slice.
+- Launching an agent or measuring model performance.
+- Using external repositories, licenses, browsers, databases, or networks.
+- Modeling every framework or accepting style-only outcomes.
+
+## Decisions
+
+### Use one focused source file per seed
+
+Each new seed has one implementation file with two or three observable
+behaviors. The task asks for one narrow fix; hidden checks separate the
+task-defining outcome from preserved behavior. This keeps known-good changes
+exact and makes wrong-failure detection useful.
+
+Alternative: copy realistic multi-package repositories. Rejected for the first
+cohort because provenance, setup, and dependency noise would obscure whether
+the corpus mechanics work across categories.
+
+### Use executable TypeScript fixtures without a compiler dependency
+
+TypeScript seeds use `.ts` modules that stay within Node's supported
+erasable-type syntax. The repository-owned driver imports them under the
+declared Node 22+ runtime. This proves TypeScript lane mechanics without adding
+a production or benchmark dependency.
+
+Alternative: transpile with the desktop toolchain. Rejected because it would
+couple corpus qualification to unrelated workspace dependencies.
+
+### Keep browser tasks DOM-independent
+
+The browser-state seed models navigation and state restoration through plain
+data/functions so it is deterministic and hermetic. Its behavior is still
+browser-specific, but qualification does not need Chromium.
+
+Alternative: Playwright qualification. Rejected because the first seed cohort
+should prove semantic coverage before adding a heavier environment.
+
+### Generate receipts through the real qualification CLI
+
+Task artifacts and corpus entries are checked in first without qualification
+references. Each task then runs through the normal two-baseline/two-known-good
+path, and the resulting receipt identity is added to the index. No receipt is
+hand-authored.
+
+Alternative: synthesize qualifying JSON. Rejected because it would not prove
+the fixtures and checks actually behave as declared.
+
+## Risks / Trade-offs
+
+- [Small fixtures are less realistic than full repositories] → Treat them as
+  owned seeds, not final publication evidence; the later expansion must add
+  broader and more integrated tasks.
+- [Node TypeScript support can drift] → Stay inside erasable syntax and run the
+  exact qualification suite in hosted Node 22 CI.
+- [Shared check-driver patterns could hide systematic mistakes] → Give each
+  category distinct behavior and assertions, then retain exact per-task
+  qualification receipts.
+- [Eight tasks satisfy categories but not statistical breadth] → Keep the
+  30-task gate closed and say so in every readiness surface.
+
+## Migration Plan
+
+Additive corpus update only. Existing task and v1/v2 contracts remain
+unchanged. Removing the new index entries and task directories reverts the
+cohort without affecting runner or evaluator compatibility.

--- a/openspec/changes/archive/2026-07-31-add-agent-task-seed-cohort/proposal.md
+++ b/openspec/changes/archive/2026-07-31-add-agent-task-seed-cohort/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+The corpus machinery is complete but currently proves only one synthetic
+validation task, so it cannot yet exercise the failure modes or runtime/lane
+coverage required by issue #53. A small owned seed cohort is the next
+reproducible step before scaling to the 30–50 task publication gate.
+
+## What Changes
+
+- Expand the owned corpus from one to eight qualified tasks covering browser
+  state, authorization, API contracts, validation, async/concurrency,
+  persistence, integration, and regression behavior.
+- Cover both browser and API lanes and both Node and TypeScript runtimes with
+  small realistic multi-behavior fixtures.
+- Give every task an immutable public packet, baseline fixture, withheld exact
+  checks, repeated known-good change, and deterministic qualification receipt.
+- Update corpus identity/counts, contribution and reproduction guidance,
+  limitations, and project status while keeping publication closed below 30
+  qualified tasks.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `agent-task-corpus-contracts`: Establish explicit owned seed-category,
+  lane, runtime, qualification, and unpublishable-readiness behavior for the
+  in-progress corpus.
+
+## Impact
+
+This affects only checked-in benchmark task artifacts, qualification receipts,
+corpus metadata, focused corpus tests, documentation, and project status. It
+adds no dependency, provider call, agent launch, UI, hosted service, CI
+enforcement, deployment, or production behavior.

--- a/openspec/changes/archive/2026-07-31-add-agent-task-seed-cohort/specs/agent-task-corpus-contracts/spec.md
+++ b/openspec/changes/archive/2026-07-31-add-agent-task-seed-cohort/specs/agent-task-corpus-contracts/spec.md
@@ -1,0 +1,32 @@
+## ADDED Requirements
+
+### Requirement: The owned seed cohort spans realistic web-agent failure modes
+Before full publication breadth, the in-progress corpus SHALL contain qualified
+owned seed tasks for browser state, authorization, API contracts, validation,
+async/concurrency, persistence, integration, and regression behavior. The
+cohort MUST include both browser and API lanes and both Node and TypeScript
+runtimes, with exact category and coverage counts reported by normal corpus
+validation.
+
+#### Scenario: Every seed category is present
+- **WHEN** the owned seed corpus is validated
+- **THEN** one or more structurally valid tasks cover each declared seed category and both required lanes and runtimes
+
+#### Scenario: Seed breadth remains below publication count
+- **WHEN** all eight seed categories qualify but fewer than 30 tasks exist
+- **THEN** normal validation reports the exact coverage while strict readiness remains non-zero and `publishable: false`
+
+### Requirement: Seed tasks prove task-defining behavior without regressions
+Every seed task SHALL expose only a public task packet and baseline fixture to
+the agent workspace, SHALL declare at least one task-defining acceptance check
+and one separate regression check, and SHALL bind a minimal known-good change.
+Qualification MUST repeat the intended baseline failure and complete
+regression-free known-good pass before the task counts as qualified.
+
+#### Scenario: An owned seed qualifies
+- **WHEN** its baseline repeatedly fails only the task-defining behavior and its exact known-good change repeatedly passes all checks
+- **THEN** the corpus records an immutable qualified receipt for that task
+
+#### Scenario: A seed passes by weakening another behavior
+- **WHEN** the task-defining check passes but any declared regression check fails
+- **THEN** qualification classifies a regression and the seed does not count as qualified

--- a/openspec/changes/archive/2026-07-31-add-agent-task-seed-cohort/tasks.md
+++ b/openspec/changes/archive/2026-07-31-add-agent-task-seed-cohort/tasks.md
@@ -1,0 +1,17 @@
+## 1. Seed Artifacts
+
+- [x] 1.1 Add browser-state, authorization, and API-contract task packages with exact hidden checks and known-good changes.
+- [x] 1.2 Add concurrency, persistence, integration, and regression task packages with exact hidden checks and known-good changes.
+- [x] 1.3 Update the owned validation seed packet and corpus index for the eight-task cohort.
+
+## 2. Qualification Evidence
+
+- [x] 2.1 Run every seed through repeated baseline and known-good qualification.
+- [x] 2.2 Bind deterministic per-task qualification receipts into the corpus index.
+- [x] 2.3 Add focused assertions for exact category, lane, runtime, qualification, and readiness-gate coverage.
+
+## 3. Documentation And Validation
+
+- [x] 3.1 Document contribution, reproduction, limitations, exact corpus identity, and remaining publication gates.
+- [x] 3.2 Update durable project status with the qualified seed-cohort truth.
+- [x] 3.3 Run corpus tests, all per-task qualification, readiness, lint, docs, strict OpenSpec validation, and diff checks.

--- a/openspec/specs/agent-task-corpus-contracts/spec.md
+++ b/openspec/specs/agent-task-corpus-contracts/spec.md
@@ -101,3 +101,34 @@ make network requests, create qualification receipts, or mutate task content.
 - **WHEN** non-strict validation or strict readiness runs
 - **THEN** no model call, subprocess-backed task check, network request, or
   corpus mutation occurs
+
+### Requirement: The owned seed cohort spans realistic web-agent failure modes
+Before full publication breadth, the in-progress corpus SHALL contain qualified
+owned seed tasks for browser state, authorization, API contracts, validation,
+async/concurrency, persistence, integration, and regression behavior. The
+cohort MUST include both browser and API lanes and both Node and TypeScript
+runtimes, with exact category and coverage counts reported by normal corpus
+validation.
+
+#### Scenario: Every seed category is present
+- **WHEN** the owned seed corpus is validated
+- **THEN** one or more structurally valid tasks cover each declared seed category and both required lanes and runtimes
+
+#### Scenario: Seed breadth remains below publication count
+- **WHEN** all eight seed categories qualify but fewer than 30 tasks exist
+- **THEN** normal validation reports the exact coverage while strict readiness remains non-zero and `publishable: false`
+
+### Requirement: Seed tasks prove task-defining behavior without regressions
+Every seed task SHALL expose only a public task packet and baseline fixture to
+the agent workspace, SHALL declare at least one task-defining acceptance check
+and one separate regression check, and SHALL bind a minimal known-good change.
+Qualification MUST repeat the intended baseline failure and complete
+regression-free known-good pass before the task counts as qualified.
+
+#### Scenario: An owned seed qualifies
+- **WHEN** its baseline repeatedly fails only the task-defining behavior and its exact known-good change repeatedly passes all checks
+- **THEN** the corpus records an immutable qualified receipt for that task
+
+#### Scenario: A seed passes by weakening another behavior
+- **WHEN** the task-defining check passes but any declared regression check fails
+- **THEN** qualification classifies a regression and the seed does not count as qualified

--- a/scripts/agent-task-corpus/qualify-task.test.mjs
+++ b/scripts/agent-task-corpus/qualify-task.test.mjs
@@ -57,6 +57,18 @@ test('qualifies the owned sample deterministically through isolated public input
   assert.equal(first.cleanup.status, 'complete');
 });
 
+test('reproduces every checked-in seed qualification receipt', async () => {
+  const index = JSON.parse(await readFile(resolve(SAMPLE_ROOT, 'corpus.json'), 'utf8'));
+  for (const entry of index.tasks) {
+    const actual = await qualifyTask({ root: SAMPLE_ROOT, taskId: entry.task_id });
+    const expected = JSON.parse(
+      await readFile(resolve(SAMPLE_ROOT, entry.qualification.path), 'utf8')
+    );
+    assert.equal(actual.qualified, true, entry.task_id);
+    assert.deepEqual(actual, expected, entry.task_id);
+  }
+});
+
 test('requalifies a valid task package when its prior receipt is stale', async (t) => {
   const directory = await mkdtemp(join(tmpdir(), 'codevetter-stale-qualification-'));
   t.after(() => rm(directory, { force: true, recursive: true }));

--- a/scripts/agent-task-corpus/run-task.test.mjs
+++ b/scripts/agent-task-corpus/run-task.test.mjs
@@ -52,8 +52,8 @@ test('creates a deterministic non-executing plan with conservative bounds', asyn
 
   assert.deepEqual(second, first);
   assert.match(first.plan_id, /^plan-[a-f0-9]{32}$/);
-  assert.equal(first.filtered_input_bytes, 434);
-  assert.equal(first.estimated_input_tokens, 173);
+  assert.equal(first.filtered_input_bytes, 327);
+  assert.equal(first.estimated_input_tokens, 146);
   assert.equal(first.estimated_max_cost_usd, 0);
   assert.equal(first.approval.launch_required, true);
   assert.equal(first.approval.paid_required, false);

--- a/scripts/agent-task-corpus/validate-corpus.test.mjs
+++ b/scripts/agent-task-corpus/validate-corpus.test.mjs
@@ -33,16 +33,27 @@ test('the owned sample is valid, deterministic, and explicitly not publishable',
   assert.deepEqual(second, first);
   assert.equal(first.valid, true);
   assert.equal(first.publishable, false);
-  assert.deepEqual(first.counts, { categories: 1, qualified_tasks: 1, tasks: 1 });
-  assert.deepEqual(first.coverage.lanes, ['api']);
+  assert.deepEqual(first.counts, { categories: 8, qualified_tasks: 8, tasks: 8 });
+  assert.deepEqual(first.coverage.categories, [
+    'api-contract',
+    'authorization',
+    'browser-state',
+    'concurrency',
+    'integration',
+    'persistence',
+    'regression',
+    'validation',
+  ]);
+  assert.deepEqual(first.coverage.lanes, ['api', 'browser']);
+  assert.deepEqual(first.coverage.runtimes, ['node', 'typescript']);
   assert.deepEqual(
     first.gates.map((gate) => [gate.id, gate.passed]),
     [
       ['task-count', false],
       ['qualification-count', true],
-      ['lane-coverage', false],
-      ['runtime-coverage', false],
-      ['failure-category-count', false],
+      ['lane-coverage', true],
+      ['runtime-coverage', true],
+      ['failure-category-count', true],
     ]
   );
 });


### PR DESCRIPTION
## Summary
- expand the owned corpus from one to eight qualified tasks across browser state, authorization, API contracts, validation, concurrency, persistence, integration, and regression behavior
- cover browser/API lanes and Node/TypeScript runtimes with exact task-defining and regression checks
- reproduce two intended baseline failures and two known-good passes for every checked-in receipt
- record corpus identity, contribution/reproduction rules, limitations, and the still-closed 30-task publication gate

## Validation
- `pnpm run test:corpus-contracts` (36 passing, including all eight receipt reproductions)
- repository Biome check (pass; pre-existing warnings only)
- `node scripts/check-docs.mjs` (74 files)
- `pnpm run corpus:validate --json` (8 valid / 8 qualified; both lanes/runtimes; 8 categories)
- `pnpm run corpus:readiness --json` (expected non-zero; only task-count gate fails at 8/30)
- `openspec validate --all --strict` (41 passing)
- `git diff --check`

## Boundaries
- compact owned synthetic seeds only
- no agent/model/provider launch, paid run, network request, browser process, deployment, or production change

Refs #53