### PR TITLE
docs: record performance PR merge status

### DIFF
--- a/docs/knowledge/performance-lab-publication.md
+++ b/docs/knowledge/performance-lab-publication.md
@@ -29,29 +29,32 @@ pull request is not itself evidence that an optimization works.
 
 ## Fleet product pull requests
 
-All PRs below are drafts. They were created from dedicated branches without a
-deployment, migration, production database, hosted-product load test, or paid
-model call.
+Nine PRs below are merged. Three remain open because merge would cross a
+recorded safety or verification boundary. The campaign used dedicated branches
+without a deployment, migration, production database, hosted-product load
+test, or paid model call.
 
 | Product | Pull request | Publication status | Runtime result |
 | --- | --- | --- | --- |
-| Web Playables | [#3](https://github.com/sarthakagrawal927/web-playables/pull/3) | Confirmed | Reusing the already-computed net revenue improved the 50,000-tick workload from 104.190 to 57.964 ms/op, or 44.37%; the shipping recommendation stayed withheld because the retained baseline had only three samples. |
-| Anime List | [#59](https://github.com/Significant-Hobbies/anime-list/pull/59) | Confirmed | Stable bounded ranking improved the 35,000-item workload from 20.575 to 10.386 ms/op, or 49.521%. |
-| Significant Hobbies | [#74](https://github.com/Significant-Hobbies/significanthobbies/pull/74) | Confirmed | Indexed category lookup improved the 35,000-phase workload from 9.116 to 1.810 ms/op, or 80.145%. |
-| App Health | [#34](https://github.com/sass-maker/app-health/pull/34) | Confirmed, small | Reusing the Go response-writer wrapper reduced 30 to 29 allocs/op and 7,361 to 7,334 B/op; latency moved +9.253%, below the recorded rejection threshold. |
-| Email Manager | [#30](https://github.com/Significant-Hobbies/email-manager/pull/30) | Directional | Weekly digest generation measured 16.181 ms/op before the experiment and 7.266/7.534 ms/op afterward, but the original paired capsule was not retained. |
-| Starboard | [#74](https://github.com/Codevetter/starboard/pull/74) | Unverified | The 50,000-row recommendation flow measured 48.167 ms/op. The PR preserves traversal cleanup; two later experiments regressed and were reverted. |
-| LoopTV | [#35](https://github.com/Significant-Hobbies/looptv/pull/35) | Unverified | The 8,760-row Smart Mix flow measured 4.230 ms/op; the PR caches favorite membership and adds a permanent scale guard. |
-| Reader | [#36](https://github.com/Significant-Hobbies/reader/pull/36) | Unverified | RSS parsing measured 8.767 ms/op, but independent profiles disagreed on the source candidate. The PR is a narrow sanitization experiment with markup correctness coverage. |
-| RolePatch | [#47](https://github.com/Significant-Hobbies/rolepatch/pull/47) | Unverified | Two profiles repeated `calculateATSScore` as the owned CPU candidate at 9.345 ms/op; no paired percentage is claimed. |
-| Free AI | [#51](https://github.com/sass-maker/free-ai/pull/51) | Guardrail | Model selection across all 79 models measured 0.016231 ms/op. CodeVetter refused source optimization and the PR adds only a regression guard. |
-| Reddit Insights | [#3](https://github.com/High-Signal-App/research-subreddit/pull/3) | Stacked, unverified | The bounded topic summarizer is based on collector [PR #2](https://github.com/High-Signal-App/research-subreddit/pull/2); no paired speedup is claimed. |
+| Web Playables | [#3](https://github.com/sarthakagrawal927/web-playables/pull/3) | Open · Confirmed | Reusing the already-computed net revenue improved the 50,000-tick workload from 104.190 to 57.964 ms/op, or 44.37%; the shipping recommendation stayed withheld because the retained baseline had only three samples. Merge remains separate because the connected Cloudflare Pages check may publish `main`. |
+| Anime List | [#59](https://github.com/Significant-Hobbies/anime-list/pull/59) | Merged · Confirmed | Stable bounded ranking improved the 35,000-item workload from 20.575 to 10.386 ms/op, or 49.521%. |
+| Significant Hobbies | [#74](https://github.com/Significant-Hobbies/significanthobbies/pull/74) | Merged · Confirmed | Indexed category lookup improved the 35,000-phase workload from 9.116 to 1.810 ms/op, or 80.145%. |
+| App Health | [#34](https://github.com/sass-maker/app-health/pull/34) | Merged · Confirmed, small | Reusing the Go response-writer wrapper reduced 30 to 29 allocs/op and 7,361 to 7,334 B/op; latency moved +9.253%, below the recorded rejection threshold. |
+| Email Manager | [#30](https://github.com/Significant-Hobbies/email-manager/pull/30) | Merged · Directional | Weekly digest generation measured 16.181 ms/op before the experiment and 7.266/7.534 ms/op afterward, but the original paired capsule was not retained. |
+| Starboard | [#74](https://github.com/Codevetter/starboard/pull/74) | Open · Unverified | The 50,000-row recommendation flow measured 48.167 ms/op. All 201 CI tests pass, but the changed branches lowered branch coverage below the required 100%; merge is blocked pending focused tests. |
+| LoopTV | [#35](https://github.com/Significant-Hobbies/looptv/pull/35) | Merged · Unverified | The 8,760-row Smart Mix flow measured 4.230 ms/op; the PR caches favorite membership and adds a permanent scale guard. |
+| Reader | [#36](https://github.com/Significant-Hobbies/reader/pull/36) | Merged · Unverified | RSS parsing measured 8.767 ms/op, but independent profiles disagreed on the source candidate. The PR is a narrow sanitization experiment with markup correctness coverage. |
+| RolePatch | [#47](https://github.com/Significant-Hobbies/rolepatch/pull/47) | Merged · Unverified | Two profiles repeated `calculateATSScore` as the owned CPU candidate at 9.345 ms/op; no paired percentage is claimed. |
+| Free AI | [#51](https://github.com/sass-maker/free-ai/pull/51) | Merged · Guardrail | Model selection across all 79 models measured 0.016231 ms/op. CodeVetter refused source optimization and the PR adds only a regression guard. |
+| Calorie | [#12](https://github.com/Significant-Hobbies/calorie/pull/12) | Merged · Confirmed synthetic stress | A one-pass exercise-history scan improved the 35,000-entry synthetic workload from 1.203 to 0.162 ms/op. The absolute saving was 1.041 ms at that stress input; no typical-user or customer-visible latency claim is made. |
+| Reddit Insights | [#3](https://github.com/High-Signal-App/research-subreddit/pull/3) | Open · Stacked, unverified | The bounded topic summarizer is based on collector [PR #2](https://github.com/High-Signal-App/research-subreddit/pull/2); no paired speedup is claimed and no PR checks are configured. |
 
 The strongest product results are Significant Hobbies, Anime List, and Web
 Playables. App Health is mechanically real but too small to represent the
-product's end game. The remaining drafts are useful reviewable experiments and
-guardrails, not eleven independent claims of proven customer impact. The full
-inactive-project disposition is retained in
+product's end game. Merge status does not upgrade evidence strength: the
+directional, unverified, guardrail, and synthetic-stress entries are not
+independent claims of proven customer impact. The full inactive-project
+disposition is retained in
 [`artifacts/performance/old-local-projects-results-2026-08-09.md`](../../artifacts/performance/old-local-projects-results-2026-08-09.md).
 
 ## External open-source work
@@ -75,8 +78,8 @@ The endpoint exponent fell from 1.644 to 0.897. A representative Markdown
 control moved +2.722%, below the 10% materiality threshold. Marked's complete
 `npm test` passed: 190 unit tests, 1,779 specification tests, ESM/UMD/CJS and
 type builds, lint, and generated-output checks. The PR is open and no longer a
-draft as of this record. Snyk passed; the visible Vercel failure is an external
-contributor authorization requirement, not a repository test failure.
+draft as of this record. Its visible unit, specification, security, and Vercel
+checks pass; upstream maintainers still own the merge decision.
 
 ### qs
 
@@ -88,7 +91,8 @@ measured 41.706 to 23.183 ms/op at 40,000 parameters, or 44.413%, and returned
 
 All 1,045 upstream tests passed with 100% statement and line coverage. The PR
 also documents the two unsafe broader candidates that the correctness suite
-rejected before the final fallback boundary was retained.
+rejected before the final fallback boundary was retained. It is ready for
+review; upstream maintainers still own the merge decision.
 
 ### No upstream PR submitted
 
@@ -105,10 +109,12 @@ the evidence does not justify one.
 
 ## What CodeVetter gained
 
-The implementation and all qualification artifacts are published together in
-[CodeVetter PR #108](https://github.com/Codevetter/codevetter/pull/108). The PR
-is a draft because the runtime, evaluator, campaign, challenge, and receipt
-surfaces deserve architecture review as one coherent system before merge.
+The implementation and all qualification artifacts merged through
+[CodeVetter PR #108](https://github.com/Codevetter/codevetter/pull/108).
+[Follow-up PR #109](https://github.com/Codevetter/codevetter/pull/109) retains
+paired Vitest domain metrics, source-anchors campaign hotspot lines while
+preserving raw coordinates, and records the Calorie evidence boundary. Both
+post-merge CI runs passed the complete desktop, CLI, MCP, and browser pipeline.
 
 The campaign expanded CodeVetter from a one-shot profiler into a bounded local
 optimization laboratory:


### PR DESCRIPTION
## What

- record the nine merged Fleet performance PRs and three still-open product PRs
- add the merged Calorie synthetic stress result with its absolute-impact caveat
- record CodeVetter PRs 108 and 109 as merged and post-merge green
- clarify that Marked and qs remain upstream maintainer decisions

## Why

The publication ledger still described the campaign PRs as drafts after the merge pass. This keeps merge state separate from evidence strength and preserves the explicit blockers for Web Playables, Starboard, and Reddit Insights.

## Checks

- node scripts/check-docs.mjs
- git diff --check

No deployment or production workflow is included.