### PR TITLE
Publish canonical optimization proofs

### DIFF
--- a/benchmarks/performance-lab/autonomous-browser-loop-anime-proof-2026-08-14.json
+++ b/benchmarks/performance-lab/autonomous-browser-loop-anime-proof-2026-08-14.json
@@ -1,0 +1,213 @@
+{
+  "schema_version": "codevetter-autonomous-browser-loop-proof/v1",
+  "recorded_at": "2026-08-14",
+  "claim": "On an isolated Anime List checkout, CodeVetter rejected sub-threshold candidates and retained one two-file local-development loading improvement after correctness-first screening and ten-sample paired promotion.",
+  "product": "anime-list",
+  "subject": {
+    "repository_revision": "db1faf0e0c27996c3eacfb9f1e3a4c0a65958938",
+    "baseline_source_snapshot_sha256": "01de0824927741ce93da7ff9eb4334d772711d451ec96ff166f5874d908db19d",
+    "retained_source_snapshot_sha256": "c3a862e3d50f322b4d201c7e10c970fc3d6fcabc8a3dd475039c64709c386145",
+    "isolation": "disposable detached worktrees with copied package payload and an empty HOME",
+    "network_or_cloud": false
+  },
+  "flow": {
+    "target": "e2e/mobile.spec.ts",
+    "name": "home page has no horizontal scroll",
+    "browser_project": "mobile",
+    "scope": "one exact local Chromium navigation against CodeVetter's config-disabled owned Vite runtime"
+  },
+  "first_pass": {
+    "observed_families": ["browser_timing", "memory", "react", "actions", "dependencies"],
+    "incomplete_families": ["loading"],
+    "unavailable_families": ["build_artifact", "review"],
+    "cause_groups": 6,
+    "queued_experiments": 4,
+    "highest_measured_dependency": {
+      "package": "lucide-react",
+      "development_response_bytes": 4263394,
+      "exact_initial_importers": [
+        "components/Navigation.tsx",
+        "components/ui/dropdown-menu.tsx"
+      ]
+    }
+  },
+  "rejected_experiments": [
+    {
+      "hypothesis": "Replace five radix-ui package-root imports with package subpaths.",
+      "changed_files": 5,
+      "screening_samples_per_side": 3,
+      "baseline_completed_response_bytes_median": 12979530,
+      "candidate_completed_response_bytes_median": 11778516,
+      "delta_bytes": -1201014,
+      "delta_percent": -9.254,
+      "decision": "rejected",
+      "reason": "The measured movement did not clear the 10 percent transfer materiality floor.",
+      "loop_elapsed_minutes_at_decision": 0.788
+    },
+    {
+      "hypothesis": "Memoize HomePage to remove repeated React work.",
+      "changed_files": 1,
+      "screening_samples_per_side": 3,
+      "decision": "rejected",
+      "reason": "No exact-flow timing, memory, React, or loading metric cleared materiality."
+    }
+  ],
+  "retained_experiment": {
+    "experiment_id": "bcbcd81274431f6792a3ef74",
+    "hypothesis": "Remove lucide-react from the exact initial home-flow boundary while preserving deferred-route usage.",
+    "host_patch": "Inline four small SVG icons in the two statically reachable importers; deferred routes remain unchanged.",
+    "changed_files": [
+      "components/Navigation.tsx",
+      "components/ui/dropdown-menu.tsx"
+    ],
+    "complexity": {
+      "files_changed": 2,
+      "added_lines": 60,
+      "deleted_lines": 2,
+      "gross_lines_changed": 62,
+      "net_lines_changed": 58,
+      "production_dependencies_added": [],
+      "budget": {
+        "max_files_changed": 3,
+        "max_lines_added": 160,
+        "max_gross_lines_changed": 200,
+        "max_production_dependencies_added": 0
+      },
+      "violations": []
+    },
+    "screening": {
+      "samples_per_side": 3,
+      "browser_completed_response_transfer_bytes": {
+        "baseline_median": 11871129,
+        "candidate_median": 7616611,
+        "delta_bytes": -4254518,
+        "delta_percent": -35.839
+      },
+      "decision": "promote"
+    },
+    "promotion": {
+      "samples_per_side": 10,
+      "warmups_per_side": 1,
+      "browser_completed_response_transfer_bytes": {
+        "baseline_median": 11871129,
+        "candidate_median": 7616611,
+        "delta_bytes": -4254518,
+        "delta_percent": -35.839,
+        "stable": true
+      },
+      "workload_duration_ms": {
+        "baseline_median": 316.5115,
+        "candidate_median": 303.9395,
+        "delta_percent": -3.972,
+        "material": false,
+        "regressed": false
+      },
+      "largest_contentful_paint_ms": {
+        "baseline_median": 250.916,
+        "candidate_median": 236.1995,
+        "delta_percent": -5.865,
+        "material": false,
+        "regressed": false
+      },
+      "process_tree_peak_rss_bytes": {
+        "baseline_median": 861634560,
+        "candidate_median": 819912704,
+        "delta_percent": -4.842,
+        "material": false,
+        "regressed": false
+      },
+      "react_actual_duration_ms": {
+        "baseline_median": 17.55,
+        "candidate_median": 17.2,
+        "delta_percent": -1.994,
+        "material": false,
+        "regressed": false
+      },
+      "correctness": {
+        "adapter": "vitest",
+        "target": "src/recommendations.test.ts",
+        "name": "keeps only the highest-ranked recommendations in stable order",
+        "incumbent_selected": 1,
+        "incumbent_failed": 0,
+        "candidate_selected": 1,
+        "candidate_failed": 0
+      },
+      "decision": "kept",
+      "reason": "Correctness passed and stable paired evidence met the promotion policy."
+    },
+    "campaign_elapsed_minutes_from_initialization_to_keep": 2.315,
+    "next_generation_replanned": true
+  },
+  "production_build_check": {
+    "provenance": "Separate host-run Vite production builds with an empty HOME; this is a diagnostic qualification, not the loop's acceptance metric.",
+    "baseline_initial_javascript": {
+      "raw_bytes": 504556,
+      "gzip_bytes": 159923
+    },
+    "candidate_initial_javascript": {
+      "raw_bytes": 503474,
+      "gzip_bytes": 159423
+    },
+    "delta": {
+      "raw_bytes": -1082,
+      "raw_percent": -0.214,
+      "gzip_bytes": -500,
+      "gzip_percent": -0.313
+    },
+    "conclusion": "The retained result is a material local Vite development-navigation improvement, not a material shipped initial-bundle improvement."
+  },
+  "superseded_measurement": {
+    "previous_claimed_gzip_change_percent": -28.452,
+    "reason": "That comparison measured selected chunk redistribution rather than the complete HTML-referenced initial JavaScript closure.",
+    "correct_full_closure_chunk_rule_result": {
+      "baseline_gzip_bytes": 159923,
+      "candidate_gzip_bytes": 154162,
+      "delta_bytes": -5761,
+      "delta_percent": -3.602,
+      "decision": "rejected_below_materiality"
+    }
+  },
+  "manual_vs_loop": {
+    "prior_manual_investigation": {
+      "agent_actions": [
+        "inspect source and historical diff",
+        "construct four build variants",
+        "manually compare chunk output",
+        "run a separate non-interleaved browser replay"
+      ],
+      "outcome": "Mechanism hypothesis only; no candidate retained, and the headline percentage was later found to use an incomplete closure."
+    },
+    "autonomous_loop": {
+      "host_actions_per_experiment": [
+        "apply the returned bounded edit",
+        "call evaluate-browser-experiment",
+        "restore only when rejected"
+      ],
+      "codevetter_owned": [
+        "evidence collection and dependency ranking",
+        "exact static-versus-deferred source seal",
+        "correctness selection",
+        "alternating screening captures",
+        "automatic ten-sample promotion",
+        "materiality and regression gates",
+        "append-only keep or reject decision",
+        "incumbent advancement and replanning"
+      ],
+      "outcome": "One sub-threshold candidate rejected and one local-development loading candidate retained with repeated evidence."
+    }
+  },
+  "product_improvements_discovered_during_trial": [
+    "Dirty candidates are accepted only when every changed file is inside the exact sealed experiment boundary and the snapshot is rechecked around every capture.",
+    "Multiline static imports are included in the literal graph.",
+    "Initial and deferred importers are retained separately, preventing lazy-route files from inflating the edit seal.",
+    "Large captured Vite dependency routes join to all exact static importers rather than substring-matching unrelated packages.",
+    "Transfer verification prefers the complete zero-failure navigation action cohort, excluding later evaluation and analytics request noise."
+  ],
+  "limitations": [
+    "The keep proves one local config-disabled Vite development navigation, not production traffic, representative devices, CDN behavior, or end-user impact.",
+    "The correctness scope is one exact repository-owned recommendation test plus the selected Playwright flow; it is not the full Anime List suite.",
+    "The production build check shows only a 0.313 percent gzip reduction, so this candidate should be presented as local developer-flow optimization rather than a consumer performance case study.",
+    "The host agent still invents and applies source patches; CodeVetter owns evidence, boundaries, verification, decisions, and replanning.",
+    "No production, cloud, registry, package installation, migration, deployment, paid-model, or secret operation was used."
+  ]
+}

