### PR TITLE
Deduplicate change-cost git helpers

### DIFF
--- a/scripts/runtime-failure-capsule/change-cost.mjs
+++ b/scripts/runtime-failure-capsule/change-cost.mjs
@@ -1,6 +1,7 @@
-import { spawn } from 'node:child_process';
+import { execFile } from 'node:child_process';
 import { readFile } from 'node:fs/promises';
 import { basename, resolve } from 'node:path';
+import { promisify } from 'node:util';
 
 import { repositoryRelative } from './contracts.mjs';
 
@@ -12,6 +13,7 @@ export const CHANGE_COST_POLICY = Object.freeze({
 });
 
 const DEPENDENCY_MANIFESTS = new Set(['package.json', 'go.mod']);
+const execFileAsync = promisify(execFile);
 
 export async function inspectChangeCost(repositoryRoot, changedFiles, baseRevision = 'HEAD') {
   const root = resolve(repositoryRoot);
@@ -158,19 +160,13 @@ function manifestDependencies(path, source) {
   return new Set(dependencies);
 }
 
-function git(cwd, args, allowMissing = false) {
-  return new Promise((resolvePromise, reject) => {
-    const child = spawn('git', args, { cwd, shell: false, stdio: ['ignore', 'pipe', 'pipe'] });
-    let stdout = '';
-    let stderr = '';
-    child.stdout.setEncoding('utf8');
-    child.stderr.setEncoding('utf8');
-    child.stdout.on('data', (chunk) => (stdout += chunk));
-    child.stderr.on('data', (chunk) => (stderr += chunk));
-    child.once('error', reject);
-    child.once('close', (code) => {
-      if (code === 0 || allowMissing) resolvePromise({ stdout, stderr });
-      else reject(new Error(`git ${args[0]} failed`));
-    });
-  });
+async function git(cwd, args, allowMissing = false) {
+  try {
+    return await execFileAsync('git', args, { cwd, encoding: 'utf8' });
+  } catch (error) {
+    if (allowMissing) {
+      return { stdout: error.stdout ?? '', stderr: error.stderr ?? '' };
+    }
+    throw new Error(`git ${args[0]} failed`, { cause: error });
+  }
 }

--- a/scripts/runtime-failure-capsule/change-cost.test.mjs
+++ b/scripts/runtime-failure-capsule/change-cost.test.mjs
@@ -1,11 +1,14 @@
 import assert from 'node:assert/strict';
-import { spawn } from 'node:child_process';
+import { execFile } from 'node:child_process';
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
+import { promisify } from 'node:util';
 
 import { assessChangeCost, inspectChangeCost } from './change-cost.mjs';
+
+const execFileAsync = promisify(execFile);
 
 test('records and accepts a small source-bounded candidate', async (context) => {
   const root = await fixture(context, { 'src/work.js': 'export const work = () => 1;\n' });
@@ -76,9 +79,9 @@ async function fixture(context, files) {
     await mkdir(join(root, path, '..'), { recursive: true });
     await writeFile(join(root, path), contents);
   }
-  await command('git', ['init', '-q'], root);
-  await command('git', ['add', '.'], root);
-  await command(
+  await execFileAsync('git', ['init', '-q'], { cwd: root });
+  await execFileAsync('git', ['add', '.'], { cwd: root });
+  await execFileAsync(
     'git',
     [
       '-c',
@@ -91,21 +94,7 @@ async function fixture(context, files) {
       '-qm',
       'fixture baseline',
     ],
-    root
+    { cwd: root }
   );
   return root;
-}
-
-function command(program, args, cwd) {
-  return new Promise((resolvePromise, reject) => {
-    const child = spawn(program, args, { cwd, shell: false, stdio: ['ignore', 'ignore', 'pipe'] });
-    let stderr = '';
-    child.stderr.setEncoding('utf8');
-    child.stderr.on('data', (chunk) => (stderr += chunk));
-    child.once('error', reject);
-    child.once('close', (code) => {
-      if (code === 0) resolvePromise();
-      else reject(new Error(`${program} failed: ${stderr.trim() || `exit ${code}`}`));
-    });
-  });
 }


### PR DESCRIPTION
## Summary

- replace duplicated child-process wrappers with `execFile`
- keep the 0.75% duplication gate unchanged
- reduce the measured duplication ratio from 0.755% to 0.743%

## Verification

- change-cost and campaign tests: 8 passed
- jscpd: 1,000 / 134,517 duplicated lines (0.74%), gate passed
- Biome: 2 changed files clean
- patch size: +20 / -35 lines, no dependencies
