### PR TITLE
Reject oversized optimization candidates

### DIFF
--- a/scripts/runtime-failure-capsule/AUTONOMOUS_OPTIMIZATION_PROGRAM.md
+++ b/scripts/runtime-failure-capsule/AUTONOMOUS_OPTIMIZATION_PROGRAM.md
@@ -13,7 +13,10 @@ inspection, one hypothesis, and one bounded edit.
    `capture_optimization_baseline`. Do not edit source first.
 4. If the next action is `propose_candidate`, inspect the incumbent evidence and
    relevant source. State one falsifiable hypothesis, edit only allowed source,
-   and call `screen_optimization_candidate` with that exact hypothesis.
+   and call `screen_optimization_candidate` with that exact hypothesis. Before
+   correctness or profiling, CodeVetter rejects candidates that change more
+   than three files, add more than 160 lines, move more than 200 gross lines, or
+   add a production dependency; the evidence receipt records the observed cost.
 5. Treat `discard`, `crash`, and `no_confidence` as negative evidence. Restore
    the independently saved incumbent source using a recoverable branch or
    worktree operation supplied by the host; never use destructive reset.

--- a/scripts/runtime-failure-capsule/campaign.mjs
+++ b/scripts/runtime-failure-capsule/campaign.mjs
@@ -13,6 +13,7 @@ import {
   sha256,
   stableStringify,
 } from './campaign-contracts.mjs';
+import { assessChangeCost, inspectChangeCost } from './change-cost.mjs';
 import { parseVitestSelection } from './capsule.mjs';
 import { verifyOptimizationCapsules } from './optimization-verification.mjs';
 import { verifyPairedRepositories } from './paired-verification.mjs';
@@ -27,6 +28,7 @@ const ENGINE_FILES = [
   'campaign-contracts.mjs',
   'campaign.mjs',
   'capsule.mjs',
+  'change-cost.mjs',
   'contracts.mjs',
   'optimization-verification.mjs',
   'paired-verification.mjs',
@@ -195,17 +197,30 @@ async function screenCampaign(root, input, dependencies) {
   if (repository.diff_digest === status.incumbent.repository.diff_digest) {
     throw new Error('candidate source identity matches the incumbent');
   }
+  const changeCost = assessChangeCost(
+    await inspectChangeCost(root, repository.changed_files, repository.base_revision),
+    { allowedFiles: campaign.manifest.allowed_files }
+  );
   const attempt = status.experiments + 1;
-  const correctness = await runCorrectness(root, campaign.manifest.correctness, dependencies);
+  const correctness =
+    changeCost.violations.length === 0
+      ? await runCorrectness(root, campaign.manifest.correctness, dependencies)
+      : { status: 'not_run', results: [], limitations: [] };
   const limitations = [...correctness.limitations];
   let evidence = {
     correctness: correctness.results,
     performance_capsule: null,
     verification: null,
+    change_cost: changeCost,
   };
   let decision;
 
-  if (correctness.status !== 'passed') {
+  if (changeCost.violations.length > 0) {
+    decision = {
+      status: 'discard',
+      reason: `Candidate exceeded its change-cost budget: ${changeCost.violations.join(', ')}.`,
+    };
+  } else if (correctness.status !== 'passed') {
     decision = correctnessDecision(correctness.status);
   } else {
     try {
@@ -226,6 +241,7 @@ async function screenCampaign(root, input, dependencies) {
         correctness: correctness.results,
         performance_capsule: current,
         verification,
+        change_cost: changeCost,
       };
       limitations.push(...verification.limitations);
       decision = screeningDecision(verification);

--- a/scripts/runtime-failure-capsule/campaign.test.mjs
+++ b/scripts/runtime-failure-capsule/campaign.test.mjs
@@ -208,6 +208,37 @@ test('campaign rejects faster incorrect work, promotes paired evidence, resumes,
   }
 });
 
+test('campaign rejects disproportionate source growth before verification', async () => {
+  const fixture = await createFixture();
+  try {
+    let profileCount = 0;
+    const service = await createOptimizationCampaignService(
+      fixture.root,
+      fakeDependencies(() => {
+        profileCount += 1;
+      })
+    );
+    await service.initialize({ campaign_directory: fixture.campaignDirectory });
+    await service.baseline({ campaign_directory: fixture.campaignDirectory });
+    const baselineProfiles = profileCount;
+    await writeFile(
+      join(fixture.root, 'source.js'),
+      Array.from({ length: 170 }, (_, index) => `export const value${index} = ${index};`).join('\n')
+    );
+
+    const result = await service.screen({
+      campaign_directory: fixture.campaignDirectory,
+      hypothesis: 'Add a large shortcut.',
+    });
+
+    assert.equal(result.record.decision.status, 'discard');
+    assert.match(result.record.decision.reason, /change-cost budget: lines_added/);
+    assert.equal(profileCount, baselineProfiles);
+  } finally {
+    await fixture.cleanup();
+  }
+});
+
 test('campaign records crash and no-confidence outcomes and detects evidence or ledger tampering', async () => {
   for (const candidate of [
     { source: 'export const mode = "CRASH";\n', decision: 'crash' },


### PR DESCRIPTION
## What

Runs the merged candidate-size measurement before campaign correctness and profiling. Candidates above the three-file, 160-added-line, 200-gross-line, or zero-production-dependency budget are discarded with a machine-readable evidence receipt.

## Why

An optimization should not trade a small runtime gain for disproportionate code growth or expensive verification work.

## Validation

- 8 focused campaign/change-cost tests passed
- focused Biome check passed

Three files, 53 additions and 3 deletions, no production dependency.
