### PR TITLE
Expose verification guides to agent discovery

### DIFF
--- a/apps/landing-page-astro/public/api-ai.json
+++ b/apps/landing-page-astro/public/api-ai.json
@@ -61,6 +61,34 @@
       "description": "Terms for the open-source desktop software"
     },
     {
+      "id": "coding-agent-verification",
+      "url": "https://codevetter.com/coding-agent-verification",
+      "md": "https://codevetter.com/coding-agent-verification.md",
+      "kind": "static",
+      "description": "Category guide to execution-backed coding-agent verification"
+    },
+    {
+      "id": "verify-ai-generated-code",
+      "url": "https://codevetter.com/verify-ai-generated-code",
+      "md": "https://codevetter.com/verify-ai-generated-code.md",
+      "kind": "static",
+      "description": "Practical workflow for verifying AI-generated code"
+    },
+    {
+      "id": "ai-code-review-vs-verification",
+      "url": "https://codevetter.com/ai-code-review-vs-verification",
+      "md": "https://codevetter.com/ai-code-review-vs-verification.md",
+      "kind": "static",
+      "description": "Comparison of static code review and executable verification"
+    },
+    {
+      "id": "verification-evidence-bundle",
+      "url": "https://codevetter.com/verification-evidence-bundle",
+      "md": "https://codevetter.com/verification-evidence-bundle.md",
+      "kind": "static",
+      "description": "Reference for portable verification evidence artifacts"
+    },
+    {
       "id": "docs",
       "url": "https://codevetter.com/docs/",
       "md": "https://codevetter.com/docs.md",

--- a/apps/landing-page-astro/public/llms-full.txt
+++ b/apps/landing-page-astro/public/llms-full.txt
@@ -38,6 +38,13 @@ Engineers evaluating or shipping coding-agent changes who need executable eviden
 - Changelog: https://codevetter.com/changelog — Verified shipped outcomes
 - Privacy: https://codevetter.com/privacy — Local-first data handling
 
+## Verification guides
+
+- Coding-agent verification: https://codevetter.com/coding-agent-verification
+- How to verify AI-generated code: https://codevetter.com/verify-ai-generated-code
+- AI code review vs verification: https://codevetter.com/ai-code-review-vs-verification
+- Verification evidence bundle: https://codevetter.com/verification-evidence-bundle
+
 ## Machine surfaces
 
 - https://codevetter.com/llms.txt
@@ -46,11 +53,15 @@ Engineers evaluating or shipping coding-agent changes who need executable eviden
 - https://codevetter.com/index.md
 - https://codevetter.com/benchmark.md
 - https://codevetter.com/changelog.md
+- https://codevetter.com/coding-agent-verification.md
 - https://codevetter.com/docs.md
 - https://codevetter.com/download.md
 - https://codevetter.com/faq.md
 - https://codevetter.com/privacy.md
 - https://codevetter.com/terms.md
+- https://codevetter.com/ai-code-review-vs-verification.md
+- https://codevetter.com/verification-evidence-bundle.md
+- https://codevetter.com/verify-ai-generated-code.md
 - https://codevetter.com/xray.md
 - https://codevetter.com/sitemap.xml
 - https://codevetter.com/sitemap-index.xml

--- a/apps/landing-page-astro/public/llms.txt
+++ b/apps/landing-page-astro/public/llms.txt
@@ -12,6 +12,13 @@
 - [Changelog](https://codevetter.com/changelog): Verified shipped outcomes
 - [Privacy](https://codevetter.com/privacy): Local-first data handling
 
+## Verification guides
+
+- [Coding-agent verification](https://codevetter.com/coding-agent-verification): Category guide to task, change, execution, evidence, and verdict
+- [How to verify AI-generated code](https://codevetter.com/verify-ai-generated-code): Practical task-to-evidence workflow
+- [AI code review vs verification](https://codevetter.com/ai-code-review-vs-verification): Comparison of static review and executable verification
+- [Verification evidence bundle](https://codevetter.com/verification-evidence-bundle): Reference for portable verification artifacts
+
 ## Machine surfaces
 
 - [Agent catalog](https://codevetter.com/api/ai): JSON inventory of public surfaces

--- a/apps/landing-page-astro/scripts/verify-agent-surfaces.mjs
+++ b/apps/landing-page-astro/scripts/verify-agent-surfaces.mjs
@@ -41,6 +41,7 @@ for (const route of routes) {
 
 const catalog = JSON.parse(fs.readFileSync(path.join(dist, 'api-ai.json'), 'utf8'));
 const surfaces = Array.isArray(catalog.surfaces) ? catalog.surfaces : [];
+const catalogRouteSet = new Set();
 
 for (const surface of surfaces) {
   const id = String(surface?.id ?? 'unnamed');
@@ -54,11 +55,18 @@ for (const surface of surfaces) {
     failures.push(`${id}: catalog route or Markdown target is not same-origin`);
     continue;
   }
+  catalogRouteSet.add(canonicalUrl(route));
   if (!routeSet.has(canonicalUrl(route))) {
     failures.push(`${id}: catalog route is absent from the public sitemap`);
   }
   if (!readableMarkdown(markdown)) {
     failures.push(`${id}: Markdown target is not readable`);
+  }
+}
+
+for (const route of routeSet) {
+  if (!catalogRouteSet.has(route)) {
+    failures.push(`${new URL(route).pathname}: public sitemap route is absent from /api/ai`);
   }
 }
 
@@ -72,5 +80,5 @@ if (failures.length > 0) {
 
 console.log(`PASS ${routes.length}/${routes.length} sitemap routes have readable Markdown`);
 console.log(
-  `PASS ${surfaces.length}/${surfaces.length} API catalog surfaces are same-origin, in the sitemap, and readable`
+  `PASS ${surfaces.length}/${routes.length} API catalog surfaces cover every sitemap route and are readable`
 );


### PR DESCRIPTION
## Summary
- list the four existing verification guides in `llms.txt` and `llms-full.txt`
- add each canonical HTML/Markdown pair to `/api/ai`
- fail the landing agent-surface check when a sitemap route is absent from the catalog

## Validation
- `pnpm --dir apps/landing-page-astro build`
- `node apps/landing-page-astro/scripts/verify-agent-surfaces.mjs` (16/16 sitemap routes; 16/16 catalog surfaces)
- `node scripts/check-docs.mjs`
- `pnpm exec biome check apps/landing-page-astro/scripts/verify-agent-surfaces.mjs`
- `git diff --check`

Closes #83
Parent: sass-maker/fleet-workspace#161