--- a/benchmarks/performance-lab/free-ai-selection-one-pass-proof-2026-08-14.json
+++ b/benchmarks/performance-lab/free-ai-selection-one-pass-proof-2026-08-14.json
@@ -1,0 +1,108 @@
+{
+  "schema_version": "codevetter-local-optimization-proof/v1",
+  "recorded_at": "2026-08-14T16:47:50+05:30",
+  "observation_date": "2026-08-14",
+  "product": "free-ai",
+  "claim": "On one isolated local Free AI checkout, a one-file candidate removed the intermediate eligibility array from model selection. Ten interleaved samples confirmed 29.841% lower largest-input time and 30.139% lower sampled bytes at the selected allocation source, with no material peak-RSS regression.",
+  "subject": {
+    "repository_revision": "23ed8566bb1b1d8d86ee1f9890aa4ad5bba9cd18",
+    "baseline_source_snapshot_sha256": "93b01ba755f1e22c53180e5c21b232b806e3d2302f7b11fc72e71a12c49542f4",
+    "candidate_source_snapshot_sha256": "d30851f91295807b466f6319bb467114225944acf794a8b39b4fe45751e337ce",
+    "isolation": "detached local Git worktree with a copy-on-write dependency tree",
+    "network_or_cloud": false
+  },
+  "flow": {
+    "adapter": "vitest",
+    "target": "test/select-model-performance.spec.ts",
+    "name": "model selection scales across the supported registry size",
+    "largest_input": 79,
+    "iterations_per_input": 5000,
+    "workload_identity": {
+      "algorithm": "sha256",
+      "digest": "08441b9854d61439d7033983fff0aa4526a3ac74f87336993a3d05b7ec661629"
+    }
+  },
+  "diagnosis": {
+    "kind": "application_allocation_hotspot",
+    "source": "src/router/select-model.ts:171",
+    "function": "selectCandidates",
+    "initial_sampled_allocation_share": 0.841449,
+    "hypothesis": "Build the ranked candidate list directly instead of allocating an intermediate filtered array."
+  },
+  "change_cost": {
+    "files_changed": 1,
+    "changed_files": ["src/router/select-model.ts"],
+    "lines_added": 19,
+    "lines_removed": 26,
+    "gross_lines_changed": 45,
+    "net_lines_changed": -7,
+    "production_dependencies_added": [],
+    "policy": {
+      "max_files_changed": 3,
+      "max_lines_added": 160,
+      "max_gross_lines_changed": 200,
+      "max_production_dependencies_added": 0
+    },
+    "violations": []
+  },
+  "paired_verification": {
+    "evidence_mode": "paired_interleaved",
+    "samples_per_side": 10,
+    "warmups_per_side": 1,
+    "scale_points": [
+      {
+        "input": 20,
+        "baseline_ms_per_operation": 0.006524,
+        "candidate_ms_per_operation": 0.004648,
+        "delta_percent": -28.755
+      },
+      {
+        "input": 50,
+        "baseline_ms_per_operation": 0.008153,
+        "candidate_ms_per_operation": 0.005679,
+        "delta_percent": -30.345
+      },
+      {
+        "input": 79,
+        "baseline_ms_per_operation": 0.016568,
+        "candidate_ms_per_operation": 0.011624,
+        "delta_percent": -29.841
+      }
+    ],
+    "sampled_source_bytes": {
+      "baseline_median": 220208512,
+      "candidate_median": 153840808,
+      "delta_bytes": -66367704,
+      "delta_percent": -30.139,
+      "attribution_status": "source_and_application_total_agree"
+    },
+    "peak_process_tree_rss_bytes": {
+      "baseline_median": 227721216,
+      "candidate_median": 227639296,
+      "delta_bytes": -81920,
+      "delta_percent": -0.036,
+      "material": false,
+      "regressed": false
+    },
+    "decision": {
+      "mechanically_confirmed": true,
+      "materially_useful": true,
+      "shipping_recommended": true,
+      "verdict": "confirmed",
+      "reason": "Largest-input time improved by 29.841% without a material smaller-input regression."
+    }
+  },
+  "correctness": {
+    "focused_selection_tests": 27,
+    "full_test_files_passed": 37,
+    "full_tests_passed": 241,
+    "typecheck": "passed",
+    "lint_changed_file": "passed"
+  },
+  "limitations": [
+    "This proves one synthetic local model-registry workload up to the repository's current 79-model registry; it does not establish production request latency or customer impact.",
+    "Sampled heap bytes include allocations that may later be collected and are not retained-heap measurements.",
+    "Peak RSS is sampled process-tree evidence and includes the runtime and test runner.",
+    "No production endpoint, provider API, cloud resource, package installation, deployment, paid model, or secret operation was used."
+  ]
+}

