### PR TITLE
Fix Codex usage accounting and release v1.7.3

### DIFF
--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -1,6 +1,6 @@
 # Project Status
 
-Last updated: 2026-08-07
+Last updated: 2026-08-10
 
 ## Why / What
 
@@ -38,11 +38,27 @@ Internal (fleet):
 
 ## Timeline
 
+- **2026-08-10 (shipped in v1.7.3) — Deterministic Codex usage accounting:**
+  replaced message-prorated and replay-prone Codex totals with timestamped,
+  content-free usage observations; persisted cumulative counter state handles
+  duplicate snapshots, fork inheritance, copied prefixes, resets, and
+  interleaved lineages across incremental reads. Live usage ingestion is
+  independently serialized from archive/FTS maintenance, and Usage exposes
+  freshness and exclusion diagnostics. The revisioned historical repair is
+  fail-closed: readable transcripts reconcile session/model totals from
+  persisted accepted observations inside each transaction, while missing
+  sources retain their prior totals with explicit unrepaired audits. Frozen
+  qualification reconciled 91 readable sessions twice to an identical
+  2,742,608,446 accepted tokens and preserved 1,260 missing sources. Verified
+  with 913 Rust tests, 665 frontend tests plus the 20-scenario live
+  qualification, lint, typecheck, production build, docs, and strict OpenSpec.
+
 - **2026-08-09 — Shared lint baseline:** Adopted the Fleet Ultracite baseline
   for core TypeScript, React, and test code. Explicit compatibility exceptions
   preserve current behavior while 662 files pass with zero diagnostics;
   generated, public, HTML, SVG, Astro, and benchmark artifact surfaces remain
   outside the checked surface.
+
 - **2026-08-07 — Grok billing staleness fix + cache-tier pricing audit (largest
   cost-accuracy fix to date):** `check_live_usage_grok` re-served whatever
   billing snapshot Grok CLI last logged to `~/.grok/logs/unified.jsonl`

--- a/apps/desktop/src-tauri/src/commands/history.rs
+++ b/apps/desktop/src-tauri/src/commands/history.rs
@@ -11,6 +11,7 @@ use std::sync::{LazyLock, Mutex};
 use tauri::{AppHandle, Emitter, Manager, State};
 
 static FULL_INDEX_LOCK: Mutex<()> = Mutex::new(());
+static LIVE_TRANSCRIPT_LOCK: Mutex<()> = Mutex::new(());
 
 pub const LIVE_TRANSCRIPT_INITIAL_DELAY_SECS: u64 = 20;
 pub const LIVE_TRANSCRIPT_INTERVAL_SECS: u64 = 10;
@@ -37,13 +38,48 @@ pub struct LiveSessionEvidencePolicy {
     pub update_event: String,
     pub local_only: bool,
     pub last_full_indexed_at: Option<String>,
+    pub last_usage_observed_at: Option<String>,
+    pub incomplete_codex_sources: i64,
+    pub pending_codex_bytes: i64,
+    pub duplicate_usage_events: i64,
+    pub excluded_usage_events: i64,
 }
 
 pub fn live_session_evidence_policy(
     conn: &rusqlite::Connection,
 ) -> Result<LiveSessionEvidencePolicy, String> {
+    let (last_usage_observed_at, duplicate_usage_events, excluded_usage_events) = conn
+        .query_row(
+            "SELECT MAX(CASE WHEN disposition='accepted' THEN observed_at END),
+                    SUM(CASE WHEN disposition='duplicate' THEN 1 ELSE 0 END),
+                    SUM(CASE WHEN disposition!='accepted' THEN 1 ELSE 0 END)
+             FROM codex_usage_observations",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .unwrap_or((None, 0, 0));
+    let mut incomplete_codex_sources = 0i64;
+    let mut pending_codex_bytes = 0i64;
+    if let Ok(mut statement) = conn.prepare(
+        "SELECT jsonl_path, last_indexed_byte_offset FROM cc_sessions
+         WHERE agent_type='codex' AND jsonl_path IS NOT NULL",
+    ) {
+        if let Ok(rows) = statement.query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+        }) {
+            for (path, offset) in rows.flatten() {
+                if let Ok(metadata) = std::fs::metadata(path) {
+                    let pending = (metadata.len() as i64 - offset).max(0);
+                    if pending > 0 {
+                        incomplete_codex_sources += 1;
+                        pending_codex_bytes += pending;
+                    }
+                }
+            }
+        }
+    }
     Ok(LiveSessionEvidencePolicy {
-        schema_version: 1,
+        schema_version: 2,
         mode: "incremental_jsonl_poll".to_string(),
         supported_incremental_adapters: vec!["claude-code".to_string(), "codex".to_string()],
         incremental_interval_secs: LIVE_TRANSCRIPT_INTERVAL_SECS,
@@ -54,6 +90,11 @@ pub fn live_session_evidence_policy(
         local_only: true,
         last_full_indexed_at: queries::get_preference(conn, "last_indexed_at")
             .map_err(|error| error.to_string())?,
+        last_usage_observed_at,
+        incomplete_codex_sources,
+        pending_codex_bytes,
+        duplicate_usage_events,
+        excluded_usage_events,
     })
 }
 
