### PR TITLE
ci: allow manual exact-main validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
 jobs:
   lint-and-typecheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds workflow_dispatch to CI so an exact main SHA can be validated when a merge event does not emit Actions checks. The normal push and pull-request gates remain unchanged.\n\nValidation: git diff --check\n\nCloses #87