--- a/benchmarks/performance-lab/starboard-token-scan-rejection-2026-08-14.json
+++ b/benchmarks/performance-lab/starboard-token-scan-rejection-2026-08-14.json
@@ -1,0 +1,50 @@
+{
+  "schema_version": "codevetter-local-optimization-rejection/v1",
+  "recorded_at": "2026-08-14",
+  "product": "starboard",
+  "repository_revision": "7af23ce31ac10c7c552713f92985934de116abee",
+  "flow": {
+    "adapter": "vitest",
+    "target": "src/__tests__/project-recommendations-performance.test.ts",
+    "name": "project recommendations scale across local catalog sizes",
+    "workload_identity_sha256": "7ea08cb2f0d112220eaedabd2103336419473773a23a3a774b1b98c4c4abb6ba"
+  },
+  "diagnosis": {
+    "source": "src/lib/project-recommendations.ts:101",
+    "function": "meaningfulTokens",
+    "cpu_sample_share": 0.1084
+  },
+  "experiment": {
+    "summary": "Replace join, match, filter, and Set construction with an incremental regular-expression scan.",
+    "change_cost": {
+      "files_changed": 1,
+      "lines_added": 12,
+      "lines_removed": 7,
+      "gross_lines_changed": 19,
+      "production_dependencies_added": [],
+      "budget_violations": []
+    },
+    "focused_correctness": {
+      "test_files_passed": 2,
+      "tests_passed": 13
+    }
+  },
+  "paired_verification": {
+    "samples_per_side": 10,
+    "warmups_per_side": 1,
+    "largest_input": 50000,
+    "baseline_ms_per_operation": 47.496,
+    "candidate_ms_per_operation": 50.026,
+    "delta_percent": 5.327,
+    "peak_rss_delta_percent": -0.55,
+    "allocation_evidence": "incomplete_collection_bound_exceeded",
+    "verdict": "no_confidence",
+    "shipping_recommended": false
+  },
+  "decision": "rejected_and_restored",
+  "limitations": [
+    "Wall-time sample spreads were 86.332% and 91.255%, so host or startup noise may dominate.",
+    "The candidate was slower at the largest input and heap evidence was incomplete; no optimization claim is made.",
+    "No production, cloud, deployment, package installation, paid model, or secret operation was used."
+  ]
+}


### PR DESCRIPTION
## What

Publishes three dated, revision-bound local optimization receipts: an accepted Free AI change, an Anime List development-flow result with production-build qualification, and a rejected Starboard experiment.

## Why

The public pages should be generated from a small canonical evidence set, not the 52 exploratory artifacts from the superseded branch.

## Validation

- all three receipts parse as JSON
- focused Biome check passed
- change-size gate: 3 files, 371 additions

The receipts make no production-performance claim.
