### PR TITLE
Keep T-Rex version contract release-safe

### DIFF
--- a/apps/desktop/src-tauri/src/bin/codevetter.rs
+++ b/apps/desktop/src-tauri/src/bin/codevetter.rs
@@ -384,7 +384,9 @@ mod tests {
 
     #[test]
     fn output_and_exit_codes_preserve_receipt_meaning() {
-        assert_eq!(app_version(), "1.7.1");
+        let config: serde_json::Value =
+            serde_json::from_str(include_str!("../../tauri.conf.json")).expect("Tauri config");
+        assert_eq!(app_version(), config["version"].as_str().expect("app version"));
         let passed = fixture_receipt(TrexPreviewVerdict::PassedWithLimits);
         let failed = fixture_receipt(TrexPreviewVerdict::Failed);
         let uncertain = fixture_receipt(TrexPreviewVerdict::NoConfidence);


### PR DESCRIPTION
Closes #93

## Root cause
The `v1.7.2` release correctly updated `tauri.conf.json`, but the CLI contract test hard-coded `1.7.1`. Main CI therefore failed after the release and again after unrelated #92.

## Fix
Compare the CLI-reported version to the version parsed from the checked-in Tauri config instead of duplicating a release number in the test. Receipt verdict and exit-code assertions remain unchanged.

## Verification
- `cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml --features browser-agent --bin codevetter` — 3 passed
- `git diff --check`
- Repository pre-push Biome check passes (four pre-existing warnings remain)