### PR TITLE
Fix canonical crawl routing and sitemap drift

### DIFF
--- a/apps/landing-page-astro/astro.config.mjs
+++ b/apps/landing-page-astro/astro.config.mjs
@@ -8,8 +8,8 @@ import tailwind from '@tailwindcss/vite';
 // Mirrors the fleet web stack standard (../../../AGENTS.md → "Fleet web
 // stack standard"):
 //   - output: 'static' (no SSR adapter; this is a marketing page)
-//   - build.format: 'directory' so /faq renders as `/faq/index.html`,
-//     served at /faq without a 308 redirect on CF Pages Workers Assets.
+//   - build.format: 'file' so slashless canonical URLs map directly to
+//     `/faq.html` instead of redirecting to `/faq/` on Cloudflare Pages.
 //   - build.inlineStylesheets: 'always' — flat-inline per-page CSS so
 //     the first paint never blocks on an external request.
 //   - Lightning CSS as both transformer and minifier.
@@ -21,7 +21,7 @@ export default defineConfig({
   output: 'static',
   trailingSlash: 'never',
   build: {
-    format: 'directory',
+    format: 'file',
     inlineStylesheets: 'always',
   },
   integrations: [sitemap({ customPages: ['https://codevetter.com/docs/'] })],

--- a/apps/landing-page-astro/public/sitemap.xml
+++ b/apps/landing-page-astro/public/sitemap.xml
@@ -7,6 +7,12 @@
   <url><loc>https://codevetter.com/faq</loc></url>
   <url><loc>https://codevetter.com/privacy</loc></url>
   <url><loc>https://codevetter.com/terms</loc></url>
+  <url><loc>https://codevetter.com/coding-agent-verification</loc></url>
+  <url><loc>https://codevetter.com/verify-ai-generated-code</loc></url>
+  <url><loc>https://codevetter.com/ai-code-review-vs-verification</loc></url>
+  <url><loc>https://codevetter.com/verification-evidence-bundle</loc></url>
+  <url><loc>https://codevetter.com/codevetter-vs-coderabbit</loc></url>
+  <url><loc>https://codevetter.com/codevetter-vs-greptile</loc></url>
   <url><loc>https://codevetter.com/docs/</loc></url>
   <url><loc>https://codevetter.com/xray/</loc></url>
   <url><loc>https://codevetter.com/xray/ts-sql-injection</loc></url>

--- a/apps/landing-page-astro/scripts/verify-agent-surfaces.mjs
+++ b/apps/landing-page-astro/scripts/verify-agent-surfaces.mjs
@@ -28,7 +28,24 @@ function readableMarkdown(value) {
 const sitemap = fs.readFileSync(path.join(dist, 'sitemap-0.xml'), 'utf8');
 const routes = [...sitemap.matchAll(/<loc>\s*([^<]+)\s*<\/loc>/g)].map((match) => match[1]);
 const routeSet = new Set(routes.map(canonicalUrl));
+const submittedSitemap = fs.readFileSync(path.join(dist, 'sitemap.xml'), 'utf8');
+const submittedRoutes = [...submittedSitemap.matchAll(/<loc>\s*([^<]+)\s*<\/loc>/g)].map(
+  (match) => match[1]
+);
+const submittedRouteSet = new Set(submittedRoutes.map(canonicalUrl));
 const failures = [];
+
+for (const route of routeSet) {
+  if (!submittedRouteSet.has(route)) {
+    failures.push(`${new URL(route).pathname}: generated route is absent from /sitemap.xml`);
+  }
+}
+
+for (const route of submittedRouteSet) {
+  if (!routeSet.has(route)) {
+    failures.push(`${new URL(route).pathname}: submitted route is absent from generated sitemap`);
+  }
+}
 
 for (const route of routes) {
   const url = new URL(route);
@@ -71,6 +88,7 @@ for (const route of routeSet) {
 }
 
 if (routes.length === 0) failures.push('public sitemap contains no routes');
+if (submittedRoutes.length === 0) failures.push('/sitemap.xml contains no routes');
 if (surfaces.length === 0) failures.push('/api/ai contains no surfaces');
 
 if (failures.length > 0) {
@@ -79,6 +97,9 @@ if (failures.length > 0) {
 }
 
 console.log(`PASS ${routes.length}/${routes.length} sitemap routes have readable Markdown`);
+console.log(
+  `PASS ${submittedRoutes.length}/${routes.length} submitted sitemap routes match the generated sitemap`
+);
 console.log(
   `PASS ${surfaces.length}/${routes.length} API catalog surfaces cover every sitemap route and are readable`
 );


### PR DESCRIPTION
Closes #91

## What changed
- Build public HTML as files so slashless canonical URLs resolve directly on Cloudflare Pages instead of redirecting to trailing-slash paths.
- Restore the six current search-intent pages missing from the submitted `/sitemap.xml`.
- Make the agent-surface verifier fail when the submitted sitemap, generated sitemap, and `/api/ai` surface catalog drift.

## Verification
- `pnpm --filter @code-reviewer/landing-page-astro build`
- `node apps/landing-page-astro/scripts/verify-agent-surfaces.mjs dist` (18/18 across all three inventories)
- `wrangler pages dev ...`: `/download`, `/coding-agent-verification`, and `/xray/ts-sql-injection` each return 200 with no redirect
- `git diff --check`
- Repository pre-push Biome check passes (four pre-existing warnings remain)

This removes avoidable redirect amplification during crawls; it does not claim a Domain Rating increase.