### PR TITLE
Publish optimization case-study pages

### DIFF
--- a/apps/landing-page-astro/src/components/Nav.astro
+++ b/apps/landing-page-astro/src/components/Nav.astro
@@ -8,6 +8,7 @@ import Icon from './Icon.astro';
 const links = [
   { href: '/#features', label: 'Features' },
   { href: '/#how', label: 'How it works' },
+  { href: '/benchmark/optimization', label: 'Proof' },
   { href: '/#providers', label: 'Providers' },
   { href: '/#pricing', label: 'Pricing' },
   { href: '/faq', label: 'FAQ' },
@@ -26,11 +27,11 @@ const links = [
       </span>
     </a>
 
-    <nav class="hidden md:flex items-center gap-8">
+    <nav class="hidden lg:flex items-center gap-7">
       {links.map((l) => (
         <a
           href={l.href}
-          class="font-mono text-[11px] uppercase tracking-[0.16em] text-[--color-text-dim] hover:text-white transition-colors"
+          class="font-mono text-[11px] uppercase tracking-[0.16em] text-[#a4a9b2] hover:text-white transition-colors"
         >
           {l.label}
         </a>

--- a/apps/landing-page-astro/src/data/optimization-case-studies.ts
+++ b/apps/landing-page-astro/src/data/optimization-case-studies.ts
@@ -1,0 +1,209 @@
+import anime from '../../../../benchmarks/performance-lab/autonomous-browser-loop-anime-proof-2026-08-14.json';
+import freeAi from '../../../../benchmarks/performance-lab/free-ai-selection-one-pass-proof-2026-08-14.json';
+import starboard from '../../../../benchmarks/performance-lab/starboard-token-scan-rejection-2026-08-14.json';
+
+export interface OptimizationCaseStudy {
+  slug: string;
+  project: string;
+  decision: 'confirmed' | 'retained' | 'rejected';
+  date: string;
+  revision: string;
+  summary: string;
+  availability: string;
+  testedFlow: string;
+  source: string;
+  primaryMetric: { label: string; value: string; note: string };
+  protectedMetrics: Array<{ label: string; value: string; decision: string }>;
+  changeCost: {
+    files: number;
+    added: number;
+    removed: number;
+    gross: number;
+    net: number;
+    dependencies: number;
+  };
+  correctness: string;
+  process: Array<{ decision: string; title: string; evidence: string }>;
+  limitations: string[];
+}
+
+const animeRetained = anime.retained_experiment;
+const animeTransfer = animeRetained.promotion.browser_completed_response_transfer_bytes;
+const freeAiLargest = freeAi.paired_verification.scale_points.at(-1)!;
+
+export const optimizationCaseStudies: OptimizationCaseStudy[] = [
+  {
+    slug: 'anime-list',
+    project: 'Anime List',
+    decision: 'retained',
+    date: anime.recorded_at,
+    revision: anime.subject.repository_revision,
+    summary:
+      'A two-file import-boundary change materially reduced one local Vite navigation, while a separate production build showed almost no shipped-bundle movement.',
+    availability:
+      'Historical research receipt. The experimental browser harness is not part of the compact current release.',
+    testedFlow: 'One mobile home-page navigation in an isolated local Vite checkout',
+    source: animeRetained.changed_files.join(', '),
+    primaryMetric: {
+      label: 'Local response bytes',
+      value: `${Math.abs(animeTransfer.delta_percent).toFixed(1)}% fewer`,
+      note: `${animeTransfer.baseline_median.toLocaleString()} → ${animeTransfer.candidate_median.toLocaleString()} bytes`,
+    },
+    protectedMetrics: [
+      {
+        label: 'Production JS gzip',
+        value: `${Math.abs(anime.production_build_check.delta.gzip_percent).toFixed(1)}% smaller`,
+        decision: 'not material',
+      },
+      {
+        label: 'Peak process-tree RSS',
+        value: `${Math.abs(animeRetained.promotion.process_tree_peak_rss_bytes.delta_percent).toFixed(1)}% lower`,
+        decision: 'non-regression only',
+      },
+    ],
+    changeCost: {
+      files: animeRetained.complexity.files_changed,
+      added: animeRetained.complexity.added_lines,
+      removed: animeRetained.complexity.deleted_lines,
+      gross: animeRetained.complexity.gross_lines_changed,
+      net: animeRetained.complexity.net_lines_changed,
+      dependencies: animeRetained.complexity.production_dependencies_added.length,
+    },
+    correctness: 'One exact repository-owned Vitest test and the selected Playwright flow passed.',
+    process: [
+      {
+        decision: 'rejected',
+        title: 'Radix package subpaths',
+        evidence: `${Math.abs(anime.rejected_experiments[0].delta_percent).toFixed(1)}% fewer bytes did not clear the 10% materiality floor.`,
+      },
+      {
+        decision: 'retained',
+        title: 'Lucide removed from the initial flow boundary',
+        evidence: `${animeRetained.promotion.samples_per_side} samples per side plus warmups confirmed the local transfer reduction.`,
+      },
+      {
+        decision: 'qualified',
+        title: 'Local developer-flow result only',
+        evidence: 'The production gzip change was 0.3%, so no consumer speed claim is made.',
+      },
+    ],
+    limitations: anime.limitations,
+  },
+  {
+    slug: 'free-ai',
+    project: 'Free AI',
+    decision: 'confirmed',
+    date: freeAi.observation_date,
+    revision: freeAi.subject.repository_revision,
+    summary:
+      'A one-pass model-selection loop removed an intermediate array and improved every tested registry size without growing the patch.',
+    availability: 'Uses the current local Vitest performance path.',
+    testedFlow: `${freeAi.flow.target} — ${freeAi.flow.name}`,
+    source: freeAi.diagnosis.source,
+    primaryMetric: {
+      label: 'Largest tested registry',
+      value: `${Math.abs(freeAiLargest.delta_percent).toFixed(1)}% faster`,
+      note: `${freeAiLargest.baseline_ms_per_operation} → ${freeAiLargest.candidate_ms_per_operation} ms/op at ${freeAiLargest.input} models`,
+    },
+    protectedMetrics: [
+      {
+        label: 'Sampled source bytes',
+        value: `${Math.abs(freeAi.paired_verification.sampled_source_bytes.delta_percent).toFixed(1)}% lower`,
+        decision: 'source and total agree',
+      },
+      {
+        label: 'Peak process-tree RSS',
+        value: `${Math.abs(freeAi.paired_verification.peak_process_tree_rss_bytes.delta_percent).toFixed(1)}% lower`,
+        decision: 'not material; no regression',
+      },
+    ],
+    changeCost: {
+      files: freeAi.change_cost.files_changed,
+      added: freeAi.change_cost.lines_added,
+      removed: freeAi.change_cost.lines_removed,
+      gross: freeAi.change_cost.gross_lines_changed,
+      net: freeAi.change_cost.net_lines_changed,
+      dependencies: freeAi.change_cost.production_dependencies_added.length,
+    },
+    correctness: `${freeAi.correctness.full_tests_passed} tests in ${freeAi.correctness.full_test_files_passed} files passed, plus typecheck and changed-file lint.`,
+    process: [
+      {
+        decision: 'observed',
+        title: 'Allocation hotspot in selectCandidates',
+        evidence: `${(freeAi.diagnosis.initial_sampled_allocation_share * 100).toFixed(1)}% of initial sampled allocation bytes pointed at the source.`,
+      },
+      {
+        decision: 'tested',
+        title: 'Build the ranked list directly',
+        evidence: `${freeAi.paired_verification.samples_per_side} interleaved samples per side covered three registry sizes.`,
+      },
+      {
+        decision: 'confirmed',
+        title: 'Faster with less code',
+        evidence:
+          'The candidate removed seven net lines, added no dependency, and passed the bounded change-cost policy.',
+      },
+    ],
+    limitations: freeAi.limitations,
+  },
+  {
+    slug: 'starboard',
+    project: 'Starboard',
+    decision: 'rejected',
+    date: starboard.recorded_at,
+    revision: starboard.repository_revision,
+    summary:
+      'A plausible incremental token scanner passed focused correctness but ran slower, so CodeVetter rejected it and restored the original code.',
+    availability: 'Uses the current local Vitest performance path.',
+    testedFlow: `${starboard.flow.target} — ${starboard.flow.name}`,
+    source: starboard.diagnosis.source,
+    primaryMetric: {
+      label: 'Largest tested catalog',
+      value: `${starboard.paired_verification.delta_percent.toFixed(1)}% slower`,
+      note: `${starboard.paired_verification.baseline_ms_per_operation} → ${starboard.paired_verification.candidate_ms_per_operation} ms/op`,
+    },
+    protectedMetrics: [
+      {
+        label: 'Peak RSS',
+        value: `${Math.abs(starboard.paired_verification.peak_rss_delta_percent).toFixed(1)}% lower`,
+        decision: 'did not offset the speed regression',
+      },
+      {
+        label: 'Allocation evidence',
+        value: 'Incomplete',
+        decision: 'collection bound exceeded',
+      },
+    ],
+    changeCost: {
+      files: starboard.experiment.change_cost.files_changed,
+      added: starboard.experiment.change_cost.lines_added,
+      removed: starboard.experiment.change_cost.lines_removed,
+      gross: starboard.experiment.change_cost.gross_lines_changed,
+      net:
+        starboard.experiment.change_cost.lines_added -
+        starboard.experiment.change_cost.lines_removed,
+      dependencies: starboard.experiment.change_cost.production_dependencies_added.length,
+    },
+    correctness: `${starboard.experiment.focused_correctness.tests_passed} focused tests passed before performance rejected the candidate.`,
+    process: [
+      {
+        decision: 'observed',
+        title: 'Tokenization appeared in the CPU profile',
+        evidence: `${(starboard.diagnosis.cpu_sample_share * 100).toFixed(1)}% of CPU samples pointed at meaningfulTokens.`,
+      },
+      {
+        decision: 'tested',
+        title: 'Incremental regular-expression scan',
+        evidence:
+          'The one-file experiment stayed within the change-cost budget and passed focused correctness.',
+      },
+      {
+        decision: 'rejected',
+        title: 'Slower and too noisy to trust',
+        evidence:
+          'The candidate was slower, sample spread was high, allocation evidence was incomplete, and the source was restored.',
+      },
+    ],
+    limitations: starboard.limitations,
+  },
+];

--- a/apps/landing-page-astro/src/pages/benchmark.astro
+++ b/apps/landing-page-astro/src/pages/benchmark.astro
@@ -97,6 +97,15 @@ const datasetJsonLd = {
         </p>
       </section>
 
+      <section class="mt-10 border-y border-[--color-line] py-7" aria-labelledby="optimization-benchmark-link">
+        <h2 id="optimization-benchmark-link" class="text-xl font-semibold text-white">Performance evidence has separate project pages</h2>
+        <p class="mt-3 text-sm leading-7 text-[--color-text-dim]">
+          Inspect dated Anime List, Free AI, and Starboard trials—including patch cost, repeated
+          measurements, rejected experiments, current availability, and local-only limitations.
+        </p>
+        <a class="mt-5 inline-flex text-sm text-[--color-accent] hover:underline" href="/benchmark/optimization">Open optimization case studies →</a>
+      </section>
+
       <section class="mt-10 grid grid-cols-2 gap-4">
         <div class="rounded-lg border border-[--color-line] bg-[--color-surface] p-5">
           <div class="text-xs font-mono uppercase tracking-widest text-[--color-text-mute]">CodeVetter</div>

--- a/apps/landing-page-astro/src/pages/benchmark/optimization-proofs.json.ts
+++ b/apps/landing-page-astro/src/pages/benchmark/optimization-proofs.json.ts
@@ -1,0 +1,14 @@
+import anime from '../../../../../benchmarks/performance-lab/autonomous-browser-loop-anime-proof-2026-08-14.json';
+import freeAi from '../../../../../benchmarks/performance-lab/free-ai-selection-one-pass-proof-2026-08-14.json';
+import starboard from '../../../../../benchmarks/performance-lab/starboard-token-scan-rejection-2026-08-14.json';
+
+export const prerender = true;
+
+export function GET() {
+  return new Response(`${JSON.stringify({ anime, free_ai: freeAi, starboard }, null, 2)}\n`, {
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600',
+    },
+  });
+}

--- a/apps/landing-page-astro/src/pages/benchmark/optimization.astro
+++ b/apps/landing-page-astro/src/pages/benchmark/optimization.astro
@@ -1,0 +1,56 @@
+---
+import Footer from '@/components/Footer.astro';
+import Nav from '@/components/Nav.astro';
+import { optimizationCaseStudies } from '@/data/optimization-case-studies';
+import Layout from '@/layouts/Layout.astro';
+
+const tone = {
+  confirmed: 'text-[--color-ok]',
+  retained: 'text-[--color-ok]',
+  rejected: 'text-[--color-danger]',
+};
+---
+
+<Layout
+  title="Optimization benchmarks and case studies — CodeVetter"
+  description="Dated CodeVetter optimization trials with tested flows, repeated measurements, correctness boundaries, patch cost, rejected candidates, and proof JSON."
+  path="/benchmark/optimization"
+>
+  <Nav />
+  <main class="mx-auto min-h-screen max-w-5xl px-6 pb-24 pt-36 text-[--color-text]">
+    <header class="max-w-3xl">
+      <a class="font-mono text-xs text-[#9297a1] hover:text-[--color-accent]" href="/benchmark">← Code-review benchmark</a>
+      <p class="mt-8 font-mono text-xs uppercase tracking-[0.16em] text-[--color-accent]">Optimization proof · observed 2026-08-14</p>
+      <h1 class="mt-4 text-5xl font-bold tracking-[-0.04em] text-white md:text-6xl">Every project gets its own evidence boundary.</h1>
+      <p class="mt-6 max-w-[70ch] text-base leading-8 text-[--color-text-dim]">
+        These are separate local trials, not one blended headline. Each page names the exact flow,
+        revision, source candidate, patch cost, correctness scope, repeated measurement, decision,
+        availability, and limitation. A rejected experiment remains visible.
+      </p>
+      <a class="mt-7 inline-flex h-10 items-center border border-[--color-line-2] px-4 text-sm text-white hover:border-[--color-accent]/50" href="/optimize">How Optimize works</a>
+    </header>
+
+    <section class="mt-20 border-t border-[--color-line]" aria-label="Project case studies">
+      {optimizationCaseStudies.map((study) => (
+        <a class="group grid gap-4 border-b border-[--color-line] py-7 sm:grid-cols-[150px_110px_minmax(0,1fr)_110px] sm:items-start" href={`/benchmark/optimization/${study.slug}`}>
+          <strong class="text-base font-medium text-white group-hover:text-[--color-accent]">{study.project}</strong>
+          <span class:list={['font-mono text-xs uppercase tracking-[0.12em]', tone[study.decision]]}>{study.decision}</span>
+          <span>
+            <span class="block text-lg font-semibold text-white">{study.primaryMetric.value}</span>
+            <span class="mt-2 block text-sm leading-6 text-[--color-text-dim]">{study.summary}</span>
+            <span class="mt-3 block font-mono text-xs text-[#9297a1]">
+              {study.changeCost.files} file{study.changeCost.files === 1 ? '' : 's'} · {study.changeCost.gross} gross lines · net {study.changeCost.net} · {study.changeCost.dependencies} dependencies
+            </span>
+          </span>
+          <time class="font-mono text-xs text-[#9297a1] sm:text-right" datetime={study.date}>{study.date}</time>
+        </a>
+      ))}
+    </section>
+
+    <p class="mt-12 max-w-[72ch] text-sm leading-7 text-[--color-text-dim]">
+      These three receipts are the intentionally small public set. Historical research capability
+      is labeled separately from the compact runtime path currently shipped in CodeVetter.
+    </p>
+  </main>
+  <Footer />
+</Layout>

--- a/apps/landing-page-astro/src/pages/benchmark/optimization/[project].astro
+++ b/apps/landing-page-astro/src/pages/benchmark/optimization/[project].astro
@@ -1,0 +1,106 @@
+---
+import Footer from '@/components/Footer.astro';
+import Nav from '@/components/Nav.astro';
+import {
+  optimizationCaseStudies,
+  type OptimizationCaseStudy,
+} from '@/data/optimization-case-studies';
+import Layout from '@/layouts/Layout.astro';
+
+export function getStaticPaths() {
+  return optimizationCaseStudies.map((study) => ({
+    params: { project: study.slug },
+    props: { study },
+  }));
+}
+
+interface Props {
+  study: OptimizationCaseStudy;
+}
+
+const { study } = Astro.props;
+const decisionTone = study.decision === 'rejected' ? 'text-[--color-danger]' : 'text-[--color-ok]';
+---
+
+<Layout
+  title={`${study.project} optimization case study — CodeVetter`}
+  description={`${study.project}: ${study.summary}`}
+  path={`/benchmark/optimization/${study.slug}`}
+>
+  <Nav />
+  <main class="mx-auto min-h-screen max-w-5xl px-6 pb-24 pt-36 text-[--color-text]">
+    <header>
+      <a class="font-mono text-xs text-[#9297a1] hover:text-[--color-accent]" href="/benchmark/optimization">← All optimization trials</a>
+      <div class="mt-8 flex flex-wrap items-center gap-3 font-mono text-xs uppercase tracking-[0.14em]">
+        <span class={decisionTone}>{study.decision}</span>
+        <time class="text-[#9297a1]" datetime={study.date}>Observed {study.date}</time>
+        <span class="text-[#9297a1]">Local evidence</span>
+      </div>
+      <h1 class="mt-5 text-5xl font-bold tracking-[-0.04em] text-white md:text-6xl">{study.project}</h1>
+      <p class="mt-6 max-w-[72ch] text-base leading-8 text-[--color-text-dim]">{study.summary}</p>
+      <p class="mt-5 max-w-[72ch] border-l border-[--color-warn] pl-4 text-sm leading-6 text-[--color-text-dim]">
+        <strong class="text-white">Availability:</strong> {study.availability}
+      </p>
+    </header>
+
+    <section class="mt-14 grid gap-px border border-[--color-line] bg-[--color-line] md:grid-cols-3" aria-label="Measured result">
+      <div class="bg-[--color-bg-elev] p-6">
+        <p class="font-mono text-xs uppercase tracking-[0.13em] text-[#9297a1]">{study.primaryMetric.label}</p>
+        <p class:list={['mt-3 text-3xl font-semibold tracking-[-0.04em]', decisionTone]}>{study.primaryMetric.value}</p>
+        <p class="mt-3 text-xs leading-5 text-[--color-text-dim]">{study.primaryMetric.note}</p>
+      </div>
+      {study.protectedMetrics.map((metric) => (
+        <div class="bg-[--color-bg-elev] p-6">
+          <p class="font-mono text-xs uppercase tracking-[0.13em] text-[#9297a1]">{metric.label}</p>
+          <p class="mt-3 text-2xl font-semibold tracking-[-0.03em] text-white">{metric.value}</p>
+          <p class="mt-3 text-xs leading-5 text-[--color-warn]">{metric.decision}</p>
+        </div>
+      ))}
+    </section>
+
+    <section class="mt-16 grid gap-10 lg:grid-cols-[0.72fr_1.28fr]" aria-labelledby="boundary-title">
+      <div>
+        <h2 id="boundary-title" class="text-2xl font-semibold text-white">Tested boundary</h2>
+        <dl class="mt-6 space-y-5 text-sm">
+          <div><dt class="font-mono text-xs uppercase tracking-wider text-[#9297a1]">Flow</dt><dd class="mt-2 leading-6 text-[--color-text-dim]">{study.testedFlow}</dd></div>
+          <div><dt class="font-mono text-xs uppercase tracking-wider text-[#9297a1]">Source</dt><dd class="mt-2 break-words font-mono text-xs leading-6 text-[--color-text-dim]">{study.source}</dd></div>
+          <div><dt class="font-mono text-xs uppercase tracking-wider text-[#9297a1]">Revision</dt><dd class="mt-2 break-all font-mono text-xs text-[--color-text-dim]">{study.revision}</dd></div>
+        </dl>
+      </div>
+      <div>
+        <h2 class="text-2xl font-semibold text-white">Decision path</h2>
+        <ol class="mt-6 border-t border-[--color-line]">
+          {study.process.map((step) => (
+            <li class="grid gap-3 border-b border-[--color-line] py-5 sm:grid-cols-[90px_minmax(0,1fr)]">
+              <span class="font-mono text-xs uppercase tracking-wider text-[#9297a1]">{step.decision}</span>
+              <span><strong class="block font-medium text-white">{step.title}</strong><span class="mt-2 block text-sm leading-6 text-[--color-text-dim]">{step.evidence}</span></span>
+            </li>
+          ))}
+        </ol>
+      </div>
+    </section>
+
+    <section class="mt-16 border-y border-[--color-line] py-7" aria-labelledby="cost-title">
+      <div class="grid gap-6 md:grid-cols-[0.7fr_1.3fr] md:items-start">
+        <div>
+          <h2 id="cost-title" class="text-xl font-semibold text-white">Patch cost</h2>
+          <p class="mt-2 font-mono text-xs text-[#9297a1]">{study.changeCost.files} file{study.changeCost.files === 1 ? '' : 's'} · +{study.changeCost.added} / -{study.changeCost.removed} · {study.changeCost.gross} gross · net {study.changeCost.net} · {study.changeCost.dependencies} dependencies</p>
+        </div>
+        <p class="text-sm leading-7 text-[--color-text-dim]"><strong class="text-white">Correctness:</strong> {study.correctness}</p>
+      </div>
+    </section>
+
+    <section class="mt-16" aria-labelledby="limitations-title">
+      <h2 id="limitations-title" class="text-2xl font-semibold text-white">What this does not prove</h2>
+      <ul class="mt-6 space-y-3 text-sm leading-7 text-[--color-text-dim]">
+        {study.limitations.map((limitation) => <li class="flex gap-3"><span aria-hidden="true" class="text-[--color-warn]">—</span><span>{limitation}</span></li>)}
+      </ul>
+    </section>
+
+    <div class="mt-16 flex flex-wrap items-center justify-between gap-4 border-t border-[--color-line] pt-7">
+      <a class="text-sm text-white hover:text-[--color-accent]" href="/benchmark/optimization">Browse all trials</a>
+      <a class="font-mono text-xs text-[#9297a1] hover:text-white" href="/benchmark/optimization-proofs.json">Open proof JSON →</a>
+    </div>
+  </main>
+  <Footer />
+</Layout>

--- a/apps/landing-page-astro/src/pages/optimize.astro
+++ b/apps/landing-page-astro/src/pages/optimize.astro
@@ -1,0 +1,91 @@
+---
+import Footer from '@/components/Footer.astro';
+import Nav from '@/components/Nav.astro';
+import Layout from '@/layouts/Layout.astro';
+
+const stages = [
+  ['Discover', 'Select one executable local test or benchmark flow.'],
+  ['Measure', 'Capture repeatable timing, CPU, allocation, and memory evidence supported by that flow.'],
+  ['Diagnose', 'Rank source-backed bottlenecks while separating observation from inference.'],
+  ['Experiment', 'Give the coding agent one bounded candidate and reject disproportionate patches.'],
+  ['Verify', 'Run exact correctness and repeated before/after measurements before retaining anything.'],
+];
+---
+
+<Layout
+  title="Optimize local application flows with runtime evidence — CodeVetter"
+  description="CodeVetter profiles bounded local JavaScript, Node.js, and Go flows and verifies performance candidates with repeated evidence."
+  path="/optimize"
+>
+  <Nav />
+  <main class="mx-auto min-h-screen max-w-6xl px-6 pb-24 pt-36 text-[--color-text]">
+    <header class="max-w-4xl">
+      <p class="font-mono text-xs uppercase tracking-[0.16em] text-[--color-accent]">Local optimization laboratory</p>
+      <h1 class="mt-5 max-w-3xl font-display text-5xl font-bold tracking-[-0.04em] text-white md:text-7xl">
+        Profile a flow. Prove the change.
+      </h1>
+      <p class="mt-6 max-w-[70ch] text-base leading-8 text-[--color-text-dim]">
+        CodeVetter gives a coding agent a bounded loop for finding a local bottleneck, proposing one
+        small experiment, and retaining it only when correctness and repeated before/after evidence
+        agree. The compact current path targets repository-owned JavaScript, Node.js, and Go tests
+        and benchmarks; it does not treat a plausible edit as an optimization.
+      </p>
+      <div class="mt-8 flex flex-wrap gap-3">
+        <a class="inline-flex h-11 items-center bg-white px-5 text-sm font-semibold text-black hover:bg-gray-100" href="/#download">Download CodeVetter</a>
+        <a class="inline-flex h-11 items-center border border-[--color-line-2] px-5 text-sm text-white hover:border-[--color-accent]/50" href="/benchmark/optimization">Inspect the case studies</a>
+      </div>
+    </header>
+
+    <section class="mt-24" aria-labelledby="loop-title">
+      <div class="grid gap-10 lg:grid-cols-[0.7fr_1.3fr]">
+        <div>
+          <h2 id="loop-title" class="text-2xl font-semibold text-white">One bounded loop</h2>
+          <p class="mt-4 max-w-[48ch] text-sm leading-7 text-[--color-text-dim]">
+            The machine receipt is authoritative. Every stage records source identity, tested
+            boundary, decision, and limitations so another agent can continue without guessing.
+          </p>
+        </div>
+        <ol class="border-t border-[--color-line]">
+          {stages.map(([title, description], index) => (
+            <li class="grid gap-3 border-b border-[--color-line] py-5 sm:grid-cols-[72px_120px_minmax(0,1fr)]">
+              <span class="font-mono text-xs text-[#9297a1]">{String(index + 1).padStart(2, '0')}</span>
+              <strong class="text-sm font-medium text-white">{title}</strong>
+              <span class="text-sm leading-6 text-[--color-text-dim]">{description}</span>
+            </li>
+          ))}
+        </ol>
+      </div>
+    </section>
+
+    <section class="mt-24 grid gap-px border border-[--color-line] bg-[--color-line] md:grid-cols-2" aria-label="Supported evidence">
+      <div class="bg-[--color-bg-elev] p-7">
+        <h2 class="text-xl font-semibold text-white">JavaScript and Node.js</h2>
+        <p class="mt-3 text-sm leading-7 text-[--color-text-dim]">
+          Exact Node, Vitest, and Jest selections with repeated console metrics, CPU source
+          attribution, sampled allocation evidence, and process-tree memory where observable.
+        </p>
+      </div>
+      <div class="bg-[--color-bg-elev] p-7">
+        <h2 class="text-xl font-semibold text-white">Go</h2>
+        <p class="mt-3 text-sm leading-7 text-[--color-text-dim]">
+          Repository-owned tests and benchmarks with ns/op, bytes/op, allocs/op, bounded profile
+          sources, paired measurements, and explicit evidence gaps.
+        </p>
+      </div>
+    </section>
+
+    <section class="mt-24 grid gap-10 lg:grid-cols-[0.8fr_1.2fr]" aria-labelledby="guardrails-title">
+      <div>
+        <p class="font-mono text-xs uppercase tracking-[0.14em] text-[--color-warn]">Shipping guardrails</p>
+        <h2 id="guardrails-title" class="mt-3 text-3xl font-semibold tracking-[-0.03em] text-white">A faster patch still has to earn its size.</h2>
+      </div>
+      <ul class="space-y-5 text-sm leading-7 text-[--color-text-dim]">
+        <li><strong class="text-white">Change cost:</strong> default maximum of 3 files, 160 added lines, 200 gross changed lines, and no new production dependency.</li>
+        <li><strong class="text-white">Correctness first:</strong> exact repository-owned checks run before repeated paired performance verification.</li>
+        <li><strong class="text-white">No confidence is a result:</strong> noisy, incomplete, stale, or externally dominated evidence cannot authorize shipping.</li>
+        <li><strong class="text-white">Local means local:</strong> no production or customer-impact claim is inferred from a development fixture or synthetic benchmark.</li>
+      </ul>
+    </section>
+  </main>
+  <Footer />
+</Layout>


### PR DESCRIPTION
## Summary

- add a public Optimize overview and separate dated case-study pages for Anime List, Free AI, and Starboard
- expose the same canonical receipts as machine-readable JSON
- label local evidence, rejected experiments, patch cost, availability, and limitations explicitly

## Scope

- 7 source files
- +488 / -2 lines
- no production dependencies

## Verification

- Astro production build: 22 pages generated
- Biome: clean for TypeScript sources
- docs validation: 76 files passed
- Impeccable detector: no findings
- browser review: 390px, 768px, and 1440px; no horizontal overflow