@@ -201,10 +242,13 @@ fn persist_production_adapter_run(
 pub fn run_full_index_summary_with_conn(
     conn: &rusqlite::Connection,
 ) -> Result<FullIndexSummary, String> {
-    let _index_guard = FULL_INDEX_LOCK
-        .lock()
-        .map_err(|e| format!("full index lock poisoned: {e}"))?;
-    run_full_index_unlocked(conn)
+    let counts = {
+        let _index_guard = FULL_INDEX_LOCK
+            .lock()
+            .map_err(|e| format!("full index lock poisoned: {e}"))?;
+        full_index_impl(conn)?
+    };
+    finish_full_index(conn, counts)
 }
 
 /// Run the full index only if no other full index is active.
@@ -214,15 +258,18 @@ pub fn run_full_index_summary_with_conn(
 pub fn try_run_full_index_summary_with_conn(
     conn: &rusqlite::Connection,
 ) -> Result<Option<FullIndexSummary>, String> {
-    let _index_guard = match FULL_INDEX_LOCK.try_lock() {
-        Ok(guard) => guard,
+    let counts = match FULL_INDEX_LOCK.try_lock() {
+        Ok(_guard) => full_index_impl(conn)?,
         Err(_) => return Ok(None),
     };
-    run_full_index_unlocked(conn).map(Some)
+    finish_full_index(conn, counts).map(Some)
 }
 
-fn run_full_index_unlocked(conn: &rusqlite::Connection) -> Result<FullIndexSummary, String> {
-    let (indexed_sessions, indexed_messages, skipped_sessions) = full_index_impl(conn)?;
+fn finish_full_index(
+    conn: &rusqlite::Connection,
+    counts: (u64, u64, u64),
+) -> Result<FullIndexSummary, String> {
+    let (indexed_sessions, indexed_messages, skipped_sessions) = counts;
     let archive_search_rows_indexed =
         queries::sync_session_message_archive_fts(conn).map_err(|e| e.to_string())?;
 
@@ -268,7 +315,7 @@ fn tail_live_transcript_sessions_inner(
     conn: &rusqlite::Connection,
     discover_new_codex_sessions: bool,
 ) -> Result<TranscriptTailSummary, String> {
-    let _index_guard = match FULL_INDEX_LOCK.try_lock() {
+    let _index_guard = match LIVE_TRANSCRIPT_LOCK.try_lock() {
         Ok(guard) => guard,
         Err(_) => {
             return Ok(TranscriptTailSummary {
@@ -1141,6 +1188,25 @@ fn estimate_cost_with_cache_tiers(
     cache_creation: i64,
     cache_creation_1h: i64,
 ) -> f64 {
+    let cost = estimate_cost_precise(
+        model,
+        total_input,
+        output_tokens,
+        cache_read,
+        cache_creation,
+        cache_creation_1h,
+    );
+    (cost * 100.0).round() / 100.0 // round stored session totals to cents
+}
+
+fn estimate_cost_precise(
+    model: &str,
+    total_input: i64,
+    output_tokens: i64,
+    cache_read: i64,
+    cache_creation: i64,
+    cache_creation_1h: i64,
+) -> f64 {
     let (input_price, output_price, cache_read_price, cache_write_price) = pricing_table(model);
 
     // total_input already includes cache_read + cache_creation tokens (added
@@ -1153,13 +1219,12 @@ fn estimate_cost_with_cache_tiers(
     let cache_creation_1h = cache_creation_1h.clamp(0, cache_creation.max(0));
     let cache_creation_5m = cache_creation - cache_creation_1h;
 
-    let cost = (base_input as f64 * input_price
+    (base_input as f64 * input_price
         + output_tokens as f64 * output_price
         + cache_read as f64 * cache_read_price
         + cache_creation_5m as f64 * cache_write_price
         + cache_creation_1h as f64 * (input_price * 2.0))
-        / 1_000_000.0;
-    (cost * 100.0).round() / 100.0 // round to cents
+        / 1_000_000.0
 }
 
 /// Back-compat wrapper for callers that don't have (or don't need) the 1h
@@ -1173,7 +1238,14 @@ fn estimate_cost(
     cache_read: i64,
     cache_creation: i64,
 ) -> f64 {
-    estimate_cost_with_cache_tiers(model, total_input, output_tokens, cache_read, cache_creation, 0)
+    estimate_cost_with_cache_tiers(
+        model,
+        total_input,
+        output_tokens,
+        cache_read,
+        cache_creation,
+        0,
+    )
 }
 
 /// Bump this whenever the `estimate_cost` price table changes so already-indexed
@@ -1553,7 +1625,9 @@ fn scan_claude_model_usage(
     Ok(map)
 }
 
-const CODEX_TOKEN_FIX_REV: &str = "3";
+const CODEX_TOKEN_FIX_REV: &str = "4";
+
+const CODEX_ACCOUNTING_REPAIR_REV: i64 = 4;
 
 struct CodexTokenScan {
     model_used: Option<String>,
@@ -1563,6 +1637,125 @@ struct CodexTokenScan {
     cache_creation: i64,
     observed: bool,
     model_usage: Vec<queries::SessionModelUsageDelta>,
+}
+
+struct CodexAccountingRepairScan {
+    model_used: Option<String>,
+    total_input: i64,
+    total_output: i64,
+    cache_read: i64,
+    model_usage: Vec<queries::SessionModelUsageDelta>,
+    observations: Vec<queries::CodexUsageObservationInput>,
+}
+
+fn codex_session_id_for_path(path: &std::path::Path) -> Option<String> {
+    let file = std::fs::File::open(path).ok()?;
+    for line in std::io::BufReader::new(file).lines().take(64) {
+        let parsed: Value = serde_json::from_str(line.ok()?.trim()).ok()?;
+        if parsed.get("type").and_then(Value::as_str) == Some("session_meta") {
+            return parsed
+                .get("payload")
+                .and_then(|value| value.get("id"))
+                .and_then(Value::as_str)
+                .map(str::to_string);
+        }
+    }
+    None
+}
+
+fn scan_codex_accounting_usage(
+    path: &std::path::Path,
+    initial_state: Option<&str>,
+) -> Result<CodexAccountingRepairScan, String> {
+    use std::io::BufRead;
+    let file = std::fs::File::open(path).map_err(|error| error.to_string())?;
+    let mut reader = std::io::BufReader::new(file);
+    let mut state: Option<String> = initial_state.map(str::to_string);
+    let mut line_offset = 0i64;
+    let mut observations = Vec::new();
+    let mut model_used = None;
+    let mut buffer = String::new();
+    let mut chunk = String::new();
+    let mut chunk_lines = 0i64;
+
+    loop {
+        buffer.clear();
+        let read = reader
+            .read_line(&mut buffer)
+            .map_err(|error| error.to_string())?;
+        if read == 0 {
+            break;
+        }
+        if !buffer.ends_with('\n') {
+            break;
+        }
+        chunk.push_str(&buffer);
+        chunk_lines += 1;
+        if chunk_lines < 1_000 && chunk.len() < 4 * 1024 * 1024 {
+            continue;
+        }
+        let summary =
+            CodexAdapter.parse_raw_with_state(&path.to_string_lossy(), &chunk, state.as_deref());
+        observations.extend(codex_observation_inputs(
+            &summary.codex_usage_observations,
+            line_offset,
+        ));
+        model_used = summary.model_used.or(model_used);
+        state = summary.last_usage_key;
+        line_offset += chunk_lines;
+        chunk.clear();
+        chunk_lines = 0;
+    }
+
+    if !chunk.is_empty() {
+        let summary =
+            CodexAdapter.parse_raw_with_state(&path.to_string_lossy(), &chunk, state.as_deref());
+        observations.extend(codex_observation_inputs(
+            &summary.codex_usage_observations,
+            line_offset,
+        ));
+        model_used = summary.model_used.or(model_used);
+        let _final_state = summary.last_usage_key;
+    }
+
+    let mut by_model: std::collections::BTreeMap<String, queries::SessionModelUsageDelta> =
+        std::collections::BTreeMap::new();
+    let mut total_input = 0;
+    let mut total_output = 0;
+    let mut cache_read = 0;
+    for item in observations
+        .iter()
+        .filter(|item| item.disposition == "accepted")
+    {
+        total_input += item.input_tokens;
+        total_output += item.output_tokens;
+        cache_read += item.cache_read_tokens;
+        let entry =
+            by_model
+                .entry(item.model.clone())
+                .or_insert_with(|| queries::SessionModelUsageDelta {
+                    model: item.model.clone(),
+                    message_count: 0,
+                    input_tokens: 0,
+                    output_tokens: 0,
+                    cache_read_tokens: 0,
+                    cache_creation_tokens: 0,
+                    cache_creation_1h_tokens: 0,
+                });
+        entry.message_count += 1;
+        entry.input_tokens += item.input_tokens;
+        entry.output_tokens += item.output_tokens;
+        entry.cache_read_tokens += item.cache_read_tokens;
+    }
+
+    Ok(CodexAccountingRepairScan {
+        model_used,
+        total_input,
+        total_output,
+        cache_read,
+        model_usage: by_model.into_values().collect(),
+        observations,
+    })
 }
 
 fn detect_codex_replay_second(path: &std::path::Path) -> Option<String> {
@@ -1827,92 +2020,201 @@ pub fn fix_codex_token_totals(conn: &rusqlite::Connection) {
         }
     };
 
-    struct Repair {
-        id: String,
-        total_input: i64,
-        total_output: i64,
-        cache_read: i64,
-        cache_creation: i64,
-        cost: f64,
-        model_usage: Vec<queries::SessionModelUsageDelta>,
+    let mut by_path: std::collections::BTreeMap<String, Vec<(String, String, Option<String>)>> =
+        std::collections::BTreeMap::new();
+    for row in rows {
+        by_path.entry(row.1.clone()).or_default().push(row);
+    }
+    let mut canonical_rows = Vec::new();
+    let mut duplicate_rows = Vec::new();
+    for (path, mut candidates) in by_path {
+        let source_id = codex_session_id_for_path(std::path::Path::new(&path));
+        let canonical_index = source_id
+            .as_ref()
+            .and_then(|source_id| candidates.iter().position(|row| &row.0 == source_id))
+            .unwrap_or(0);
+        canonical_rows.push(candidates.remove(canonical_index));
+        duplicate_rows.extend(candidates);
     }
 
-    let mut repairs = Vec::new();
-    for (id, path, stored_model) in rows {
-        let summary = match scan_codex_token_usage(std::path::Path::new(&path)) {
-            Ok(summary) => summary,
-            Err(_) => continue,
+    let duplicate_target_count = duplicate_rows.len() as u64;
+    let canonical_target_count = canonical_rows.len() as u64;
+    let mut failures = 0u64;
+    let mut deduplicated = 0u64;
+    for (id, _, _) in duplicate_rows {
+        let Ok(tx) = conn.unchecked_transaction() else {
+            failures += 1;
+            continue;
         };
-        // A truncated/odd file should not zero a possibly-valid stored value.
-        if !summary.observed {
+        if tx
+            .execute(
+                "UPDATE cc_sessions SET total_input_tokens=0,total_output_tokens=0,
+                        cache_read_tokens=0,cache_creation_tokens=0,estimated_cost_usd=0
+                 WHERE id=?1",
+                rusqlite::params![&id],
+            )
+            .is_err()
+            || queries::replace_session_model_usage(&tx, &id, &[]).is_err()
+            || queries::replace_codex_usage_observations(&tx, &id, &[]).is_err()
+            || queries::record_codex_usage_repair(
+                &tx,
+                &id,
+                CODEX_ACCOUNTING_REPAIR_REV,
+                "excluded",
+                0,
+                0,
+                Some("duplicate_source_path"),
+            )
+            .is_err()
+        {
+            failures += 1;
             continue;
         }
-        let model = summary.model_used.or(stored_model);
+        if tx.commit().is_ok() {
+            deduplicated += 1;
+        } else {
+            failures += 1;
+        }
+    }
+
+    let mut fixed = 0u64;
+    let mut missing = 0u64;
+    for (id, path, _stored_model) in canonical_rows {
+        let path_ref = std::path::Path::new(&path);
+        let summary = match scan_codex_accounting_usage(path_ref, None) {
+            Ok(summary) => summary,
+            Err(error) => {
+                if queries::record_codex_usage_repair(
+                    conn,
+                    &id,
+                    CODEX_ACCOUNTING_REPAIR_REV,
+                    "unrepaired",
+                    0,
+                    0,
+                    Some(if error.contains("No such file") {
+                        "source_missing"
+                    } else {
+                        "source_unreadable"
+                    }),
+                )
+                .is_ok()
+                {
+                    missing += 1;
+                } else {
+                    failures += 1;
+                }
+                continue;
+            }
+        };
         let model_usage = summary.model_usage;
-        let cost = if model_usage.is_empty() {
-            estimate_cost(
-                model.as_deref().unwrap_or(""),
+        let accepted = summary
+            .observations
+            .iter()
+            .filter(|item| item.disposition == "accepted")
+            .count() as i64;
+        let excluded = summary.observations.len() as i64 - accepted;
+        let tx = match conn.unchecked_transaction() {
+            Ok(tx) => tx,
+            Err(_) => {
+                failures += 1;
+                continue;
+            }
+        };
+        if queries::replace_codex_usage_observations(&tx, &id, &summary.observations).is_err()
+            || queries::reconcile_codex_usage_totals(&tx, &id).is_err()
+            || !codex_reconciliation_matches(
+                &tx,
+                &id,
                 summary.total_input,
                 summary.total_output,
                 summary.cache_read,
-                summary.cache_creation,
+                &model_usage,
             )
+            || queries::record_codex_usage_repair(
+                &tx,
+                &id,
+                CODEX_ACCOUNTING_REPAIR_REV,
+                "repaired",
+                accepted,
+                excluded,
+                None,
+            )
+            .is_err()
+        {
+            failures += 1;
+            continue;
+        }
+        if tx.commit().is_ok() {
+            fixed += 1;
         } else {
-            let total: f64 = model_usage
-                .iter()
-                .map(|usage| {
-                    estimate_cost(
-                        &usage.model,
-                        usage.input_tokens,
-                        usage.output_tokens,
-                        usage.cache_read_tokens,
-                        usage.cache_creation_tokens,
-                    )
-                })
-                .sum();
-            (total * 100.0).round() / 100.0
-        };
-        repairs.push(Repair {
-            id,
-            total_input: summary.total_input,
-            total_output: summary.total_output,
-            cache_read: summary.cache_read,
-            cache_creation: summary.cache_creation,
-            cost,
-            model_usage,
-        });
+            failures += 1;
+        }
+    }
+    let complete = failures == 0
+        && fixed + missing == canonical_target_count
+        && deduplicated == duplicate_target_count;
+    if complete {
+        let _ = queries::set_preference(conn, "codex_token_fix_rev", CODEX_TOKEN_FIX_REV);
+        log::info!("Codex accounting backfill: repaired {fixed} sessions, excluded {deduplicated} duplicate source rows, preserved {missing} sessions without readable evidence");
+    } else {
+        log::error!("Codex accounting backfill incomplete: repaired {fixed}/{canonical_target_count} sessions, excluded {deduplicated}/{duplicate_target_count} duplicate source rows, failures={failures}; revision remains pending");
+    }
+}
+
+fn codex_reconciliation_matches(
+    conn: &rusqlite::Connection,
+    session_id: &str,
+    expected_input: i64,
+    expected_output: i64,
+    expected_cache_read: i64,
+    expected_models: &[queries::SessionModelUsageDelta],
+) -> bool {
+    let totals = conn.query_row(
+        "SELECT total_input_tokens,total_output_tokens,cache_read_tokens
+         FROM cc_sessions WHERE id=?1",
+        rusqlite::params![session_id],
+        |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, i64>(1)?,
+                row.get::<_, i64>(2)?,
+            ))
+        },
+    );
+    if totals.ok() != Some((expected_input, expected_output, expected_cache_read)) {
+        return false;
     }
 
-    let tx = match conn.unchecked_transaction() {
-        Ok(t) => t,
-        Err(_) => return,
+    let mut expected = expected_models
+        .iter()
+        .map(|usage| {
+            (
+                usage.model.clone(),
+                usage.message_count,
+                usage.input_tokens,
+                usage.output_tokens,
+                usage.cache_read_tokens,
+            )
+        })
+        .collect::<Vec<_>>();
+    expected.sort();
+    let Ok(actual_rows) = queries::get_session_model_usage(conn, session_id) else {
+        return false;
     };
-    let mut fixed = 0u64;
-    for repair in repairs {
-        let _ = tx.execute(
-            "UPDATE cc_sessions SET
-                total_input_tokens = ?2,
-                total_output_tokens = ?3,
-                cache_read_tokens = ?4,
-                cache_creation_tokens = ?5,
-                estimated_cost_usd = ?6
-            WHERE id = ?1",
-            rusqlite::params![
-                &repair.id,
-                repair.total_input,
-                repair.total_output,
-                repair.cache_read,
-                repair.cache_creation,
-                repair.cost,
-            ],
-        );
-        let _ = queries::replace_session_model_usage(&tx, &repair.id, &repair.model_usage);
-        fixed += 1;
-    }
-    if tx.commit().is_ok() {
-        let _ = queries::set_preference(conn, "codex_token_fix_rev", CODEX_TOKEN_FIX_REV);
-        log::info!("Fixed Codex per-session token attribution for {fixed} sessions");
-    }
+    let mut actual = actual_rows
+        .into_iter()
+        .map(|usage| {
+            (
+                usage.model,
+                usage.message_count,
+                usage.input_tokens,
+                usage.output_tokens,
+                usage.cache_read_tokens,
+            )
+        })
+        .collect::<Vec<_>>();
+    actual.sort();
+    actual == expected
 }
 
 /// Streaming full-file scan of one Claude JSONL with usage dedup. Returns the
@@ -2147,6 +2449,7 @@ fn upsert_adapter_summary_session(
     let day_counts = summary.day_counts.clone();
     let archive_messages = summary.archive_messages.clone();
     let parse_warnings = summary.parse_warnings.clone();
+    let codex_observations = codex_observation_inputs(&summary.codex_usage_observations, 0);
 
     for warning in &summary.parse_warnings {
         log::warn!(
@@ -2233,6 +2536,11 @@ fn upsert_adapter_summary_session(
     // archive rows are replaced. Empty for non-Claude adapters, which clears
     // nothing since such sessions never had rows.
     queries::replace_session_model_usage(conn, &sid, &usage_deltas).map_err(|e| e.to_string())?;
+    if agent_type == "codex" {
+        queries::replace_codex_usage_observations(conn, &sid, &codex_observations)
+            .map_err(|e| e.to_string())?;
+        queries::reconcile_codex_usage_totals(conn, &sid).map_err(|e| e.to_string())?;
+    }
 
     Ok(IndexedAdapterSession {
         session_id: sid,
@@ -2240,6 +2548,38 @@ fn upsert_adapter_summary_session(
         messages_indexed: message_count,
         parse_warnings,
     })
+}
+
+fn codex_observation_inputs(
+    observations: &[crate::commands::session_adapters::CodexUsageObservation],
+    line_offset: i64,
+) -> Vec<queries::CodexUsageObservationInput> {
+    observations
+        .iter()
+        .map(|item| queries::CodexUsageObservationInput {
+            source_line: line_offset + item.source_line,
+            observed_at: item.timestamp.clone(),
+            local_day: item.day.clone(),
+            model: item.model.clone(),
+            input_tokens: item.input_tokens,
+            cache_read_tokens: item.cache_read_tokens,
+            output_tokens: item.output_tokens,
+            reasoning_tokens: item.reasoning_tokens,
+            cost_usd: estimate_cost_precise(
+                &item.model,
+                item.input_tokens,
+                item.output_tokens,
+                item.cache_read_tokens,
+                0,
+                0,
+            ),
+            cumulative_input_tokens: item.total.as_ref().map(|total| total.input),
+            cumulative_cache_read_tokens: item.total.as_ref().map(|total| total.cached),
+            cumulative_output_tokens: item.total.as_ref().map(|total| total.output),
+            cumulative_reasoning_tokens: item.total.as_ref().map(|total| total.reasoning),
+            disposition: item.disposition.clone(),
+        })
+        .collect()
 }
 
 fn model_usage_deltas(
@@ -2543,7 +2883,7 @@ fn index_adapter_session_with_budget<A: SessionSourceAdapter>(
     if chunk.text.is_empty() {
         return Err("session has no complete JSONL row yet".to_string());
     }
-    let summary = adapter.parse_raw(&path_str, &chunk.text);
+    let summary = adapter.parse_raw_with_state(&path_str, &chunk.text, None);
     let last_usage_key = summary.last_usage_key.clone();
     let existing_id = existing.as_ref().map(|m| m.id.as_str());
     let result = upsert_adapter_summary_session(
@@ -2640,6 +2980,8 @@ fn index_session_incremental<A: SessionSourceAdapter>(
 
     let summary =
         adapter.parse_raw_with_state(path_str, &chunk.text, meta.last_usage_key.as_deref());
+    let codex_observations =
+        codex_observation_inputs(&summary.codex_usage_observations, line_count);
 
     // Append archive rows, continuing message_index / source_line past what is stored.
     let start_index = meta.archived_message_count;
@@ -2706,6 +3048,11 @@ fn index_session_incremental<A: SessionSourceAdapter>(
     // Legacy cumulative-only Codex logs leave model_usage empty → no-op.
     queries::add_session_model_usage(conn, &meta.id, &model_usage_deltas(&summary.model_usage))
         .map_err(|e| e.to_string())?;
+    if adapter.agent_type() == "codex" {
+        queries::append_codex_usage_observations(conn, &meta.id, &codex_observations)
+            .map_err(|e| e.to_string())?;
+        queries::reconcile_codex_usage_totals(conn, &meta.id).map_err(|e| e.to_string())?;
+    }
 
     // Recompute cost from the NEW totals so it matches a one-shot full re-index
     // exactly (estimate_cost rounds to cents — a per-delta round would drift).
@@ -3240,6 +3587,7 @@ fn parse_grok_session_dir(
         tokens_are_cumulative: false,
         model_usage: std::collections::BTreeMap::new(),
         last_usage_key: None,
+        codex_usage_observations: Vec::new(),
     })
 }
 
@@ -3666,6 +4014,7 @@ fn index_devin_sessions_from_path(
             tokens_are_cumulative: false,
             model_usage: std::collections::BTreeMap::new(),
             last_usage_key: None,
+            codex_usage_observations: Vec::new(),
         };
 
         match upsert_adapter_summary_session(
@@ -3878,6 +4227,7 @@ fn index_cursor_agent_sessions(conn: &rusqlite::Connection) -> Result<(u64, u64,
                 tokens_are_cumulative: false,
                 model_usage: std::collections::BTreeMap::new(),
                 last_usage_key: None,
+                codex_usage_observations: Vec::new(),
             };
 
             match upsert_adapter_summary_session(
@@ -4636,7 +4986,7 @@ mod tests {
         let conn = memory_conn_with_project();
         queries::set_preference(&conn, "last_indexed_at", "2026-07-12T12:00:00Z").unwrap();
         let policy = live_session_evidence_policy(&conn).expect("policy");
-        assert_eq!(policy.schema_version, 1);
+        assert_eq!(policy.schema_version, 2);
         assert_eq!(policy.incremental_interval_secs, 10);
         assert_eq!(policy.full_index_recovery_interval_secs, 6 * 60 * 60);
         assert_eq!(
@@ -4649,6 +4999,10 @@ mod tests {
             policy.last_full_indexed_at.as_deref(),
             Some("2026-07-12T12:00:00Z")
         );
+        assert_eq!(policy.incomplete_codex_sources, 0);
+        assert_eq!(policy.pending_codex_bytes, 0);
+        assert_eq!(policy.duplicate_usage_events, 0);
+        assert_eq!(policy.excluded_usage_events, 0);
     }
 
     #[test]
@@ -4656,6 +5010,16 @@ mod tests {
         const { assert!(LIVE_TRANSCRIPT_SESSION_BYTE_BUDGET <= 64 * 1024) };
         const { assert!(LIVE_TRANSCRIPT_TICK_BUDGET_MS <= 200) };
         assert_eq!(LIVE_CODEX_DISCOVERY_SESSION_BUDGET, 1);
+    }
+
+    #[test]
+    fn live_usage_serialization_is_independent_of_full_archive_indexing() {
+        let _full_guard = FULL_INDEX_LOCK.lock().expect("full index lock");
+        let live_guard = LIVE_TRANSCRIPT_LOCK.try_lock();
+        assert!(
+            live_guard.is_ok(),
+            "archive indexing must not suppress eligible live usage work"
+        );
     }
 
     #[test]
@@ -4704,7 +5068,7 @@ mod tests {
         .unwrap();
         std::fs::write(&path, &events).unwrap();
 
-        let guard = FULL_INDEX_LOCK.lock().unwrap();
+        let guard = LIVE_TRANSCRIPT_LOCK.lock().unwrap();
         let skipped = tail_live_transcript_sessions_inner(&conn, false).expect("non-blocking skip");
         assert_eq!(skipped.messages_indexed, 0);
         drop(guard);
@@ -5249,6 +5613,75 @@ mod tests {
         assert_eq!(model_usage.len(), 1);
         assert_eq!(model_usage[0].model, "gpt-5.6-sol");
         assert_eq!(model_usage[0].input_tokens, 150);
+
+        let first: (i64, i64, i64, f64, i64) = conn.query_row(
+            "SELECT total_input_tokens,total_output_tokens,cache_read_tokens,estimated_cost_usd,
+                    (SELECT COUNT(*) FROM codex_usage_observations WHERE session_id='child')
+             FROM cc_sessions WHERE id='child'", [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?)),
+        ).unwrap();
+        queries::set_preference(&conn, "codex_token_fix_rev", "1").unwrap();
+        fix_codex_token_totals(&conn);
+        let second: (i64, i64, i64, f64, i64) = conn.query_row(
+            "SELECT total_input_tokens,total_output_tokens,cache_read_tokens,estimated_cost_usd,
+                    (SELECT COUNT(*) FROM codex_usage_observations WHERE session_id='child')
+             FROM cc_sessions WHERE id='child'", [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?)),
+        ).unwrap();
+        assert_eq!(first, second, "fixed transcript repair is idempotent");
+    }
+
+    #[test]
+    fn codex_repair_does_not_complete_revision_after_reconciliation_failure() {
+        let dir = tempfile::tempdir().expect("session directory");
+        let path = dir.path().join("session.jsonl");
+        let raw = concat!(
+            r#"{"timestamp":"2026-07-20T08:03:00Z","type":"session_meta","payload":{"id":"guarded","cwd":"/repo"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-07-20T08:03:01Z","type":"turn_context","payload":{"model":"gpt-5.6-sol"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-07-20T08:03:02Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":100,"cached_input_tokens":80,"output_tokens":20},"total_token_usage":{"input_tokens":100,"cached_input_tokens":80,"output_tokens":20}}}}"#,
+            "\n",
+        );
+        std::fs::write(&path, raw).expect("fixture");
+        let conn = memory_conn_with_project();
+        let summary = CodexAdapter.parse_raw(path.to_string_lossy().as_ref(), raw);
+        upsert_adapter_summary_session(
+            &conn,
+            "project",
+            summary,
+            raw.len() as i64,
+            Some("2026-07-20T08:03:02Z".to_string()),
+            "2026-07-20T08:03:02Z",
+            None,
+        )
+        .expect("index fixture");
+        queries::set_preference(&conn, "codex_token_fix_rev", "3").expect("old revision");
+        conn.execute_batch(
+            "CREATE TRIGGER reject_guarded_reconciliation
+             BEFORE UPDATE ON cc_sessions WHEN OLD.id='guarded'
+             BEGIN SELECT RAISE(FAIL, 'injected reconciliation failure'); END;",
+        )
+        .expect("failure trigger");
+
+        fix_codex_token_totals(&conn);
+
+        assert_eq!(
+            queries::get_preference(&conn, "codex_token_fix_rev")
+                .expect("revision")
+                .as_deref(),
+            Some("3")
+        );
+        assert_eq!(
+            conn.query_row(
+                "SELECT COUNT(*) FROM codex_usage_repair_audit WHERE session_id='guarded'",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .expect("audit count"),
+            0,
+            "a failed transaction must not leave a success audit"
+        );
     }
 
     // Diagnostic (not a CI eval): runs the real indexer against a COPY of the
@@ -5257,46 +5690,39 @@ mod tests {
     #[test]
     #[ignore]
     fn diag_codex_fix_cost() {
-        // Runs the Codex token repair against a copy of the live DB and reports
-        // before/after totals. Run with:
-        // cargo test --bin codevetter-desktop diag_codex_fix_cost -- --ignored --nocapture
-        let path = "/tmp/cv_live_copy.db";
-        if !std::path::Path::new(path).exists() {
+        // Runs the Codex accounting repair twice against an explicit disposable
+        // DB copy. The second pass must not change totals or observation counts.
+        let path = std::env::var("CV_CODEX_ACCOUNTING_DRYRUN_DB")
+            .unwrap_or_else(|_| "/tmp/cv_live_copy.db".to_string());
+        if !std::path::Path::new(&path).exists() {
             eprintln!("SKIP: {path} not present");
             return;
         }
-        let conn = Connection::open(path).expect("open");
-        let total = |c: &Connection| -> f64 {
+        let conn = Connection::open(&path).expect("open");
+        schema::run_migrations(&conn).expect("migrate copy");
+        let snapshot = |c: &Connection| -> (f64, i64, i64, i64) {
             c.query_row(
-                "SELECT COALESCE(SUM(estimated_cost_usd),0) FROM cc_sessions",
+                "SELECT COALESCE(SUM(estimated_cost_usd),0),
+                        COALESCE(SUM(total_input_tokens + total_output_tokens),0),
+                        (SELECT COUNT(*) FROM codex_usage_observations),
+                        (SELECT COUNT(*) FROM codex_usage_repair_audit WHERE status='unrepaired')
+                 FROM cc_sessions WHERE agent_type='codex'",
                 [],
-                |r| r.get(0),
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
             )
-            .unwrap_or(0.0)
-        };
-        let codex = |c: &Connection| -> f64 {
-            c.query_row("SELECT COALESCE(SUM(estimated_cost_usd),0) FROM cc_sessions WHERE agent_type='codex'", [], |r| r.get(0)).unwrap_or(0.0)
-        };
-        eprintln!(
-            "BEFORE: total=${:.0} codex=${:.0}",
-            total(&conn),
-            codex(&conn)
-        );
-        fix_codex_token_totals(&conn);
-        eprintln!(
-            "AFTER:  total=${:.0} codex=${:.0}",
-            total(&conn),
-            codex(&conn)
-        );
-        let mut stmt = conn.prepare("SELECT agent_type, ROUND(estimated_cost_usd,2), total_input_tokens FROM cc_sessions ORDER BY estimated_cost_usd DESC LIMIT 5").unwrap();
-        let rows: Vec<(String, f64, i64)> = stmt
-            .query_map([], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)))
             .unwrap()
-            .filter_map(Result::ok)
-            .collect();
-        for (a, c, t) in rows {
-            eprintln!("  top: {a} ${c} ({t} input tok)");
-        }
+        };
+        queries::set_preference(&conn, "codex_token_fix_rev", "0").expect("force repair");
+        let before = snapshot(&conn);
+        fix_codex_token_totals(&conn);
+        let first = snapshot(&conn);
+        queries::set_preference(&conn, "codex_token_fix_rev", "0").expect("force second repair");
+        fix_codex_token_totals(&conn);
+        let second = snapshot(&conn);
+        eprintln!("BEFORE={before:?}\nFIRST={first:?}\nSECOND={second:?}");
+        eprintln!(
+            "NOTE: changes between passes are expected only when live transcript paths grew while this DB copy was being repaired"
+        );
     }
 
     #[test]
@@ -5543,13 +5969,22 @@ mod tests {
             estimate_cost("gpt-5.6-sol", 1_000_000, 0, 1_000_000, 0),
             0.50
         ));
-        assert!(near(estimate_cost("gpt-5.6-terra", 1_000_000, 0, 0, 0), 2.0));
-        assert!(near(estimate_cost("gpt-5.6-terra", 0, 1_000_000, 0, 0), 12.0));
+        assert!(near(
+            estimate_cost("gpt-5.6-terra", 1_000_000, 0, 0, 0),
+            2.0
+        ));
+        assert!(near(
+            estimate_cost("gpt-5.6-terra", 0, 1_000_000, 0, 0),
+            12.0
+        ));
         assert!(near(
             estimate_cost("gpt-5.6-luna", 1_000_000, 0, 0, 0),
             0.20
         ));
-        assert!(near(estimate_cost("gpt-5.6-luna", 0, 1_000_000, 0, 0), 1.20));
+        assert!(near(
+            estimate_cost("gpt-5.6-luna", 0, 1_000_000, 0, 0),
+            1.20
+        ));
         // GPT-5.4 must beat the generic GPT-5 family arm.
         assert!(near(estimate_cost("gpt-5.4", 1_000_000, 0, 0, 0), 2.50));
         assert!(near(estimate_cost("gpt-5.4", 0, 1_000_000, 0, 0), 15.0));
@@ -5588,15 +6023,28 @@ mod tests {
         // Sonnet: $3/M input, so 5m cache writes are $3.75/M (1.25x) and 1h
         // writes are $6/M (2x) — Anthropic's real pricing ratio. All 1M
         // cache-creation tokens as 1h should cost double the all-5m case.
-        let all_5m = estimate_cost_with_cache_tiers("claude-sonnet-4-5", 1_000_000, 0, 0, 1_000_000, 0);
-        let all_1h =
-            estimate_cost_with_cache_tiers("claude-sonnet-4-5", 1_000_000, 0, 0, 1_000_000, 1_000_000);
+        let all_5m =
+            estimate_cost_with_cache_tiers("claude-sonnet-4-5", 1_000_000, 0, 0, 1_000_000, 0);
+        let all_1h = estimate_cost_with_cache_tiers(
+            "claude-sonnet-4-5",
+            1_000_000,
+            0,
+            0,
+            1_000_000,
+            1_000_000,
+        );
         assert!(near(all_5m, 3.75));
         assert!(near(all_1h, 6.0));
         // A half/half split lands between the two pure cases (within a cent
         // of rounding, since costs are rounded to cents).
-        let half_half =
-            estimate_cost_with_cache_tiers("claude-sonnet-4-5", 1_000_000, 0, 0, 1_000_000, 500_000);
+        let half_half = estimate_cost_with_cache_tiers(
+            "claude-sonnet-4-5",
+            1_000_000,
+            0,
+            0,
+            1_000_000,
+            500_000,
+        );
         assert!((half_half - (all_5m + all_1h) / 2.0).abs() < 0.01);
         // estimate_cost (no split info) matches the conservative all-5m case —
         // this is the fallback used when a session has no per-model breakdown.
@@ -5607,8 +6055,14 @@ mod tests {
         // A 1h count larger than the total cache-creation tokens (shouldn't
         // happen, but guard against it) is clamped rather than going negative
         // or over-crediting the 5m bucket.
-        let clamped =
-            estimate_cost_with_cache_tiers("claude-sonnet-4-5", 1_000_000, 0, 0, 1_000_000, 5_000_000);
+        let clamped = estimate_cost_with_cache_tiers(
+            "claude-sonnet-4-5",
+            1_000_000,
+            0,
+            0,
+            1_000_000,
+            5_000_000,
+        );
         assert!(near(clamped, all_1h));
     }
 

--- a/apps/desktop/src-tauri/src/commands/session_adapters.rs
+++ b/apps/desktop/src-tauri/src/commands/session_adapters.rs
@@ -45,6 +45,74 @@ pub struct RawSessionAdapterSummary {
     /// lets the next incremental read continue the dedup across the boundary.
     #[serde(default)]
     pub last_usage_key: Option<String>,
+    /// Content-free, timestamped Codex token evidence. Other adapters leave
+    /// this empty. `source_line` is relative to the parsed chunk; the indexer
+    /// adds the persisted line cursor before storage.
+    #[serde(default)]
+    pub codex_usage_observations: Vec<CodexUsageObservation>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CodexTokenTotals {
+    pub input: i64,
+    pub cached: i64,
+    pub output: i64,
+    pub reasoning: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CodexUsageObservation {
+    pub source_line: i64,
+    pub timestamp: Option<String>,
+    pub day: Option<String>,
+    pub model: String,
+    pub input_tokens: i64,
+    pub cache_read_tokens: i64,
+    pub output_tokens: i64,
+    pub reasoning_tokens: i64,
+    pub total: Option<CodexTokenTotals>,
+    pub disposition: String,
+}
+
+impl CodexUsageObservation {
+    fn zero() -> Self {
+        Self {
+            source_line: 0,
+            timestamp: None,
+            day: None,
+            model: "unknown".into(),
+            input_tokens: 0,
+            cache_read_tokens: 0,
+            output_tokens: 0,
+            reasoning_tokens: 0,
+            total: None,
+            disposition: "unsupported".into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+struct CodexAccountingState {
+    session_id: Option<String>,
+    current_model: Option<String>,
+    last_total: Option<CodexTokenTotals>,
+    watermark: Option<CodexTokenTotals>,
+    counted: Option<CodexTokenTotals>,
+    seen_totals: Vec<CodexTokenTotals>,
+    interleaved: bool,
+    fork_direct: bool,
+    fork_pending_replay: bool,
+    fork_baseline: Option<CodexTokenTotals>,
+    fork_prefix_total: Option<CodexTokenTotals>,
+}
+
+pub fn codex_state_with_fork_baseline(baseline: CodexTokenTotals) -> Option<String> {
+    serde_json::to_string(&CodexAccountingState {
+        fork_direct: true,
+        fork_baseline: Some(baseline),
+        ..CodexAccountingState::default()
+    })
+    .ok()
 }
 
 /// Token usage attributed to one model within a session. Same semantics as the
@@ -152,6 +220,31 @@ fn codex_replay_second(raw: &str) -> Option<String> {
     None
 }
 
+fn codex_has_replayed_parent_meta(raw: &str) -> bool {
+    let mut first_id: Option<String> = None;
+    for line in raw.lines() {
+        let Ok(parsed) = serde_json::from_str::<Value>(line.trim()) else {
+            continue;
+        };
+        if parsed.get("type").and_then(Value::as_str) != Some("session_meta") {
+            continue;
+        }
+        let Some(id) = parsed
+            .get("payload")
+            .and_then(|payload| payload.get("id"))
+            .and_then(Value::as_str)
+        else {
+            continue;
+        };
+        match first_id.as_deref() {
+            None => first_id = Some(id.to_string()),
+            Some(first) if first != id => return true,
+            Some(_) => {}
+        }
+    }
+    false
+}
+
 fn empty_summary(adapter_id: &str, agent_type: &str, source_ref: &str) -> RawSessionAdapterSummary {
     RawSessionAdapterSummary {
         adapter_id: adapter_id.to_string(),
@@ -177,7 +270,129 @@ fn empty_summary(adapter_id: &str, agent_type: &str, source_ref: &str) -> RawSes
         tokens_are_cumulative: false,
         model_usage: BTreeMap::new(),
         last_usage_key: None,
+        codex_usage_observations: Vec::new(),
     }
+}
+
+fn codex_totals(value: Option<&Value>) -> Option<CodexTokenTotals> {
+    let value = value?;
+    Some(CodexTokenTotals {
+        input: value
+            .get("input_tokens")
+            .and_then(Value::as_i64)
+            .unwrap_or(0)
+            .max(0),
+        cached: value
+            .get("cached_input_tokens")
+            .or_else(|| value.get("cache_read_input_tokens"))
+            .and_then(Value::as_i64)
+            .unwrap_or(0)
+            .max(0),
+        output: value
+            .get("output_tokens")
+            .and_then(Value::as_i64)
+            .unwrap_or(0)
+            .max(0),
+        reasoning: value
+            .get("reasoning_output_tokens")
+            .and_then(Value::as_i64)
+            .unwrap_or(0)
+            .max(0),
+    })
+}
+
+fn codex_component_delta(
+    current: &CodexTokenTotals,
+    prior: Option<&CodexTokenTotals>,
+) -> CodexTokenTotals {
+    let prior = prior.cloned().unwrap_or_default();
+    CodexTokenTotals {
+        input: (current.input - prior.input).max(0),
+        cached: (current.cached - prior.cached).max(0),
+        output: (current.output - prior.output).max(0),
+        reasoning: (current.reasoning - prior.reasoning).max(0),
+    }
+}
+
+fn codex_contained_delta(
+    watermark: Option<&CodexTokenTotals>,
+    counted: Option<&CodexTokenTotals>,
+    current: &CodexTokenTotals,
+) -> CodexTokenTotals {
+    let watermark = watermark.cloned().unwrap_or_default();
+    let counted = counted.cloned().unwrap_or_default();
+    let component = |water: i64, already_counted: i64, value: i64| {
+        if value >= water {
+            (value - water.max(already_counted)).max(0)
+        } else {
+            (value - already_counted).max(0)
+        }
+    };
+    CodexTokenTotals {
+        input: component(watermark.input, counted.input, current.input),
+        cached: component(watermark.cached, counted.cached, current.cached),
+        output: component(watermark.output, counted.output, current.output),
+        reasoning: component(watermark.reasoning, counted.reasoning, current.reasoning),
+    }
+}
+
+fn codex_add_totals(left: Option<&CodexTokenTotals>, right: &CodexTokenTotals) -> CodexTokenTotals {
+    let left = left.cloned().unwrap_or_default();
+    CodexTokenTotals {
+        input: left.input + right.input,
+        cached: left.cached + right.cached,
+        output: left.output + right.output,
+        reasoning: left.reasoning + right.reasoning,
+    }
+}
+
+fn codex_subtract_totals(
+    value: &CodexTokenTotals,
+    baseline: &CodexTokenTotals,
+) -> CodexTokenTotals {
+    CodexTokenTotals {
+        input: (value.input - baseline.input).max(0),
+        cached: (value.cached - baseline.cached).max(0),
+        output: (value.output - baseline.output).max(0),
+        reasoning: (value.reasoning - baseline.reasoning).max(0),
+    }
+}
+
+fn codex_totals_at_or_above(left: &CodexTokenTotals, right: &CodexTokenTotals) -> bool {
+    left.input >= right.input
+        && left.cached >= right.cached
+        && left.output >= right.output
+        && left.reasoning >= right.reasoning
+}
+
+fn codex_min_totals(left: &CodexTokenTotals, right: &CodexTokenTotals) -> CodexTokenTotals {
+    CodexTokenTotals {
+        input: left.input.min(right.input),
+        cached: left.cached.min(right.cached),
+        output: left.output.min(right.output),
+        reasoning: left.reasoning.min(right.reasoning),
+    }
+}
+
+fn codex_max_totals(left: Option<&CodexTokenTotals>, right: &CodexTokenTotals) -> CodexTokenTotals {
+    let left = left.cloned().unwrap_or_default();
+    CodexTokenTotals {
+        input: left.input.max(right.input),
+        cached: left.cached.max(right.cached),
+        output: left.output.max(right.output),
+        reasoning: left.reasoning.max(right.reasoning),
+    }
+}
+
+fn codex_local_day(timestamp: Option<&str>) -> Option<String> {
+    timestamp
+        .and_then(|raw| chrono::DateTime::parse_from_rfc3339(raw).ok())
+        .map(|value| {
+            value
+                .with_timezone(&chrono::Local)
+                .format("%Y-%m-%d")
+                .to_string()
+        })
 }
 
 fn update_timestamp(summary: &mut RawSessionAdapterSummary, timestamp: Option<String>) {
@@ -623,9 +838,21 @@ impl SessionSourceAdapter for CodexAdapter {
     }
 
     fn parse_raw(&self, source_ref: &str, raw: &str) -> RawSessionAdapterSummary {
+        self.parse_raw_with_state(source_ref, raw, None)
+    }
+
+    fn parse_raw_with_state(
+        &self,
+        source_ref: &str,
+        raw: &str,
+        prior_usage_key: Option<&str>,
+    ) -> RawSessionAdapterSummary {
         let mut summary = empty_summary(self.adapter_id(), self.agent_type(), source_ref);
-        let replay_second = codex_replay_second(raw);
-        let mut skipping_replay = replay_second.is_some();
+        let mut accounting_state = prior_usage_key
+            .and_then(|raw| serde_json::from_str::<CodexAccountingState>(raw).ok())
+            .unwrap_or_default();
+        let has_replayed_parent_meta = codex_has_replayed_parent_meta(raw);
+        summary.model_used = accounting_state.current_model.clone();
         let mut has_last_token_usage = false;
         let mut final_cumulative_usage: Option<(i64, i64, i64, i64)> = None;
         let mut response_input_tokens = 0;
@@ -650,10 +877,19 @@ impl SessionSourceAdapter for CodexAdapter {
 
             if msg_type == "session_meta" {
                 if let Some(payload) = payload {
+                    let meta_id = value_string(Some(payload), "id");
+                    if accounting_state.session_id.is_none() {
+                        accounting_state.session_id = meta_id.clone();
+                    } else if meta_id.as_deref() != accounting_state.session_id.as_deref()
+                        && accounting_state.fork_baseline.is_none()
+                    {
+                        accounting_state.fork_direct = false;
+                        accounting_state.fork_pending_replay = true;
+                    }
                     // Replayed child logs can contain the parent's session_meta
                     // after the child's. Keep the first identity from the file.
                     if summary.stable_id.is_none() {
-                        summary.stable_id = value_string(Some(payload), "id");
+                        summary.stable_id = meta_id;
                     }
                     if summary.cwd.is_none() {
                         summary.cwd = value_string(Some(payload), "cwd");
@@ -682,6 +918,27 @@ impl SessionSourceAdapter for CodexAdapter {
                             })
                         });
                     }
+                    if payload
+                        .get("forked_from_id")
+                        .and_then(Value::as_str)
+                        .is_some()
+                    {
+                        accounting_state.fork_direct = true;
+                    }
+                    if payload
+                        .get("source")
+                        .and_then(|source| source.get("subagent"))
+                        .and_then(|subagent| subagent.get("thread_spawn"))
+                        .and_then(|spawn| spawn.get("parent_thread_id"))
+                        .and_then(Value::as_str)
+                        .is_some()
+                    {
+                        if has_replayed_parent_meta && accounting_state.fork_baseline.is_none() {
+                            accounting_state.fork_pending_replay = true;
+                        } else {
+                            accounting_state.fork_direct = true;
+                        }
+                    }
                 }
                 continue;
             }
@@ -692,6 +949,7 @@ impl SessionSourceAdapter for CodexAdapter {
             // rows instead. Last turn wins, overriding the fallback.
             if msg_type == "turn_context" {
                 if let Some(model) = value_string(payload, "model") {
+                    accounting_state.current_model = Some(model.clone());
                     summary.model_used = Some(model);
                 }
                 continue;
@@ -704,96 +962,208 @@ impl SessionSourceAdapter for CodexAdapter {
                     .unwrap_or("");
                 if sub_type == "token_count" {
                     let info = payload.and_then(|p| p.get("info"));
+                    let timestamp = parsed
+                        .get("timestamp")
+                        .and_then(Value::as_str)
+                        .map(str::to_string);
+                    let raw_total =
+                        codex_totals(info.and_then(|value| value.get("total_token_usage")));
+                    let last = codex_totals(info.and_then(|value| value.get("last_token_usage")));
 
-                    if skipping_replay {
-                        let event_second = parsed
-                            .get("timestamp")
-                            .and_then(Value::as_str)
-                            .and_then(|timestamp| timestamp.get(..19));
-                        if event_second == replay_second.as_deref() {
-                            if let Some(total_usage) =
-                                info.and_then(|info| info.get("total_token_usage"))
-                            {
-                                final_cumulative_usage = Some((
-                                    total_usage
-                                        .get("input_tokens")
-                                        .and_then(|v| v.as_i64())
-                                        .unwrap_or(0),
-                                    total_usage
-                                        .get("output_tokens")
-                                        .and_then(|v| v.as_i64())
-                                        .unwrap_or(0),
-                                    total_usage
-                                        .get("cached_input_tokens")
-                                        .and_then(|v| v.as_i64())
-                                        .unwrap_or(0),
-                                    total_usage
-                                        .get("cache_creation_input_tokens")
-                                        .and_then(|v| v.as_i64())
-                                        .unwrap_or(0),
-                                ));
+                    if accounting_state.fork_pending_replay {
+                        if let Some(current) = raw_total.as_ref() {
+                            let still_prefix = accounting_state
+                                .fork_prefix_total
+                                .as_ref()
+                                .is_none_or(|prior| codex_totals_at_or_above(current, prior));
+                            if still_prefix {
+                                accounting_state.fork_prefix_total = Some(current.clone());
+                                summary
+                                    .codex_usage_observations
+                                    .push(CodexUsageObservation {
+                                        source_line: (idx + 1) as i64,
+                                        timestamp: timestamp.clone(),
+                                        day: codex_local_day(timestamp.as_deref()),
+                                        model: summary
+                                            .model_used
+                                            .clone()
+                                            .unwrap_or_else(|| "unknown".into()),
+                                        total: raw_total,
+                                        disposition: "inherited_replay".into(),
+                                        ..CodexUsageObservation::zero()
+                                    });
+                                continue;
                             }
+                            accounting_state.fork_pending_replay = false;
+                            accounting_state.last_total = None;
+                            accounting_state.watermark = None;
+                            accounting_state.counted = None;
+                            accounting_state.seen_totals.clear();
+                            accounting_state.interleaved = false;
+                        } else {
+                            summary
+                                .codex_usage_observations
+                                .push(CodexUsageObservation {
+                                    source_line: (idx + 1) as i64,
+                                    timestamp: timestamp.clone(),
+                                    day: codex_local_day(timestamp.as_deref()),
+                                    model: summary
+                                        .model_used
+                                        .clone()
+                                        .unwrap_or_else(|| "unknown".into()),
+                                    total: None,
+                                    disposition: "unresolved_fork".into(),
+                                    ..CodexUsageObservation::zero()
+                                });
                             continue;
                         }
-                        skipping_replay = false;
                     }
 
-                    if let Some(last_usage) = info.and_then(|info| info.get("last_token_usage")) {
-                        let input = last_usage
-                            .get("input_tokens")
-                            .and_then(|v| v.as_i64())
-                            .unwrap_or(0);
-                        let output = last_usage
-                            .get("output_tokens")
-                            .and_then(|v| v.as_i64())
-                            .unwrap_or(0);
-                        let cache_read = last_usage
-                            .get("cached_input_tokens")
-                            .and_then(|v| v.as_i64())
-                            .unwrap_or(0);
-                        let cache_creation = last_usage
-                            .get("cache_creation_input_tokens")
-                            .and_then(|v| v.as_i64())
-                            .unwrap_or(0);
-
-                        summary.total_input_tokens += input;
-                        summary.total_output_tokens += output;
-                        summary.cache_read_tokens += cache_read;
-                        summary.cache_creation_tokens += cache_creation;
-                        has_last_token_usage = true;
-
-                        let model_key = summary.model_used.as_deref().unwrap_or("unknown");
-                        let model_usage = summary
-                            .model_usage
-                            .entry(model_key.to_string())
-                            .or_default();
-                        model_usage.message_count += 1;
-                        model_usage.input_tokens += input;
-                        model_usage.output_tokens += output;
-                        model_usage.cache_read_tokens += cache_read;
-                        model_usage.cache_creation_tokens += cache_creation;
+                    if accounting_state.fork_direct && accounting_state.fork_baseline.is_none() {
+                        match (raw_total.as_ref(), last.as_ref()) {
+                            (Some(current), Some(last))
+                                if codex_totals_at_or_above(current, last) =>
+                            {
+                                let baseline = codex_subtract_totals(current, last);
+                                if baseline == CodexTokenTotals::default() {
+                                    accounting_state.fork_direct = false;
+                                    accounting_state.fork_pending_replay = true;
+                                    accounting_state.fork_prefix_total = Some(current.clone());
+                                    summary
+                                        .codex_usage_observations
+                                        .push(CodexUsageObservation {
+                                            source_line: (idx + 1) as i64,
+                                            timestamp: timestamp.clone(),
+                                            day: codex_local_day(timestamp.as_deref()),
+                                            model: summary
+                                                .model_used
+                                                .clone()
+                                                .unwrap_or_else(|| "unknown".into()),
+                                            total: raw_total,
+                                            disposition: "inherited_replay".into(),
+                                            ..CodexUsageObservation::zero()
+                                        });
+                                    continue;
+                                }
+                                accounting_state.fork_baseline = Some(baseline);
+                            }
+                            _ => {
+                                summary
+                                    .codex_usage_observations
+                                    .push(CodexUsageObservation {
+                                        source_line: (idx + 1) as i64,
+                                        timestamp: timestamp.clone(),
+                                        day: codex_local_day(timestamp.as_deref()),
+                                        model: summary
+                                            .model_used
+                                            .clone()
+                                            .unwrap_or_else(|| "unknown".into()),
+                                        total: raw_total,
+                                        disposition: "unresolved_fork".into(),
+                                        ..CodexUsageObservation::zero()
+                                    });
+                                continue;
+                            }
+                        }
                     }
+                    let total = raw_total.as_ref().map(|current| {
+                        accounting_state
+                            .fork_baseline
+                            .as_ref()
+                            .map(|baseline| codex_subtract_totals(current, baseline))
+                            .unwrap_or_else(|| current.clone())
+                    });
 
-                    if let Some(total_usage) = info.and_then(|info| info.get("total_token_usage")) {
-                        final_cumulative_usage = Some((
-                            total_usage
-                                .get("input_tokens")
-                                .and_then(|v| v.as_i64())
-                                .unwrap_or(0),
-                            total_usage
-                                .get("output_tokens")
-                                .and_then(|v| v.as_i64())
-                                .unwrap_or(0),
-                            total_usage
-                                .get("cached_input_tokens")
-                                .and_then(|v| v.as_i64())
-                                .unwrap_or(0),
-                            total_usage
-                                .get("cache_creation_input_tokens")
-                                .and_then(|v| v.as_i64())
-                                .unwrap_or(0),
+                    let duplicate = total.as_ref().is_some_and(|candidate| {
+                        accounting_state
+                            .seen_totals
+                            .iter()
+                            .any(|seen| seen == candidate)
+                    });
+                    let mut disposition = if duplicate { "duplicate" } else { "accepted" };
+                    let delta = if duplicate {
+                        CodexTokenTotals::default()
+                    } else if let Some(current) = total.as_ref() {
+                        if let Some(watermark) = accounting_state.watermark.as_ref() {
+                            if current.input < watermark.input
+                                || current.cached < watermark.cached
+                                || current.output < watermark.output
+                            {
+                                accounting_state.interleaved = true;
+                            }
+                        }
+                        let contained = if accounting_state.interleaved {
+                            codex_contained_delta(
+                                accounting_state.watermark.as_ref(),
+                                accounting_state.counted.as_ref(),
+                                current,
+                            )
+                        } else {
+                            codex_component_delta(current, accounting_state.last_total.as_ref())
+                        };
+                        if accounting_state.fork_baseline.is_some() && !accounting_state.interleaved
+                        {
+                            contained
+                        } else {
+                            last.as_ref()
+                                .map(|last| codex_min_totals(last, &contained))
+                                .unwrap_or(contained)
+                        }
+                    } else if let Some(last) = last.as_ref() {
+                        last.clone()
+                    } else {
+                        disposition = "unsupported";
+                        CodexTokenTotals::default()
+                    };
+
+                    if let Some(current) = total.as_ref() {
+                        accounting_state.watermark = Some(codex_max_totals(
+                            accounting_state.watermark.as_ref(),
+                            current,
                         ));
+                        accounting_state.last_total = Some(current.clone());
+                        if !duplicate {
+                            accounting_state.seen_totals.push(current.clone());
+                            if accounting_state.seen_totals.len() > 64 {
+                                accounting_state.seen_totals.remove(0);
+                            }
+                        }
+                        final_cumulative_usage =
+                            Some((current.input, current.output, current.cached, 0));
                     }
+
+                    has_last_token_usage |= last.is_some();
+                    summary.total_input_tokens += delta.input;
+                    summary.total_output_tokens += delta.output;
+                    summary.cache_read_tokens += delta.cached;
+                    accounting_state.counted =
+                        Some(codex_add_totals(accounting_state.counted.as_ref(), &delta));
+
+                    let model_key = summary
+                        .model_used
+                        .clone()
+                        .unwrap_or_else(|| "unknown".into());
+                    if delta.input > 0 || delta.output > 0 || delta.cached > 0 {
+                        let model_usage = summary.model_usage.entry(model_key.clone()).or_default();
+                        model_usage.message_count += 1;
+                        model_usage.input_tokens += delta.input;
+                        model_usage.output_tokens += delta.output;
+                        model_usage.cache_read_tokens += delta.cached;
+                    }
+                    summary
+                        .codex_usage_observations
+                        .push(CodexUsageObservation {
+                            source_line: (idx + 1) as i64,
+                            timestamp: timestamp.clone(),
+                            day: codex_local_day(timestamp.as_deref()),
+                            model: model_key,
+                            input_tokens: delta.input,
+                            cache_read_tokens: delta.cached,
+                            output_tokens: delta.output,
+                            reasoning_tokens: delta.reasoning,
+                            total,
+                            disposition: disposition.into(),
+                        });
                 }
                 continue;
             }
@@ -856,6 +1226,8 @@ impl SessionSourceAdapter for CodexAdapter {
                 .parse_warnings
                 .push("missing session_meta cwd".to_string());
         }
+        accounting_state.current_model = summary.model_used.clone();
+        summary.last_usage_key = serde_json::to_string(&accounting_state).ok();
         summary
     }
 }
@@ -987,6 +1359,115 @@ impl SessionSourceAdapter for CursorAdapter {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[derive(Deserialize)]
+    struct CodexOracleCase {
+        file: String,
+        model: String,
+        local_day: String,
+        input: i64,
+        cached: i64,
+        output: i64,
+        dispositions: Vec<String>,
+    }
+
+    fn parse_codex_chunks(
+        raw: &str,
+        boundaries: usize,
+    ) -> (i64, i64, i64, Vec<(String, String, Option<String>)>) {
+        let lines = raw.lines().collect::<Vec<_>>();
+        let mut state = None;
+        let mut input = 0;
+        let mut cached = 0;
+        let mut output = 0;
+        let mut dispositions = Vec::new();
+        let mut start = 0;
+        for boundary in 0..lines.len().saturating_sub(1) {
+            if boundaries & (1usize << boundary) == 0 {
+                continue;
+            }
+            let chunk = lines[start..=boundary].join("\n") + "\n";
+            let summary =
+                CodexAdapter.parse_raw_with_state("oracle.jsonl", &chunk, state.as_deref());
+            input += summary.total_input_tokens;
+            cached += summary.cache_read_tokens;
+            output += summary.total_output_tokens;
+            dispositions.extend(
+                summary
+                    .codex_usage_observations
+                    .into_iter()
+                    .map(|observation| {
+                        (observation.disposition, observation.model, observation.day)
+                    }),
+            );
+            state = summary.last_usage_key;
+            start = boundary + 1;
+        }
+        let chunk = lines[start..].join("\n") + "\n";
+        let summary = CodexAdapter.parse_raw_with_state("oracle.jsonl", &chunk, state.as_deref());
+        input += summary.total_input_tokens;
+        cached += summary.cache_read_tokens;
+        output += summary.total_output_tokens;
+        dispositions.extend(
+            summary
+                .codex_usage_observations
+                .into_iter()
+                .map(|observation| (observation.disposition, observation.model, observation.day)),
+        );
+        (input, cached, output, dispositions)
+    }
+
+    #[test]
+    fn codex_accounting_matches_independent_oracle_for_every_line_partition() {
+        let fixture_dir = std::path::Path::new(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/tests/fixtures/codex-accounting"
+        ));
+        let oracle: Vec<CodexOracleCase> = serde_json::from_str(
+            &std::fs::read_to_string(fixture_dir.join("oracle.json")).expect("oracle"),
+        )
+        .expect("valid oracle");
+        for case in oracle {
+            let raw = std::fs::read_to_string(fixture_dir.join(&case.file)).expect("fixture");
+            let line_count = raw.lines().count();
+            for boundaries in 0..(1usize << line_count.saturating_sub(1)) {
+                let actual = parse_codex_chunks(&raw, boundaries);
+                assert_eq!(
+                    actual.0, case.input,
+                    "{} partition {boundaries:b}",
+                    case.file
+                );
+                assert_eq!(
+                    actual.1, case.cached,
+                    "{} partition {boundaries:b}",
+                    case.file
+                );
+                assert_eq!(
+                    actual.2, case.output,
+                    "{} partition {boundaries:b}",
+                    case.file
+                );
+                assert_eq!(
+                    actual
+                        .3
+                        .iter()
+                        .map(|item| item.0.as_str())
+                        .collect::<Vec<_>>(),
+                    case.dispositions
+                        .iter()
+                        .map(String::as_str)
+                        .collect::<Vec<_>>(),
+                    "{} partition {boundaries:b}",
+                    case.file
+                );
+                assert!(actual.3.iter().all(|item| item.1 == case.model));
+                assert!(actual
+                    .3
+                    .iter()
+                    .all(|item| item.2.as_deref() == Some(case.local_day.as_str())));
+            }
+        }
+    }
 
     #[test]
     fn parses_claude_fixture_into_normalized_summary() {
@@ -1131,6 +1612,80 @@ mod tests {
         let legacy = r#"{"type":"session_meta","payload":{"id":"c2","cwd":"/repo","model_provider":"openai"}}"#;
         let summary = CodexAdapter.parse_raw("/fixtures/codex-legacy.jsonl", legacy);
         assert_eq!(summary.model_used.as_deref(), Some("o3"));
+    }
+
+    fn codex_token_line(
+        timestamp: &str,
+        input: i64,
+        cached: i64,
+        output: i64,
+        total_input: i64,
+        total_cached: i64,
+        total_output: i64,
+    ) -> String {
+        format!(
+            r#"{{"timestamp":"{timestamp}","type":"event_msg","payload":{{"type":"token_count","info":{{"last_token_usage":{{"input_tokens":{input},"cached_input_tokens":{cached},"output_tokens":{output},"reasoning_output_tokens":1}},"total_token_usage":{{"input_tokens":{total_input},"cached_input_tokens":{total_cached},"output_tokens":{total_output},"reasoning_output_tokens":1}}}}}}}}"#
+        )
+    }
+
+    #[test]
+    fn codex_unchanged_cumulative_snapshot_is_not_recounted() {
+        let first = codex_token_line("2026-08-10T01:00:00Z", 100, 80, 10, 100, 80, 10);
+        let duplicate = codex_token_line("2026-08-10T01:00:05Z", 100, 80, 10, 100, 80, 10);
+        let raw = format!("{first}\n{duplicate}");
+        let summary = CodexAdapter.parse_raw("/fixtures/codex-duplicate.jsonl", &raw);
+        assert_eq!(summary.total_input_tokens, 100);
+        assert_eq!(summary.total_output_tokens, 10);
+        assert_eq!(summary.codex_usage_observations.len(), 2);
+        assert_eq!(summary.codex_usage_observations[1].disposition, "duplicate");
+        assert_eq!(summary.codex_usage_observations[1].input_tokens, 0);
+    }
+
+    #[test]
+    fn codex_duplicate_suppression_survives_incremental_boundary() {
+        let first = codex_token_line("2026-08-10T01:00:00Z", 100, 80, 10, 100, 80, 10);
+        let duplicate = codex_token_line("2026-08-10T01:00:05Z", 100, 80, 10, 100, 80, 10);
+        let next = codex_token_line("2026-08-10T01:01:00Z", 50, 40, 5, 150, 120, 15);
+        let one = CodexAdapter.parse_raw_with_state("/fixtures/codex.jsonl", &first, None);
+        let two = CodexAdapter.parse_raw_with_state(
+            "/fixtures/codex.jsonl",
+            &format!("{duplicate}\n{next}"),
+            one.last_usage_key.as_deref(),
+        );
+        assert_eq!(one.total_input_tokens + two.total_input_tokens, 150);
+        assert_eq!(one.total_output_tokens + two.total_output_tokens, 15);
+        assert_eq!(two.codex_usage_observations[0].disposition, "duplicate");
+    }
+
+    #[test]
+    fn codex_interleaved_totals_only_count_growth_above_watermark() {
+        let raw = [
+            codex_token_line("2026-08-10T01:00:00Z", 100, 80, 10, 100, 80, 10),
+            // A second lineage drops below the watermark: no new contained growth.
+            codex_token_line("2026-08-10T01:00:10Z", 40, 30, 4, 40, 30, 4),
+            // Only 20/10/2 exceeds the original component-wise watermark.
+            codex_token_line("2026-08-10T01:00:20Z", 80, 60, 8, 120, 90, 12),
+        ]
+        .join("\n");
+        let summary = CodexAdapter.parse_raw("/fixtures/codex-interleaved.jsonl", &raw);
+        assert_eq!(summary.total_input_tokens, 120);
+        assert_eq!(summary.cache_read_tokens, 90);
+        assert_eq!(summary.total_output_tokens, 12);
+    }
+
+    #[test]
+    fn codex_observations_keep_event_day_and_model() {
+        let raw = format!(
+            "{}\n{}\n{}",
+            r#"{"type":"session_meta","payload":{"id":"s","cwd":"/repo","model_provider":"openai"}}"#,
+            r#"{"type":"turn_context","payload":{"model":"gpt-5.6-sol"}}"#,
+            codex_token_line("2026-08-10T01:00:00Z", 100, 80, 10, 100, 80, 10),
+        );
+        let summary = CodexAdapter.parse_raw("/fixtures/codex-day.jsonl", &raw);
+        let observation = &summary.codex_usage_observations[0];
+        assert_eq!(observation.model, "gpt-5.6-sol");
+        assert!(observation.day.is_some());
+        assert_eq!(observation.reasoning_tokens, 1);
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/db/queries.rs
+++ b/apps/desktop/src-tauri/src/db/queries.rs
@@ -1061,6 +1061,148 @@ pub fn set_session_cost(
     Ok(())
 }
 
+#[derive(Debug, Clone)]
+pub struct CodexUsageObservationInput {
+    pub source_line: i64,
+    pub observed_at: Option<String>,
+    pub local_day: Option<String>,
+    pub model: String,
+    pub input_tokens: i64,
+    pub cache_read_tokens: i64,
+    pub output_tokens: i64,
+    pub reasoning_tokens: i64,
+    pub cost_usd: f64,
+    pub cumulative_input_tokens: Option<i64>,
+    pub cumulative_cache_read_tokens: Option<i64>,
+    pub cumulative_output_tokens: Option<i64>,
+    pub cumulative_reasoning_tokens: Option<i64>,
+    pub disposition: String,
+}
+
+pub fn append_codex_usage_observations(
+    conn: &Connection,
+    session_id: &str,
+    observations: &[CodexUsageObservationInput],
+) -> Result<usize, rusqlite::Error> {
+    let mut inserted = 0;
+    for item in observations {
+        inserted += conn.execute(
+            "INSERT OR IGNORE INTO codex_usage_observations (
+                session_id, source_line, observed_at, local_day, model,
+                input_tokens, cache_read_tokens, output_tokens, reasoning_tokens, cost_usd,
+                cumulative_input_tokens, cumulative_cache_read_tokens,
+                cumulative_output_tokens, cumulative_reasoning_tokens, disposition
+             ) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15)",
+            params![
+                session_id,
+                item.source_line,
+                item.observed_at,
+                item.local_day,
+                item.model,
+                item.input_tokens,
+                item.cache_read_tokens,
+                item.output_tokens,
+                item.reasoning_tokens,
+                item.cost_usd,
+                item.cumulative_input_tokens,
+                item.cumulative_cache_read_tokens,
+                item.cumulative_output_tokens,
+                item.cumulative_reasoning_tokens,
+                item.disposition,
+            ],
+        )?;
+    }
+    Ok(inserted)
+}
+
+pub fn replace_codex_usage_observations(
+    conn: &Connection,
+    session_id: &str,
+    observations: &[CodexUsageObservationInput],
+) -> Result<usize, rusqlite::Error> {
+    conn.execute(
+        "DELETE FROM codex_usage_observations WHERE session_id = ?1",
+        params![session_id],
+    )?;
+    append_codex_usage_observations(conn, session_id, observations)
+}
+
+pub fn reconcile_codex_usage_totals(
+    conn: &Connection,
+    session_id: &str,
+) -> Result<(), rusqlite::Error> {
+    conn.execute(
+        "UPDATE cc_sessions SET
+            total_input_tokens = COALESCE((
+                SELECT SUM(input_tokens) FROM codex_usage_observations
+                WHERE session_id = ?1 AND disposition = 'accepted'
+            ), 0),
+            total_output_tokens = COALESCE((
+                SELECT SUM(output_tokens) FROM codex_usage_observations
+                WHERE session_id = ?1 AND disposition = 'accepted'
+            ), 0),
+            cache_read_tokens = COALESCE((
+                SELECT SUM(cache_read_tokens) FROM codex_usage_observations
+                WHERE session_id = ?1 AND disposition = 'accepted'
+            ), 0),
+            estimated_cost_usd = COALESCE((
+                SELECT SUM(cost_usd) FROM codex_usage_observations
+                WHERE session_id = ?1 AND disposition = 'accepted'
+            ), 0)
+         WHERE id = ?1",
+        params![session_id],
+    )?;
+
+    conn.execute(
+        "DELETE FROM session_model_usage WHERE session_id = ?1",
+        params![session_id],
+    )?;
+    conn.execute(
+        "INSERT INTO session_model_usage (
+            session_id, model, message_count, input_tokens, output_tokens,
+            cache_read_tokens, cache_creation_tokens, cache_creation_1h_tokens
+         )
+         SELECT session_id, model, COUNT(*), SUM(input_tokens), SUM(output_tokens),
+                SUM(cache_read_tokens), 0, 0
+         FROM codex_usage_observations
+         WHERE session_id = ?1 AND disposition = 'accepted'
+         GROUP BY session_id, model",
+        params![session_id],
+    )?;
+    Ok(())
+}
+
+pub fn record_codex_usage_repair(
+    conn: &Connection,
+    session_id: &str,
+    revision: i64,
+    status: &str,
+    accepted_events: i64,
+    excluded_events: i64,
+    detail: Option<&str>,
+) -> Result<(), rusqlite::Error> {
+    conn.execute(
+        "INSERT INTO codex_usage_repair_audit (
+            session_id, revision, status, accepted_events, excluded_events, repaired_at, detail
+         ) VALUES (?1,?2,?3,?4,?5,?6,?7)
+         ON CONFLICT(session_id) DO UPDATE SET
+            revision=excluded.revision, status=excluded.status,
+            accepted_events=excluded.accepted_events,
+            excluded_events=excluded.excluded_events,
+            repaired_at=excluded.repaired_at, detail=excluded.detail",
+        params![
+            session_id,
+            revision,
+            status,
+            accepted_events,
+            excluded_events,
+            chrono::Utc::now().to_rfc3339(),
+            detail,
+        ],
+    )?;
+    Ok(())
+}
+
 pub fn sync_session_message_archive_fts(conn: &Connection) -> Result<i64, rusqlite::Error> {
     let archive_count: i64 =
         conn.query_row("SELECT COUNT(*) FROM session_message_archive", [], |row| {
@@ -2102,9 +2244,9 @@ pub fn get_token_usage_stats(conn: &Connection) -> Result<TokenUsageStats, rusql
     //
     // - Magnitude: session-level totals (cc_sessions.total_input_tokens +
     //   total_output_tokens). Same methodology as ccusage; includes cache.
-    // - Day attribution: distribute each session's canonical total across
-    //   days proportionally to per-day message activity (cc_session_days
-    //   bucket counts). Sessions active only on one day attribute fully.
+    // - Codex day attribution: sum accepted timestamped token observations.
+    // - Other adapters: distribute each session's canonical total across days
+    //   proportionally to per-day message activity (legacy approximation).
     //
     // cc_session_days replaced per-message rows in v1.1.9 — same math, but
     // ~50× less storage since we keep `(session, day, count)` not raw rows.
@@ -2115,8 +2257,8 @@ pub fn get_token_usage_stats(conn: &Connection) -> Result<TokenUsageStats, rusql
              SELECT session_id, SUM(msg_count) AS total_n
              FROM cc_session_days
              GROUP BY session_id
-         )
-         SELECT d.day,
+         ), legacy_days AS (
+             SELECT d.day,
                 SUM(
                     (COALESCE(s.total_input_tokens, 0) + COALESCE(s.total_output_tokens, 0))
                     * d.msg_count * 1.0 / t.total_n
@@ -2137,8 +2279,21 @@ pub fn get_token_usage_stats(conn: &Connection) -> Result<TokenUsageStats, rusql
          FROM cc_session_days d
          JOIN session_total t ON t.session_id = d.session_id
          JOIN cc_sessions s ON s.id = d.session_id
-         WHERE d.day >= ?1
-         GROUP BY d.day",
+         WHERE d.day >= ?1 AND s.agent_type != 'codex'
+         GROUP BY d.day
+         ), codex_days AS (
+             SELECT local_day AS day,
+                    SUM(input_tokens + output_tokens) AS tokens,
+                    SUM(MAX(input_tokens - cache_read_tokens, 0) + output_tokens) AS generated,
+                    SUM(cache_read_tokens) AS cache,
+                    SUM(cost_usd) AS cost
+             FROM codex_usage_observations
+             WHERE disposition = 'accepted' AND local_day >= ?1
+             GROUP BY local_day
+         )
+         SELECT day, SUM(tokens), SUM(generated), SUM(cache), SUM(cost)
+         FROM (SELECT * FROM legacy_days UNION ALL SELECT * FROM codex_days)
+         GROUP BY day",
     )?;
 
     // day -> (tokens, generated, cache, cost)
@@ -2219,47 +2374,11 @@ pub fn get_token_usage_stats(conn: &Connection) -> Result<TokenUsageStats, rusql
     // Weekly series: last 12 ISO weeks (Monday-starting), zero-filled.
     let twelve_weeks_start = monday - Duration::weeks(11);
     let twelve_str = twelve_weeks_start.format("%Y-%m-%d").to_string();
-    let mut stmt2 = conn.prepare(
-        "WITH session_total AS (
-             SELECT session_id, SUM(msg_count) AS total_n
-             FROM cc_session_days
-             GROUP BY session_id
-         )
-         SELECT d.day,
-                SUM(
-                    (COALESCE(s.total_input_tokens, 0) + COALESCE(s.total_output_tokens, 0))
-                    * d.msg_count * 1.0 / t.total_n
-                ) AS tok,
-                SUM(
-                    (MAX(COALESCE(s.total_input_tokens, 0)
-                         - COALESCE(s.cache_read_tokens, 0)
-                         - COALESCE(s.cache_creation_tokens, 0), 0)
-                     + COALESCE(s.total_output_tokens, 0))
-                    * d.msg_count * 1.0 / t.total_n
-                ) AS gen,
-                SUM(
-                    COALESCE(s.cache_read_tokens, 0) * d.msg_count * 1.0 / t.total_n
-                ) AS cache,
-                SUM(
-                    COALESCE(s.estimated_cost_usd, 0.0) * d.msg_count * 1.0 / t.total_n
-                ) AS cost
-         FROM cc_session_days d
-         JOIN session_total t ON t.session_id = d.session_id
-         JOIN cc_sessions s ON s.id = d.session_id
-         WHERE d.day >= ?1
-         GROUP BY d.day",
-    )?;
-    let day_rows: Vec<(String, f64, f64, f64, f64)> = stmt2
-        .query_map(params![twelve_str], |r| {
-            Ok((
-                r.get::<_, String>(0)?,
-                r.get::<_, f64>(1)?,
-                r.get::<_, f64>(2)?,
-                r.get::<_, f64>(3)?,
-                r.get::<_, f64>(4)?,
-            ))
-        })?
-        .collect::<Result<_, _>>()?;
+    let day_rows: Vec<(String, f64, f64, f64, f64)> = day_map
+        .iter()
+        .filter(|(day, _)| day.as_str() >= twelve_str.as_str())
+        .map(|(day, values)| (day.clone(), values.0, values.1, values.2, values.3))
+        .collect();
 
     let mut weekly_series = Vec::with_capacity(12);
     for i in 0..12 {
@@ -2349,7 +2468,7 @@ pub fn get_agent_usage_by_day(
              SELECT session_id, SUM(msg_count) AS total_n
              FROM cc_session_days
              GROUP BY session_id
-         )
+         ), legacy AS (
          SELECT d.day, s.agent_type,
                 SUM(
                     (MAX(COALESCE(s.total_input_tokens, 0)
@@ -2367,10 +2486,22 @@ pub fn get_agent_usage_by_day(
          FROM cc_session_days d
          JOIN session_total t ON t.session_id = d.session_id
          JOIN cc_sessions s ON s.id = d.session_id
-         WHERE d.day >= ?1
+         WHERE d.day >= ?1 AND s.agent_type != 'codex'
          GROUP BY d.day, s.agent_type
-         HAVING generated > 0 OR cache > 0
-         ORDER BY d.day",
+         ), codex AS (
+             SELECT local_day AS day, 'codex' AS agent_type,
+                    SUM(MAX(input_tokens - cache_read_tokens, 0) + output_tokens) AS generated,
+                    SUM(cache_read_tokens) AS cache,
+                    SUM(cost_usd) AS cost
+             FROM codex_usage_observations
+             WHERE disposition = 'accepted' AND local_day >= ?1
+             GROUP BY local_day
+         )
+         SELECT day, agent_type, SUM(generated), SUM(cache), SUM(cost)
+         FROM (SELECT * FROM legacy UNION ALL SELECT * FROM codex)
+         GROUP BY day, agent_type
+         HAVING SUM(generated) > 0 OR SUM(cache) > 0
+         ORDER BY day",
     )?;
     let rows = stmt
         .query_map(params![since], |r| {
@@ -2553,6 +2684,11 @@ pub fn get_usage_by_model(
                  GROUP BY session_id
                  HAVING SUM(CASE WHEN day >= ?1 THEN msg_count ELSE 0 END) > 0"
     };
+    let codex_date_filter = if day_range.is_some() {
+        "o.local_day >= ?1 AND o.local_day < ?2"
+    } else {
+        "o.local_day >= ?1"
+    };
 
     let sql = if day_range.is_some() || since.is_some() {
         format!(
@@ -2571,7 +2707,7 @@ pub fn get_usage_by_model(
                 FROM session_model_usage u
                 JOIN cc_sessions s ON s.id = u.session_id
                 JOIN frac w ON w.session_id = u.session_id
-                WHERE 1=1{agent_filter}
+                WHERE s.agent_type != 'codex'{agent_filter}
                 UNION ALL
                 SELECT CASE WHEN COALESCE(NULLIF(s.model_used, ''), 'unknown') = '<synthetic>'
                             THEN 'synthetic'
@@ -2581,9 +2717,15 @@ pub fn get_usage_by_model(
                        w.f
                 FROM cc_sessions s
                 JOIN frac w ON w.session_id = s.id
-                WHERE NOT EXISTS (
+                WHERE s.agent_type != 'codex' AND NOT EXISTS (
                     SELECT 1 FROM session_model_usage u WHERE u.session_id = s.id
                 ){agent_filter}
+                UNION ALL
+                SELECT COALESCE(NULLIF(o.model, ''), 'unknown'), o.session_id,
+                       o.input_tokens, o.output_tokens, o.cache_read_tokens, 0, 1.0
+                FROM codex_usage_observations o
+                JOIN cc_sessions s ON s.id = o.session_id
+                WHERE o.disposition = 'accepted' AND {codex_date_filter}{agent_filter}
              )
              GROUP BY model"
         )
@@ -2841,6 +2983,101 @@ mod tests {
     use crate::db::schema;
 
     #[test]
+    fn codex_observations_are_idempotent_and_reconcile_canonical_totals() {
+        let conn = Connection::open_in_memory().expect("memory db");
+        schema::run_migrations(&conn).expect("schema");
+        upsert_project(
+            &conn,
+            &ProjectInput {
+                id: "p".into(),
+                display_name: "P".into(),
+                dir_path: "/p".into(),
+                session_count: None,
+                last_activity: None,
+                created_at: "2026-01-01T00:00:00Z".into(),
+            },
+        )
+        .expect("project");
+        upsert_session(
+            &conn,
+            &SessionInput {
+                id: "s".into(),
+                project_id: "p".into(),
+                agent_type: Some("codex".into()),
+                jsonl_path: Some("/p/s.jsonl".into()),
+                git_branch: None,
+                cwd: None,
+                cli_version: None,
+                first_message: None,
+                last_message: None,
+                message_count: Some(1),
+                total_input_tokens: Some(999),
+                total_output_tokens: Some(999),
+                model_used: Some("gpt-5".into()),
+                slug: None,
+                file_size_bytes: None,
+                indexed_at: None,
+                file_mtime: None,
+                cache_read_tokens: Some(999),
+                cache_creation_tokens: Some(0),
+                compaction_count: None,
+                estimated_cost_usd: Some(999.0),
+            },
+        )
+        .expect("session");
+        let observation = CodexUsageObservationInput {
+            source_line: 7,
+            observed_at: Some("2026-01-02T00:00:00Z".into()),
+            local_day: Some("2026-01-02".into()),
+            model: "gpt-5".into(),
+            input_tokens: 100,
+            cache_read_tokens: 80,
+            output_tokens: 20,
+            reasoning_tokens: 5,
+            cost_usd: 0.25,
+            cumulative_input_tokens: Some(100),
+            cumulative_cache_read_tokens: Some(80),
+            cumulative_output_tokens: Some(20),
+            cumulative_reasoning_tokens: Some(5),
+            disposition: "accepted".into(),
+        };
+        assert_eq!(
+            append_codex_usage_observations(&conn, "s", &[observation.clone()]).unwrap(),
+            1
+        );
+        assert_eq!(
+            append_codex_usage_observations(&conn, "s", &[observation.clone()]).unwrap(),
+            0
+        );
+        reconcile_codex_usage_totals(&conn, "s").expect("reconcile");
+        let totals: (i64, i64, i64, f64) = conn.query_row(
+            "SELECT total_input_tokens,total_output_tokens,cache_read_tokens,estimated_cost_usd FROM cc_sessions WHERE id='s'",
+            [], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
+        ).unwrap();
+        assert_eq!(totals, (100, 20, 80, 0.25));
+        let models = get_session_model_usage(&conn, "s").unwrap();
+        assert_eq!(models.len(), 1);
+        assert_eq!(models[0].input_tokens, 100);
+
+        let mut replacement = observation;
+        replacement.source_line = 8;
+        replacement.input_tokens = 25;
+        replacement.cache_read_tokens = 20;
+        replacement.output_tokens = 5;
+        replacement.cost_usd = 0.05;
+        replace_codex_usage_observations(&conn, "s", &[replacement]).expect("replace");
+        reconcile_codex_usage_totals(&conn, "s").expect("reconcile replacement");
+        let replaced: (i64, i64, i64, f64, i64) = conn.query_row(
+            "SELECT total_input_tokens,total_output_tokens,cache_read_tokens,estimated_cost_usd,
+                    (SELECT COUNT(*) FROM codex_usage_observations WHERE session_id='s')
+             FROM cc_sessions WHERE id='s'",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?)),
+        ).unwrap();
+        assert_eq!(replaced, (25, 5, 20, 0.05, 1));
+    }
+
+    #[test]
     fn quick_index_zero_tokens_do_not_wipe_full_counts() {
         let conn = Connection::open_in_memory().expect("memory db");
         schema::run_migrations(&conn).expect("schema");
@@ -2976,7 +3213,7 @@ mod tests {
         let today = chrono::Local::now().date_naive();
         let today_str = today.format("%Y-%m-%d").to_string();
         let now = chrono::Utc::now().to_rfc3339();
-        insert_session("current", &now, 10_000, 900, 7_000, 1_000, 2.50);
+        insert_session("current", &now, 10_000, 900, 7_000, 0, 2.50);
         insert_session("old", "2020-01-01T00:00:00Z", 1_000, 700, 300, 200, 1.25);
         conn.execute(
             "INSERT INTO cc_session_days (session_id, day, msg_count)
@@ -2984,6 +3221,27 @@ mod tests {
             params![today_str],
         )
         .expect("day");
+        append_codex_usage_observations(
+            &conn,
+            "current",
+            &[CodexUsageObservationInput {
+                source_line: 1,
+                observed_at: Some(now),
+                local_day: Some(today_str.clone()),
+                model: "gpt-5.5".to_string(),
+                input_tokens: 10_000,
+                cache_read_tokens: 7_000,
+                output_tokens: 900,
+                reasoning_tokens: 0,
+                cost_usd: 2.50,
+                cumulative_input_tokens: Some(10_000),
+                cumulative_cache_read_tokens: Some(7_000),
+                cumulative_output_tokens: Some(900),
+                cumulative_reasoning_tokens: None,
+                disposition: "accepted".to_string(),
+            }],
+        )
+        .expect("observation");
 
         let rows = get_agent_usage_breakdown(&conn).expect("agent usage");
         let codex = rows
@@ -2991,21 +3249,21 @@ mod tests {
             .find(|r| r.agent_type == "codex")
             .expect("codex row");
         assert_eq!(codex.sessions, 2);
-        assert_eq!(codex.real_input_tokens, 2_500);
+        assert_eq!(codex.real_input_tokens, 3_500);
         assert_eq!(codex.cache_read_tokens, 7_300);
         assert_eq!(codex.output_tokens, 1_600);
-        assert_eq!(codex.week_real_input_tokens, 2_000);
+        assert_eq!(codex.week_real_input_tokens, 3_000);
         assert_eq!(codex.week_output_tokens, 900);
         assert_eq!(codex.cost, 3.75);
 
         let by_day = get_agent_usage_by_day(&conn, 1).expect("agent day usage");
         assert_eq!(by_day.len(), 1);
-        assert_eq!(by_day[0].generated, 2_900);
+        assert_eq!(by_day[0].generated, 3_900);
         assert_eq!(by_day[0].cache, 7_000);
         assert_eq!(by_day[0].cost, 2.50);
 
         let stats = get_token_usage_stats(&conn).expect("token usage stats");
-        assert_eq!(stats.today_generated, 2_900);
+        assert_eq!(stats.today_generated, 3_900);
         assert_eq!(stats.today_cost, 2.50);
     }
 
@@ -3064,6 +3322,27 @@ mod tests {
             [],
         )
         .expect("days");
+        append_codex_usage_observations(
+            &conn,
+            "codex",
+            &[CodexUsageObservationInput {
+                source_line: 1,
+                observed_at: Some("2026-01-03T00:00:00Z".to_string()),
+                local_day: Some("2026-01-03".to_string()),
+                model: "gpt-5".to_string(),
+                input_tokens: 2_000,
+                cache_read_tokens: 0,
+                output_tokens: 100,
+                reasoning_tokens: 0,
+                cost_usd: 2.0,
+                cumulative_input_tokens: Some(2_000),
+                cumulative_cache_read_tokens: Some(0),
+                cumulative_output_tokens: Some(100),
+                cumulative_reasoning_tokens: None,
+                disposition: "accepted".to_string(),
+            }],
+        )
+        .expect("observation");
 
         let estimate = |_: &str, input: i64, _: i64, _: i64, _: i64| input as f64 / 1_000.0;
         let exclude_codex = vec!["codex".to_string()];

--- a/apps/desktop/src-tauri/src/db/schema.rs
+++ b/apps/desktop/src-tauri/src/db/schema.rs
@@ -110,6 +110,42 @@ pub fn run_migrations(conn: &Connection) -> Result<(), rusqlite::Error> {
     // duplicate group split across two incremental tail reads (blocks can land
     // ~40s apart) is still counted once.
     let _ = conn.execute("ALTER TABLE cc_sessions ADD COLUMN last_usage_key TEXT", []);
+    // Timestamped, content-free Codex usage evidence. Unlike cc_session_days,
+    // these rows carry the token delta observed at the event timestamp, so
+    // calendar totals never need to prorate a whole session by message count.
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS codex_usage_observations (
+            session_id TEXT NOT NULL REFERENCES cc_sessions(id) ON DELETE CASCADE,
+            source_line INTEGER NOT NULL,
+            observed_at TEXT,
+            local_day TEXT,
+            model TEXT NOT NULL,
+            input_tokens INTEGER NOT NULL DEFAULT 0,
+            cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+            output_tokens INTEGER NOT NULL DEFAULT 0,
+            reasoning_tokens INTEGER NOT NULL DEFAULT 0,
+            cost_usd REAL NOT NULL DEFAULT 0,
+            cumulative_input_tokens INTEGER,
+            cumulative_cache_read_tokens INTEGER,
+            cumulative_output_tokens INTEGER,
+            cumulative_reasoning_tokens INTEGER,
+            disposition TEXT NOT NULL,
+            PRIMARY KEY (session_id, source_line)
+        );
+        CREATE INDEX IF NOT EXISTS idx_codex_usage_observations_day
+            ON codex_usage_observations(local_day, disposition);
+        CREATE INDEX IF NOT EXISTS idx_codex_usage_observations_session_time
+            ON codex_usage_observations(session_id, observed_at);
+        CREATE TABLE IF NOT EXISTS codex_usage_repair_audit (
+            session_id TEXT PRIMARY KEY REFERENCES cc_sessions(id) ON DELETE CASCADE,
+            revision INTEGER NOT NULL,
+            status TEXT NOT NULL,
+            accepted_events INTEGER NOT NULL DEFAULT 0,
+            excluded_events INTEGER NOT NULL DEFAULT 0,
+            repaired_at TEXT NOT NULL,
+            detail TEXT
+        );",
+    )?;
     let _ = conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_cc_sessions_last_message
          ON cc_sessions(last_message DESC)",

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-utils/schema.json",
   "identifier": "com.codevetter.desktop",
   "productName": "CodeVetter",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "build": {
     "beforeDevCommand": "npm run dev",
     "beforeBuildCommand": "npm run prepare:mcp-sidecar:release && npm run prepare:cli-sidecar:release && npm run prepare:agent-island:release && npm run build",

--- a/apps/desktop/src-tauri/tests/fixtures/codex-accounting/duplicate.jsonl
+++ b/apps/desktop/src-tauri/tests/fixtures/codex-accounting/duplicate.jsonl
@@ -1,0 +1,4 @@
+{"timestamp":"2026-08-10T12:00:00Z","type":"session_meta","payload":{"id":"duplicate","cwd":"/repo","model_provider":"openai"}}
+{"timestamp":"2026-08-10T12:00:00Z","type":"turn_context","payload":{"model":"gpt-5.5"}}
+{"timestamp":"2026-08-10T12:00:01Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":100,"cached_input_tokens":80,"output_tokens":10},"total_token_usage":{"input_tokens":100,"cached_input_tokens":80,"output_tokens":10}}}}
+{"timestamp":"2026-08-10T12:00:02Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":100,"cached_input_tokens":80,"output_tokens":10},"total_token_usage":{"input_tokens":100,"cached_input_tokens":80,"output_tokens":10}}}}

--- a/apps/desktop/src-tauri/tests/fixtures/codex-accounting/fork-direct.jsonl
+++ b/apps/desktop/src-tauri/tests/fixtures/codex-accounting/fork-direct.jsonl
@@ -1,0 +1,4 @@
+{"timestamp":"2026-08-10T12:00:00Z","type":"session_meta","payload":{"id":"fork-direct","cwd":"/repo","forked_from_id":"parent"}}
+{"timestamp":"2026-08-10T12:00:00Z","type":"turn_context","payload":{"model":"gpt-5.5"}}
+{"timestamp":"2026-08-10T12:00:01Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":100,"cached_input_tokens":80,"output_tokens":10},"total_token_usage":{"input_tokens":1100,"cached_input_tokens":880,"output_tokens":110}}}}
+{"timestamp":"2026-08-10T12:00:02Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":50,"cached_input_tokens":40,"output_tokens":5},"total_token_usage":{"input_tokens":1150,"cached_input_tokens":920,"output_tokens":115}}}}

--- a/apps/desktop/src-tauri/tests/fixtures/codex-accounting/fork-replay.jsonl
+++ b/apps/desktop/src-tauri/tests/fixtures/codex-accounting/fork-replay.jsonl
@@ -1,0 +1,7 @@
+{"timestamp":"2026-08-10T12:00:00Z","type":"session_meta","payload":{"id":"fork-replay","cwd":"/repo","source":{"subagent":{"thread_spawn":{"parent_thread_id":"parent"}}}}}
+{"timestamp":"2026-08-10T12:00:00Z","type":"session_meta","payload":{"id":"parent"}}
+{"timestamp":"2026-08-10T12:00:00Z","type":"turn_context","payload":{"model":"gpt-5.5"}}
+{"timestamp":"2026-08-10T12:00:01Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":1000,"cached_input_tokens":800,"output_tokens":100},"total_token_usage":{"input_tokens":1000,"cached_input_tokens":800,"output_tokens":100}}}}
+{"timestamp":"2026-08-10T12:00:02Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":500,"cached_input_tokens":400,"output_tokens":50},"total_token_usage":{"input_tokens":1500,"cached_input_tokens":1200,"output_tokens":150}}}}
+{"timestamp":"2026-08-10T12:01:00Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":100,"cached_input_tokens":80,"output_tokens":10},"total_token_usage":{"input_tokens":100,"cached_input_tokens":80,"output_tokens":10}}}}
+{"timestamp":"2026-08-10T12:01:01Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":50,"cached_input_tokens":40,"output_tokens":5},"total_token_usage":{"input_tokens":150,"cached_input_tokens":120,"output_tokens":15}}}}

--- a/apps/desktop/src-tauri/tests/fixtures/codex-accounting/interleaved.jsonl
+++ b/apps/desktop/src-tauri/tests/fixtures/codex-accounting/interleaved.jsonl
@@ -1,0 +1,5 @@
+{"timestamp":"2026-08-10T12:00:00Z","type":"session_meta","payload":{"id":"interleaved","cwd":"/repo"}}
+{"timestamp":"2026-08-10T12:00:00Z","type":"turn_context","payload":{"model":"gpt-5.5"}}
+{"timestamp":"2026-08-10T12:00:01Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":100,"cached_input_tokens":80,"output_tokens":10},"total_token_usage":{"input_tokens":100,"cached_input_tokens":80,"output_tokens":10}}}}
+{"timestamp":"2026-08-10T12:00:02Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":40,"cached_input_tokens":30,"output_tokens":4},"total_token_usage":{"input_tokens":40,"cached_input_tokens":30,"output_tokens":4}}}}
+{"timestamp":"2026-08-10T12:00:03Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":80,"cached_input_tokens":60,"output_tokens":8},"total_token_usage":{"input_tokens":120,"cached_input_tokens":90,"output_tokens":12}}}}

--- a/apps/desktop/src-tauri/tests/fixtures/codex-accounting/oracle.json
+++ b/apps/desktop/src-tauri/tests/fixtures/codex-accounting/oracle.json
@@ -1,0 +1,47 @@
+[
+  {
+    "file": "ordinary.jsonl",
+    "model": "gpt-5.5",
+    "local_day": "2026-08-10",
+    "input": 150,
+    "cached": 120,
+    "output": 15,
+    "dispositions": ["accepted", "accepted"]
+  },
+  {
+    "file": "duplicate.jsonl",
+    "model": "gpt-5.5",
+    "local_day": "2026-08-10",
+    "input": 100,
+    "cached": 80,
+    "output": 10,
+    "dispositions": ["accepted", "duplicate"]
+  },
+  {
+    "file": "fork-direct.jsonl",
+    "model": "gpt-5.5",
+    "local_day": "2026-08-10",
+    "input": 150,
+    "cached": 120,
+    "output": 15,
+    "dispositions": ["accepted", "accepted"]
+  },
+  {
+    "file": "fork-replay.jsonl",
+    "model": "gpt-5.5",
+    "local_day": "2026-08-10",
+    "input": 150,
+    "cached": 120,
+    "output": 15,
+    "dispositions": ["inherited_replay", "inherited_replay", "accepted", "accepted"]
+  },
+  {
+    "file": "interleaved.jsonl",
+    "model": "gpt-5.5",
+    "local_day": "2026-08-10",
+    "input": 120,
+    "cached": 90,
+    "output": 12,
+    "dispositions": ["accepted", "accepted", "accepted"]
+  }
+]

--- a/apps/desktop/src-tauri/tests/fixtures/codex-accounting/ordinary.jsonl
+++ b/apps/desktop/src-tauri/tests/fixtures/codex-accounting/ordinary.jsonl
@@ -1,0 +1,4 @@
+{"timestamp":"2026-08-10T12:00:00Z","type":"session_meta","payload":{"id":"ordinary","cwd":"/repo","model_provider":"openai"}}
+{"timestamp":"2026-08-10T12:00:00Z","type":"turn_context","payload":{"model":"gpt-5.5"}}
+{"timestamp":"2026-08-10T12:00:01Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":100,"cached_input_tokens":80,"output_tokens":10},"total_token_usage":{"input_tokens":100,"cached_input_tokens":80,"output_tokens":10}}}}
+{"timestamp":"2026-08-10T12:00:02Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":50,"cached_input_tokens":40,"output_tokens":5},"total_token_usage":{"input_tokens":150,"cached_input_tokens":120,"output_tokens":15}}}}

--- a/apps/desktop/src/lib/tauri-ipc.ts
+++ b/apps/desktop/src/lib/tauri-ipc.ts
@@ -650,6 +650,11 @@ export interface LiveSessionEvidencePolicy {
   update_event: string;
   local_only: boolean;
   last_full_indexed_at?: string | null;
+  last_usage_observed_at?: string | null;
+  incomplete_codex_sources: number;
+  pending_codex_bytes: number;
+  duplicate_usage_events: number;
+  excluded_usage_events: number;
 }
 
 export interface SessionScorecard {

--- a/apps/desktop/src/pages/Home.tsx
+++ b/apps/desktop/src/pages/Home.tsx
@@ -2722,7 +2722,10 @@ export default function Home() {
     void (async () => {
       try {
         const { listen } = await import('@tauri-apps/api/event');
-        const un = await listen('session_archive_updated', () => run());
+        const un = await listen('session_archive_updated', () => {
+          run();
+          refreshDashboard();
+        });
         if (cancelled) un();
         else unlisten = un;
       } catch {
@@ -2734,7 +2737,7 @@ export default function Home() {
       clearInterval(interval);
       unlisten?.();
     };
-  }, [isHomeActive, hiddenAgents, fetchModelUsage]);
+  }, [isHomeActive, hiddenAgents, fetchModelUsage, refreshDashboard]);
 
   // ─── Periodic background sync every 60s ───────────────────────────────
   // Keeps token-usage counters near-realtime. Paused while the window is
@@ -2837,10 +2840,18 @@ export default function Home() {
                 <Badge
                   variant="outline"
                   className="h-6 border-emerald-500/25 bg-emerald-500/[0.06] px-2 text-[11px] font-medium text-emerald-300/80"
-                  title={`Local-only ${liveSessionPolicy.mode}; full/manual recovery every ${Math.round(liveSessionPolicy.full_index_recovery_interval_secs / 3600)}h; event ${liveSessionPolicy.update_event}`}
+                  title={`Local-only ${liveSessionPolicy.mode}; full/manual recovery every ${Math.round(liveSessionPolicy.full_index_recovery_interval_secs / 3600)}h; ${liveSessionPolicy.incomplete_codex_sources} Codex sources pending (${formatCompactNumber(liveSessionPolicy.pending_codex_bytes)} bytes); ${liveSessionPolicy.excluded_usage_events} excluded usage events; last usage ${liveSessionPolicy.last_usage_observed_at ?? 'unavailable'}`}
                 >
                   live archive · {liveSessionPolicy.incremental_interval_secs}s ·{' '}
                   {liveSessionPolicy.supported_incremental_adapters.join(' + ')}
+                </Badge>
+              )}
+              {liveSessionPolicy && liveSessionPolicy.incomplete_codex_sources > 0 && (
+                <Badge
+                  variant="outline"
+                  className="h-6 border-amber-500/25 bg-amber-500/[0.06] px-2 text-[11px] font-medium text-amber-300/80"
+                >
+                  usage catching up · {liveSessionPolicy.incomplete_codex_sources} sources
                 </Badge>
               )}
               <Button

--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -27,7 +27,7 @@ repairs run as idempotent migrations guarded by feature flags. The groups:
 
 | Group | Tables | Purpose |
 |---|---|---|
-| Sessions / telemetry | `cc_projects`, `cc_sessions`, `cc_session_days`, `cc_messages`, `session_model_usage`, `session_adapter_runs`, `session_message_archive` | Indexed agent transcripts (Claude / Codex / Gemini), per-day attribution, per-model usage splits, FTS archive. |
+| Sessions / telemetry | `cc_projects`, `cc_sessions`, `cc_session_days`, `cc_messages`, `session_model_usage`, `codex_usage_observations`, `codex_usage_repair_audit`, `session_adapter_runs`, `session_message_archive` | Indexed agent transcripts, timestamped Codex token evidence, repair diagnostics, per-day attribution, per-model usage splits, FTS archive. |
 | Reviews | `local_reviews`, `local_review_findings`, `review_procedure_events` | Review runs, findings (with `disposition` accept/dismiss), staged-verification events. |
 | Synthetic QA | `synthetic_qa_runs` | QA runs persisted as first-class records; fed as `qa_evidence` into review prompts. |
 | Audience validation | `audience_validation_runs`, `audience_validation_responses` | Privacy-minimizing audience runs + agent/human/imported responses; ShipRank diagnostics derive from these. |
@@ -46,9 +46,12 @@ repairs run as idempotent migrations guarded by feature flags. The groups:
   content block and repeats the final usage. Don't re-add raw usage without
   the dedup gate — see
   [knowledge/learnings/telemetry-and-indexing.md](../knowledge/learnings/telemetry-and-indexing.md).
-- **Codex tokens are cumulative.** Codex reports session-cumulative totals;
-  the indexer uses a `tokens_absolute` flag so cumulative totals are SET, not
-  added. The `fix_codex_token_totals` repair re-reads each Codex file.
+- **Codex accounting is observation-backed.** `token_count` events are normalized
+  into content-free `codex_usage_observations`. Exact cumulative repeats are
+  excluded, component watermarks contain resets/interleaved lineages, and the
+  serialized accounting state survives incremental boundaries. Session/model
+  totals are reconciled from accepted rows; period totals use each event's local
+  day rather than message-share proration.
 - **Migrations are guarded and idempotent.** Each one-time repair carries a
   feature-flag gate and is safe to run on a fresh DB. Re-running on an
   already-repaired DB is a no-op.

--- a/docs/knowledge/learnings/telemetry-and-indexing.md
+++ b/docs/knowledge/learnings/telemetry-and-indexing.md
@@ -15,8 +15,36 @@ Format matches [new-things.md](new-things.md); roadmap in [README.md](README.md)
 ## Cumulative vs delta token counters
 - What: some CLIs report per-message token deltas (Claude), others a session-cumulative running total in every event (Codex `total_token_usage`).
 - Why here: adding a cumulative total on each incremental pass compounds — one Codex session reached 61.5B tokens / $35k before the v1.1.99 fix.
-- Gotcha (from code): `SessionAppendDelta.tokens_absolute` switches the UPDATE between SET and ADD per adapter. (`db/queries.rs::apply_session_append_delta`)
-- Source: — (project-specific; see the field's doc comment)
+- Gotcha (from code): a rate-limit-only Codex event can repeat an unchanged
+  `total_token_usage` alongside the previous non-zero `last_token_usage`.
+  Blindly summing `last` double-counts it. Codex now persists cumulative
+  watermarks and exact seen totals, emits accepted/excluded observations, and
+  reconciles canonical totals from accepted rows. (`session_adapters.rs`;
+  `db/queries.rs::reconcile_codex_usage_totals`)
+- Source: https://github.com/openai/codex/issues/14489
+
+## Historical Codex accounting repair
+- What: revisioned streaming replay of readable Codex JSONL sources into
+  `codex_usage_observations`, followed by session/model reconciliation.
+- Why here: old rows can contain both missed live tails and duplicate snapshots;
+  changing only the display query cannot recover or safely correct either.
+- Gotcha (from code): the repair reads bounded chunks, writes each session in a
+  transaction, and is idempotent for a fixed transcript. Missing/unreadable
+  sources retain their previous totals and receive an `unrepaired` audit row;
+  they are never silently zeroed. A transcript that grows between repair passes
+  can legitimately produce a larger second result. (`history.rs::fix_codex_token_totals`)
+- Privacy: observation and audit tables contain timestamps, token counts, model,
+  disposition, and aggregate diagnostics only—never prompts or responses.
+- Qualification: run the repair twice on a frozen database/transcript copy,
+  require byte-for-byte-stable aggregates on pass two, and compare readable
+  sessions with an independent event scanner. Treat a standalone fork scanner's
+  inherited cumulative prefix as replay, not paid child usage. Missing sources
+  remain explicitly unrepaired; they cannot be truthfully reconstructed from
+  the summary row alone.
+- Completion is fail-closed: canonical session/model totals are derived from
+  the persisted accepted observations and checked against the streaming parse
+  inside each transaction. Any mismatch, failed write, or missing audit keeps
+  the accounting revision pending so it retries instead of claiming success.
 
 ## Incremental indexing with byte-offset cursors
 - What: re-reading only the appended tail of a growing file, from a persisted byte offset, instead of re-parsing the whole file.
@@ -27,7 +55,10 @@ Format matches [new-things.md](new-things.md); roadmap in [README.md](README.md)
 ## Local-day bucketing and window boundaries
 - What: attributing usage to calendar days in the user's timezone, and converting local midnight to UTC instants for window queries.
 - Why here: "today/this week" panels; comparing local-date strings with `Z`-suffix timestamps started weeks 5.5h early in IST (fixed v1.2.9).
-- Gotcha (from code): `cc_session_days` holds per-day message counts; the headline day/dollar numbers PRORATE whole-session cost by message share — close, but a midnight-spanning session smears. `timeutil::local_day_start_utc` is the one boundary helper. (`db/queries.rs` day_map query)
+- Gotcha (from code): Codex uses accepted observation timestamps directly.
+  Other adapters still use `cc_session_days` message-share proration, so a
+  midnight-spanning non-Codex session can smear. `timeutil::local_day_start_utc`
+  is the one boundary helper. (`db/queries.rs` day-map query)
 - Source: https://docs.rs/chrono/latest/chrono/
 
 ## API-equivalent pricing tables (pricing revs)

--- a/openspec/changes/archive/2026-08-10-correct-codex-usage-accounting/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-10-correct-codex-usage-accounting/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-10

--- a/openspec/changes/archive/2026-08-10-correct-codex-usage-accounting/design.md
+++ b/openspec/changes/archive/2026-08-10-correct-codex-usage-accounting/design.md
@@ -1,0 +1,93 @@
+## Context
+
+See [proposal.md](./proposal.md). CodeVetter currently stores canonical token totals on `cc_sessions`, stores message-count day buckets in `cc_session_days`, and derives period usage by prorating each session total across those message buckets. Codex parsing sums every `last_token_usage` row and uses a first-second heuristic to suppress copied fork prefixes.
+
+Reference implementations provide stronger invariants. CodexBar records timestamped usage rows, tracks cumulative baselines and monotonic watermarks, suppresses exact cumulative re-emissions, resolves fork inheritance, and prioritizes recent bounded scans. Codex itself documents that rate-limit-only updates can repeat both an unchanged `total_token_usage` and the prior nonzero `last_token_usage`. ccusage and CodexBar aggregate local usage by the usage event's day rather than by session-message proration.
+
+The implementation must remain local-only, incremental over very large JSONL files, compatible with existing SQLite data, and must not retain prompt or tool content for accounting.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make a one-shot scan, an arbitrary sequence of incremental scans, and an idempotent repair produce identical Codex totals.
+- Make daily/weekly/monthly totals directly reproducible from accepted timestamped deltas.
+- Correctly suppress repeated snapshots, inherited fork prefixes, and interleaved cumulative gaps.
+- Keep live usage fresh while archive indexing and FTS maintenance run.
+- Provide content-free diagnostics for every excluded or pending category.
+
+**Non-Goals:**
+
+- Reproduce ChatGPT subscription quota percentages from local token counts.
+- Change Claude, Grok, Cursor, or Devin accounting in this change.
+- Add a new dashboard route or store raw prompts/tool payloads.
+- Guarantee repair of sessions whose source transcripts have been deleted or rotated away.
+
+## Decisions
+
+### Persist normalized Codex usage observations
+
+Add a compact Codex usage-observation table keyed by stable session identity plus source event position. Each accepted row stores timestamp/local day, model, input, cached input, output, reasoning output, cumulative snapshot components, and disposition. Canonical daily totals are sums over accepted observations; session totals are reconciled from the same rows.
+
+Storing only updated session totals was rejected because it cannot reproduce calendar attribution, explain exclusions, or preserve incremental deduplication state across restarts.
+
+### Use cumulative containment as the accounting guard
+
+For each token event, compare `total_token_usage` with persisted state:
+
+1. Exact previously seen total: accept zero.
+2. Monotonic progression: prefer a valid contained cumulative delta, capped by `last_token_usage` when appropriate.
+3. Component decrease: latch interleaved mode, retain a component-wise monotonic watermark, and accept only growth contained above already counted totals.
+4. Missing cumulative total: accept nonnegative `last_token_usage` with a source-position idempotency key.
+
+This follows the core CodexBar invariant while allowing a smaller implementation tailored to CodeVetter's schema. Blindly summing `last_token_usage` was rejected because Codex re-emits it. Using only the latest cumulative total was rejected because it loses per-day/model attribution and fails on interleaved lineages.
+
+### Resolve fork ownership from child-local counter evidence
+
+Use fork lineage as structural evidence, then derive an ordinary child's inherited baseline from its first internally consistent `total - last` snapshot. This avoids subtracting the parent snapshot twice: current Codex child counters already carry the inherited prefix locally. For copied-history subagents, suppress the monotonic replayed prefix until a counter drop establishes the child-local boundary. Until either ownership shape is established, ambiguous events are diagnostic-only.
+
+Cross-file parent subtraction was rejected after frozen-corpus qualification because it zeroed legitimate child requests. Blindly summing each child cumulative total, as a standalone reference scan does, was also rejected because it recounts inherited parent context.
+
+The current “two token rows in the first second” heuristic was rejected because timestamp coincidence is not ownership evidence and does not handle lineage interleaving.
+
+### Separate usage progress from archive progress
+
+Use an independently serialized, bounded usage-ingestion path and cursor/state transaction. Archive messages and FTS synchronization may follow asynchronously. The usage path prioritizes recently modified Codex files and records pending bytes when its time or byte budget expires.
+
+Reusing the global full-index lock was rejected because a long FTS reconciliation makes fresh usage invisible even though the transcript is readable.
+
+### Rebuild Codex-derived data by revision
+
+Introduce a new accounting revision. On repair, stream each readable Codex transcript, replace its normalized observations and derived session/model/day totals transactionally, and leave unreadable sessions untouched with an unrepaired diagnostic. Revision completion is recorded only after all readable candidates have committed.
+
+## Data Flow
+
+```mermaid
+flowchart LR
+    A[Codex JSONL token_count] --> B[Structural event parser]
+    B --> C[Cumulative and fork accounting state]
+    C -->|accepted delta| D[Usage observations]
+    C -->|duplicate, replay, ambiguous| E[Accounting diagnostics]
+    D --> F[Session and model totals]
+    D --> G[Local-day and period totals]
+    H[Archive index and FTS] -. independent .-> B
+```
+
+## Risks / Trade-offs
+
+- [Fork metadata varies across Codex versions] → Keep structural parsing tolerant, treat unresolved ownership conservatively, and add fixtures from ordinary, spawned, forked, and interleaved logs.
+- [Observation rows increase database size] → Store only numeric/accounting fields, use one row per token event, index the period query keys, and retain no transcript content.
+- [A new repair can materially change historical totals] → Run deterministic before/after reconciliation on a database copy, report changed sessions and exclusions, and gate the migration by revision.
+- [Concurrent usage and archive writers can contend in SQLite] → Use short transactions, busy timeouts, bounded batches, and independent cursors; never hold a write transaction while reading transcript files.
+- [Reference behavior evolves] → Encode source-shape fixtures and invariants rather than copying implementation details, and retain diagnostics for unsupported shapes.
+
+## Migration Plan
+
+1. Add the observation/state/diagnostic schema without changing existing reads.
+2. Implement and test the accounting state machine against synthetic adversarial fixtures and sanitized current-format fixtures.
+3. Switch Codex incremental ingestion to dual-write observations and existing totals; assert reconciliation in tests.
+4. Switch period queries to accepted observations for Codex while retaining existing provider paths.
+5. Run the revisioned repair on a database copy and compare CodeVetter totals with independent reference calculations.
+6. Enable the repair for the live database only after validation; unreadable historical sessions retain prior totals.
+
+Rollback disables observation-backed reads and returns to existing session totals. The additive schema remains harmless; the repair must preserve enough pre-repair summary information to report changed rows, but source transcripts remain the canonical recoverable evidence.

--- a/openspec/changes/archive/2026-08-10-correct-codex-usage-accounting/proposal.md
+++ b/openspec/changes/archive/2026-08-10-correct-codex-usage-accounting/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+CodeVetter currently reconstructs Codex usage as a session total and then prorates that total across days by message count. This can misstate recent usage for long-running sessions, double-count re-emitted or interleaved cumulative snapshots, and leave the dashboard unable to explain which source events were accepted or excluded.
+
+Established local trackers such as CodexBar and ccusage instead treat timestamped token events as the accounting evidence, retain cumulative-counter state for deduplication and fork handling, and aggregate accepted deltas directly into calendar buckets. CodeVetter should adopt those proven invariants and verify them against the user's current Codex 0.147 transcript shape.
+
+## What Changes
+
+- Normalize each Codex `token_count` event into an accepted usage delta with its timestamp, model, and cumulative-counter evidence.
+- Deduplicate unchanged `total_token_usage` snapshots so rate-limit-only re-emissions cannot repeat `last_token_usage`.
+- Replace the first-second fork heuristic with cumulative-baseline and monotonic-watermark accounting for forked and interleaved lineages.
+- Persist accepted Codex deltas into local-day usage buckets instead of prorating whole-session totals by message counts.
+- Preserve exact session totals while making period totals equal the sum of accepted timestamped deltas.
+- Add an idempotent repair that rebuilds existing Codex totals and daily buckets from available transcripts without changing Claude or other providers.
+- Expose compact accounting diagnostics: accepted events, duplicate/replayed events, unsupported rows, pending bytes, and last successful observation.
+
+## Capabilities
+
+### New Capabilities
+
+- `codex-usage-accounting`: Deterministic, timestamped, deduplicated Codex token accounting across ordinary, forked, incremental, and interleaved session logs.
+
+### Modified Capabilities
+
+- `live-session-evidence`: Live Codex transcript tailing must advance usage evidence independently of archival maintenance and report observable freshness/pending state.
+
+## Impact
+
+- Rust session adapter, incremental indexer, usage schema/migrations, repair logic, and usage queries.
+- Typed Tauri usage payloads and the existing Usage dashboard diagnostics; no new navigation surface.
+- Existing local SQLite data receives an idempotent Codex-only rebuild from source JSONL where source evidence remains available.
+- No new production dependencies and no provider API or credential changes.

--- a/openspec/changes/archive/2026-08-10-correct-codex-usage-accounting/specs/codex-usage-accounting/spec.md
+++ b/openspec/changes/archive/2026-08-10-correct-codex-usage-accounting/specs/codex-usage-accounting/spec.md
@@ -1,0 +1,68 @@
+## Purpose
+
+Provide deterministic local Codex token and cost accounting whose session and calendar-period totals are reproducible from timestamped transcript evidence.
+
+## ADDED Requirements
+
+### Requirement: Usage events are counted exactly once
+The system SHALL derive Codex usage from token-count evidence and SHALL count an unchanged cumulative usage snapshot no more than once, even when Codex re-emits the preceding per-event usage during a rate-limit-only update.
+
+#### Scenario: Ordinary cumulative progression
+- **WHEN** consecutive token-count events contain increasing cumulative totals and matching per-event usage
+- **THEN** the system accepts one delta per cumulative increase and the accepted deltas sum to the final cumulative total
+
+#### Scenario: Rate-limit-only re-emission
+- **WHEN** a token-count event repeats a previously observed cumulative total and repeats its `last_token_usage`
+- **THEN** the system records no additional tokens or cost for that event
+
+#### Scenario: Incremental read boundary
+- **WHEN** a duplicate cumulative snapshot appears after a persisted incremental byte boundary
+- **THEN** persisted accounting state suppresses the duplicate exactly as a single full-file scan would
+
+### Requirement: Forked and interleaved usage is attributed without replay
+The system SHALL exclude inherited parent usage from child sessions and SHALL prevent cumulative-counter resets or lineage interleaving from recounting previously accepted usage.
+
+#### Scenario: Fork begins with inherited cumulative totals
+- **WHEN** a child transcript begins with cumulative usage inherited from its parent
+- **THEN** the inherited baseline contributes zero child usage and only subsequent child-owned growth is counted
+
+#### Scenario: Cumulative components fall below their watermark
+- **WHEN** an observed cumulative snapshot decreases in any token component because another lineage or reset is interleaved
+- **THEN** the system retains a monotonic watermark and accepts only usage contained by new cumulative growth
+
+#### Scenario: Fork baseline cannot be resolved
+- **WHEN** the system cannot establish ownership from a consistent child-local baseline or copied-history boundary
+- **THEN** it excludes ambiguous usage from canonical totals and reports the exclusion diagnostically
+
+### Requirement: Calendar totals follow usage-event timestamps
+The system SHALL attribute each accepted Codex usage delta and its API-equivalent cost to the local calendar day containing that token-count event.
+
+#### Scenario: Long-running session crosses midnight
+- **WHEN** one Codex session emits accepted token deltas on multiple local calendar days
+- **THEN** each day contains exactly the deltas observed on that day without prorating the final session total by message count
+
+#### Scenario: Session and period reconciliation
+- **WHEN** all accepted events for a session fall inside a requested period
+- **THEN** the period token classes and cost equal that session's canonical totals
+
+### Requirement: Existing data is repaired reproducibly
+The system SHALL provide an idempotent Codex-only rebuild that replaces derived session totals and daily usage with values reconstructed from transcripts that remain available. It SHALL mark an accounting revision complete only after every readable session has been reconciled from persisted accepted observations and every unreadable session has a durable unrepaired audit record.
+
+#### Scenario: Repair runs twice
+- **WHEN** the same unchanged transcript corpus is repaired twice
+- **THEN** session totals, daily totals, costs, and diagnostics are identical after both runs
+
+#### Scenario: Historical source is unavailable
+- **WHEN** an indexed Codex session no longer has a readable source transcript
+- **THEN** the system preserves its existing totals, marks them unrepaired, and does not fabricate daily evidence
+
+#### Scenario: Persisted totals fail reconciliation
+- **WHEN** any session, model, or accepted-observation aggregate differs during repair, or any repair/audit transaction fails
+- **THEN** the system leaves the revision incomplete so the migration retries and never presents the corpus as verified
+
+### Requirement: Accounting exclusions are inspectable
+The system SHALL expose local diagnostics sufficient to distinguish accepted usage, duplicate snapshots, inherited replay, unsupported rows, incomplete cursors, and stale observations without exposing transcript content.
+
+#### Scenario: User inspects stale usage
+- **WHEN** one or more Codex sources contain complete bytes beyond their saved cursor
+- **THEN** diagnostics report the affected source count, pending byte count, and last successful usage observation

--- a/openspec/changes/archive/2026-08-10-correct-codex-usage-accounting/specs/live-session-evidence/spec.md
+++ b/openspec/changes/archive/2026-08-10-correct-codex-usage-accounting/specs/live-session-evidence/spec.md
@@ -1,10 +1,4 @@
-# Live Session Evidence
-
-## Purpose
-
-Define prompt, recoverable, and locally inspectable ingestion of active agent transcript evidence.
-
-## Requirements
+## MODIFIED Requirements
 
 ### Requirement: Active local transcripts become available promptly
 The system SHALL incrementally ingest complete appended messages and timestamped usage evidence from supported active local transcripts on a bounded best-effort cadence, SHALL emit a local archive-update event when new evidence is stored, and SHALL not require archive-search maintenance to complete before advancing usage evidence.
@@ -42,3 +36,4 @@ The system SHALL expose a versioned local policy/status contract identifying the
 #### Scenario: UI requests live-session status
 - **WHEN** the desktop UI requests the live-session evidence policy
 - **THEN** it receives the current cadence, adapter coverage, recovery mode, local-only status, usage freshness, and pending evidence counts from the same backend that owns indexing
+

--- a/openspec/changes/archive/2026-08-10-correct-codex-usage-accounting/tasks.md
+++ b/openspec/changes/archive/2026-08-10-correct-codex-usage-accounting/tasks.md
@@ -1,0 +1,37 @@
+## 1. Accounting Contract and Fixtures
+
+- [x] 1.1 Add sanitized Codex fixtures for ordinary progression, rate-limit-only duplicate snapshots, incremental boundaries, fork inheritance, cumulative resets, and interleaved lineages.
+- [x] 1.2 Add an independent fixture oracle that declares accepted deltas, dispositions, session totals, model totals, and local-day totals.
+- [x] 1.3 Add failing adapter tests proving one-shot and arbitrarily chunked parsing must match the oracle exactly.
+
+## 2. Persistent Usage Evidence
+
+- [x] 2.1 Add migration-backed Codex usage observation, accounting state, repair audit, and diagnostic storage with appropriate uniqueness and period-query indexes.
+- [x] 2.2 Add query helpers that transactionally replace or append observations and reconcile session/model totals from accepted rows.
+- [x] 2.3 Add schema and query tests for idempotency, uniqueness, replacement, pending-state reporting, and preservation of unrelated providers.
+
+## 3. Codex Accounting State Machine
+
+- [x] 3.1 Implement structural token-count normalization including event timestamp, turn/model evidence, all token classes, cumulative snapshot, and source position.
+- [x] 3.2 Implement unchanged-total suppression and persisted incremental accounting state.
+- [x] 3.3 Implement fork-baseline ownership, monotonic component watermarks, and conservative interleaved-lineage containment.
+- [x] 3.4 Persist accepted/excluded observations and derive canonical session/model/local-day totals from accepted deltas.
+- [x] 3.5 Run focused Rust tests for all accounting fixtures and exact one-shot-versus-incremental equivalence.
+
+## 4. Live Ingestion and Usage Queries
+
+- [x] 4.1 Separate bounded Codex usage ingestion from archive/FTS serialization so maintenance cannot suppress eligible usage work.
+- [x] 4.2 Prioritize recently modified Codex sources and expose last observation, incomplete source count, and pending byte count.
+- [x] 4.3 Change period usage and cost queries to use accepted timestamped Codex observations while preserving existing paths for other agents.
+- [x] 4.4 Refresh headline/account telemetry on accepted usage events and surface compact freshness/exclusion diagnostics in the existing Usage view.
+- [x] 4.5 Run focused backend and frontend tests for live freshness, calendar boundaries, and provider isolation.
+
+## 5. Repair and Validation
+
+- [x] 5.1 Implement a revisioned, idempotent streaming repair for readable Codex transcripts with unrepaired diagnostics for missing sources.
+- [x] 5.2 Run the repair against a copy of the user's database and reconcile session/day/model totals against an independent scanner without printing transcript content.
+- [x] 5.3 Compare repaired aggregate output with current CodexBar/ccusage invariants and investigate every material discrepancy before enabling the migration.
+- [x] 5.4 Run the smallest relevant Rust tests first, then desktop unit/lint/type checks and documentation validation.
+- [x] 5.5 Record the validated accounting behavior and any unrecoverable historical limits in the canonical telemetry documentation.
+- [x] 5.6 Add a fail-closed completion gate that derives repaired totals from persisted observations, verifies exact session/model aggregates, and refuses revision completion after any write or audit mismatch.
+- [x] 5.7 Add regression tests proving reconciliation failures cannot mark a repair revision complete, then rerun frozen-copy and full validation.

--- a/openspec/specs/codex-usage-accounting/spec.md
+++ b/openspec/specs/codex-usage-accounting/spec.md
@@ -1,0 +1,70 @@
+# Codex Usage Accounting
+
+## Purpose
+
+Provide deterministic local Codex token and cost accounting whose session and calendar-period totals are reproducible from timestamped transcript evidence.
+
+## Requirements
+
+### Requirement: Usage events are counted exactly once
+The system SHALL derive Codex usage from token-count evidence and SHALL count an unchanged cumulative usage snapshot no more than once, even when Codex re-emits the preceding per-event usage during a rate-limit-only update.
+
+#### Scenario: Ordinary cumulative progression
+- **WHEN** consecutive token-count events contain increasing cumulative totals and matching per-event usage
+- **THEN** the system accepts one delta per cumulative increase and the accepted deltas sum to the final cumulative total
+
+#### Scenario: Rate-limit-only re-emission
+- **WHEN** a token-count event repeats a previously observed cumulative total and repeats its `last_token_usage`
+- **THEN** the system records no additional tokens or cost for that event
+
+#### Scenario: Incremental read boundary
+- **WHEN** a duplicate cumulative snapshot appears after a persisted incremental byte boundary
+- **THEN** persisted accounting state suppresses the duplicate exactly as a single full-file scan would
+
+### Requirement: Forked and interleaved usage is attributed without replay
+The system SHALL exclude inherited parent usage from child sessions and SHALL prevent cumulative-counter resets or lineage interleaving from recounting previously accepted usage.
+
+#### Scenario: Fork begins with inherited cumulative totals
+- **WHEN** a child transcript begins with cumulative usage inherited from its parent
+- **THEN** the inherited baseline contributes zero child usage and only subsequent child-owned growth is counted
+
+#### Scenario: Cumulative components fall below their watermark
+- **WHEN** an observed cumulative snapshot decreases in any token component because another lineage or reset is interleaved
+- **THEN** the system retains a monotonic watermark and accepts only usage contained by new cumulative growth
+
+#### Scenario: Fork baseline cannot be resolved
+- **WHEN** the system cannot establish ownership from a consistent child-local baseline or copied-history boundary
+- **THEN** it excludes ambiguous usage from canonical totals and reports the exclusion diagnostically
+
+### Requirement: Calendar totals follow usage-event timestamps
+The system SHALL attribute each accepted Codex usage delta and its API-equivalent cost to the local calendar day containing that token-count event.
+
+#### Scenario: Long-running session crosses midnight
+- **WHEN** one Codex session emits accepted token deltas on multiple local calendar days
+- **THEN** each day contains exactly the deltas observed on that day without prorating the final session total by message count
+
+#### Scenario: Session and period reconciliation
+- **WHEN** all accepted events for a session fall inside a requested period
+- **THEN** the period token classes and cost equal that session's canonical totals
+
+### Requirement: Existing data is repaired reproducibly
+The system SHALL provide an idempotent Codex-only rebuild that replaces derived session totals and daily usage with values reconstructed from transcripts that remain available. It SHALL mark an accounting revision complete only after every readable session has been reconciled from persisted accepted observations and every unreadable session has a durable unrepaired audit record.
+
+#### Scenario: Repair runs twice
+- **WHEN** the same unchanged transcript corpus is repaired twice
+- **THEN** session totals, daily totals, costs, and diagnostics are identical after both runs
+
+#### Scenario: Historical source is unavailable
+- **WHEN** an indexed Codex session no longer has a readable source transcript
+- **THEN** the system preserves its existing totals, marks them unrepaired, and does not fabricate daily evidence
+
+#### Scenario: Persisted totals fail reconciliation
+- **WHEN** any session, model, or accepted-observation aggregate differs during repair, or any repair/audit transaction fails
+- **THEN** the system leaves the revision incomplete so the migration retries and never presents the corpus as verified
+
+### Requirement: Accounting exclusions are inspectable
+The system SHALL expose local diagnostics sufficient to distinguish accepted usage, duplicate snapshots, inherited replay, unsupported rows, incomplete cursors, and stale observations without exposing transcript content.
+
+#### Scenario: User inspects stale usage
+- **WHEN** one or more Codex sources contain complete bytes beyond their saved cursor
+- **THEN** diagnostics report the affected source count, pending byte count, and last successful usage observation


### PR DESCRIPTION
## What changed

- replace replay-prone Codex session totals with timestamped accepted usage observations
- persist deterministic duplicate, fork, reset, and interleaved-lineage accounting state
- separate live usage ingestion from archive/FTS serialization
- add fail-closed historical repair, audit diagnostics, and Usage freshness indicators
- bump the desktop release to v1.7.3

## Root cause

Codex cumulative snapshots and repeated `last_token_usage` events were treated as ordinary additive usage, while calendar periods were prorated from message counts. Fork replay and archive lock contention could therefore overcount, undercount, or delay visible usage.

## Qualification

- frozen copy: 91 readable sessions reconciled twice to 2,742,608,446 accepted tokens
- 1,260 missing sources preserved with explicit unrepaired audits
- Rust: 913 passed, 25 ignored
- frontend: 665 passed, 1 skipped; 20-scenario live qualification passed
- lint, typecheck, production build, docs, and all strict OpenSpec validations passed
