### PR TITLE
Reject oversized pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
         env:
           CODE_HEALTH_BASE: ${{ github.event.pull_request.base.sha || github.event.before || 'HEAD^' }}
         run: |
+          pnpm run quality:change-size
           pnpm run knip:strict
           pnpm run quality:complexity
           pnpm run quality:cycles

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "deploy": "node scripts/manual-deploy.mjs deploy-landing.yml ci.yml",
     "knip": "knip --no-exit-code --reporter symbols",
     "knip:strict": "knip --reporter symbols",
+    "quality:change-size": "node scripts/check-change-size.mjs",
     "quality:complexity": "node scripts/check-changed-complexity.mjs",
     "quality:cycles": "biome lint --only=suspicious/noImportCycles .",
     "quality:dependencies": "pnpm audit --audit-level high",

--- a/scripts/check-change-size.mjs
+++ b/scripts/check-change-size.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import { lstatSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const limits = Object.freeze({ changedFiles: 40, addedLines: 4_000, grossLines: 6_000 });
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const comparisonBase = process.env.CODE_HEALTH_BASE?.trim() || 'origin/main';
+const result = spawnSync(
+  'git',
+  ['diff', '--numstat', '--no-renames', '--diff-filter=ACDMR', comparisonBase, '--'],
+  { cwd: repositoryRoot, encoding: 'utf8' }
+);
+const untracked = spawnSync('git', ['ls-files', '--others', '--exclude-standard'], {
+  cwd: repositoryRoot,
+  encoding: 'utf8',
+});
+
+if (result.status !== 0 || untracked.status !== 0) {
+  console.error(
+    `Unable to measure change size from ${comparisonBase}: ${result.stderr.trim() || untracked.stderr.trim() || 'git failed'}`
+  );
+  process.exit(1);
+}
+
+const summary = result.stdout
+  .split('\n')
+  .filter(Boolean)
+  .reduce(
+    (totals, line) => {
+      const [added, removed] = line.split('\t');
+      return {
+        changedFiles: totals.changedFiles + 1,
+        addedLines: totals.addedLines + (/^\d+$/.test(added) ? Number(added) : 0),
+        grossLines:
+          totals.grossLines +
+          (/^\d+$/.test(added) ? Number(added) : 0) +
+          (/^\d+$/.test(removed) ? Number(removed) : 0),
+      };
+    },
+    { changedFiles: 0, addedLines: 0, grossLines: 0 }
+  );
+for (const file of untracked.stdout.split('\n').filter(Boolean)) {
+  summary.changedFiles += 1;
+  const absolute = path.join(repositoryRoot, file);
+  if (!lstatSync(absolute).isFile()) continue;
+  const content = readFileSync(absolute);
+  const lines = content.includes(0)
+    ? 0
+    : content.length === 0
+      ? 0
+      : content.toString('utf8').split('\n').length - (content.at(-1) === 10 ? 1 : 0);
+  summary.addedLines += lines;
+  summary.grossLines += lines;
+}
+const violations = Object.entries(limits).filter(([metric, limit]) => summary[metric] > limit);
+
+if (violations.length > 0) {
+  console.error(
+    `Change-size gate: FAIL (${summary.changedFiles} files, ${summary.addedLines} additions, ${summary.grossLines} gross lines)`
+  );
+  for (const [metric, limit] of violations) {
+    console.error(`- ${metric}: ${summary[metric]} exceeds ${limit}`);
+  }
+  console.error(
+    'Split the change into dependency-ordered, independently reviewable pull requests.'
+  );
+  process.exit(1);
+}
+
+console.log(
+  `Change-size gate: PASS (${summary.changedFiles}/${limits.changedFiles} files, ${summary.addedLines}/${limits.addedLines} additions, ${summary.grossLines}/${limits.grossLines} gross lines)`
+);


### PR DESCRIPTION
## What

Adds a CI gate that rejects changes above 40 files, 4,000 additions, or 6,000 gross changed lines.

## Why

The previous performance branch accumulated 349 files and 82,779 additions without an explicit review-size failure. This makes that class of mistake executable policy and directs authors to dependency-ordered PRs.

## Validation

- the gate passes this three-file, 77-line change
- focused Biome check passed

No production dependency.
