### PR TITLE
fix: consume adapter diagnostics before hidden checks

### DIFF
--- a/docs/development/agent-task-corpus.md
+++ b/docs/development/agent-task-corpus.md
@@ -201,8 +201,9 @@ workspace-relative `diagnostics_path` and writes a bounded closed
 `codevetter.agent-task-diagnostics.v1` document after execution. The runner
 loads it after termination and before hidden checks, rejects missing, unsafe,
 malformed, secret-bearing, unknown, empty, or out-of-bounds declared evidence,
-and never fabricates token, cost, tool, or file counts. Diagnostics are
-activity metadata only; executable checks remain authoritative.
+consumes the sidecar before hidden checks inspect the workspace, and never
+fabricates token, cost, tool, or file counts. Diagnostics are activity metadata
+only; executable checks remain authoritative.
 
 ## Receipt evaluation boundary
 

--- a/scripts/agent-task-corpus/run-task.mjs
+++ b/scripts/agent-task-corpus/run-task.mjs
@@ -175,7 +175,7 @@ export async function executeAgentTask({
       ['exited', 'failed'].includes(agentResult.status)
     ) {
       try {
-        diagnostics = await loadAdapterDiagnostics({
+        diagnostics = await consumeAdapterDiagnostics({
           workspace,
           path: adapter.value.diagnostics_path,
           secretValues: Object.values(declaredEnvironment),
@@ -336,6 +336,17 @@ export async function loadAdapterDiagnostics({ workspace, path, secretValues = [
   for (const field of ['files_inspected', 'files_modified']) {
     if (document[field] !== undefined) diagnostics[field] = [...document[field]];
   }
+  return diagnostics;
+}
+
+async function consumeAdapterDiagnostics(options) {
+  const diagnostics = await loadAdapterDiagnostics(options);
+  const diagnosticsPath = resolveArtifact(
+    options.workspace,
+    options.path,
+    CORPUS_LIMITS.maxDocumentBytes
+  );
+  await rm(diagnosticsPath);
   return diagnostics;
 }
 

--- a/scripts/agent-task-corpus/run-task.test.mjs
+++ b/scripts/agent-task-corpus/run-task.test.mjs
@@ -220,8 +220,11 @@ test('captures declared bounded diagnostics before hidden checks', async (t) => 
         truncated: false,
       };
     },
-    executeDriver: async ({ acceptanceSha256 }) => {
+    executeDriver: async ({ acceptanceSha256, workspace }) => {
       checksStarted = true;
+      await assert.rejects(readFile(join(workspace, 'adapter-diagnostics.json')), {
+        code: 'ENOENT',
+      });
       return passingChecks(acceptanceSha256);
     },
     runIdFactory: () => 'run-with-diagnostics',


### PR DESCRIPTION
## Summary

- consume a valid declared diagnostics sidecar before hidden acceptance checks inspect the workspace
- fail closed if the sidecar cannot be consumed
- add regression coverage and document the isolation boundary

## Why

A real external Codex adapter run for #53 fixed the task but failed the public-inputs-only regression check because adapter-diagnostics.json remained in the disposable task workspace.

## Validation

- pnpm test:corpus-contracts (41 passed)
- pnpm corpus:readiness --json (30/30 publishable)
- Biome on touched files
- git diff --check

No dependency, provider adapter, credentials, UI, network policy, deploy, release, or production configuration changes.