### PR TITLE
Align landing deploy checks with file output

### DIFF
--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -47,8 +47,8 @@ jobs:
       - name: Verify required static routes
         run: |
           test -f apps/landing-page-astro/dist/index.html
-          test -f apps/landing-page-astro/dist/privacy/index.html
-          test -f apps/landing-page-astro/dist/download/index.html
+          test -f apps/landing-page-astro/dist/privacy.html
+          test -f apps/landing-page-astro/dist/download.html
           test -f apps/landing-page-astro/dist/sitemap-index.xml
           test -f apps/landing-page-astro/dist/robots.txt
           test -f apps/landing-page-astro/dist/docs/index.html


### PR DESCRIPTION
Follow-up for #91.

The crawler fix changed Astro output from directory files to `.html` files so canonical slashless URLs resolve without redirects. The manual deploy workflow still asserted the old `privacy/index.html` and `download/index.html` paths. Update those two pre-deploy checks to the built `privacy.html` and `download.html` files.

Validation: the landing build from #92 emitted both exact paths; `git diff --check` passes.