### PR TITLE
Keep X-Ray canonical URL slashless

### DIFF
--- a/apps/landing-page-astro/astro.config.mjs
+++ b/apps/landing-page-astro/astro.config.mjs
@@ -24,7 +24,17 @@ export default defineConfig({
     format: 'file',
     inlineStylesheets: 'always',
   },
-  integrations: [sitemap({ customPages: ['https://codevetter.com/docs/'] })],
+  integrations: [
+    sitemap({
+      customPages: ['https://codevetter.com/docs/'],
+      serialize(item) {
+        if (item.url === 'https://codevetter.com/xray/') {
+          item.url = 'https://codevetter.com/xray';
+        }
+        return item;
+      },
+    }),
+  ],
   vite: {
     plugins: [tailwind()],
     css: { transformer: 'lightningcss' },

--- a/apps/landing-page-astro/public/api-ai.json
+++ b/apps/landing-page-astro/public/api-ai.json
@@ -111,7 +111,7 @@
     },
     {
       "id": "xray",
-      "url": "https://codevetter.com/xray/",
+      "url": "https://codevetter.com/xray",
       "md": "https://codevetter.com/xray.md",
       "kind": "static",
       "description": "Public evidence-export examples"

--- a/apps/landing-page-astro/public/sitemap.xml
+++ b/apps/landing-page-astro/public/sitemap.xml
@@ -14,7 +14,7 @@
   <url><loc>https://codevetter.com/codevetter-vs-coderabbit</loc></url>
   <url><loc>https://codevetter.com/codevetter-vs-greptile</loc></url>
   <url><loc>https://codevetter.com/docs/</loc></url>
-  <url><loc>https://codevetter.com/xray/</loc></url>
+  <url><loc>https://codevetter.com/xray</loc></url>
   <url><loc>https://codevetter.com/xray/ts-sql-injection</loc></url>
   <url><loc>https://codevetter.com/xray/go-race-condition</loc></url>
   <url><loc>https://codevetter.com/xray/py-path-traversal</loc></url>

--- a/apps/landing-page-astro/scripts/verify-agent-surfaces.mjs
+++ b/apps/landing-page-astro/scripts/verify-agent-surfaces.mjs
@@ -14,6 +14,11 @@ function canonicalUrl(value) {
   return url.toString();
 }
 
+function isPublishedUrlCanonical(value) {
+  const url = new URL(value, origin);
+  return url.pathname === '/' || url.pathname === '/docs/' || value === canonicalUrl(value);
+}
+
 function localFile(value) {
   const url = new URL(value, origin);
   const pathname = decodeURIComponent(url.pathname).replace(/^\/+/, '');
@@ -34,6 +39,18 @@ const submittedRoutes = [...submittedSitemap.matchAll(/<loc>\s*([^<]+)\s*<\/loc>
 );
 const submittedRouteSet = new Set(submittedRoutes.map(canonicalUrl));
 const failures = [];
+
+for (const route of routes) {
+  if (!isPublishedUrlCanonical(route)) {
+    failures.push(`${new URL(route).pathname}: generated sitemap URL is not canonical`);
+  }
+}
+
+for (const route of submittedRoutes) {
+  if (!isPublishedUrlCanonical(route)) {
+    failures.push(`${new URL(route).pathname}: submitted sitemap URL is not canonical`);
+  }
+}
 
 for (const route of routeSet) {
   if (!submittedRouteSet.has(route)) {
@@ -73,6 +90,9 @@ for (const surface of surfaces) {
     continue;
   }
   catalogRouteSet.add(canonicalUrl(route));
+  if (!isPublishedUrlCanonical(surface.url)) {
+    failures.push(`${id}: catalog URL is not canonical`);
+  }
   if (!routeSet.has(canonicalUrl(route))) {
     failures.push(`${id}: catalog route is absent from the public sitemap`);
   }


### PR DESCRIPTION
## Summary
- emit the X-Ray index as the slashless canonical URL across generated and submitted sitemaps
- align the machine-readable API catalog
- make verification reject non-canonical trailing-slash drift while preserving the root and Blume docs route

## Verification
- `pnpm run build` (landing)
- `node scripts/verify-agent-surfaces.mjs` (18/18)
- targeted Biome check
- local Worker: `/xray` and `/privacy` return 200 without redirects

Partial fix for #91. The issue remains open for the Cloudflare rate-limit rule audit.