### PR TITLE
Update Nano ID security pin

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
       "astro>esbuild": "0.28.1",
       "brace-expansion": "5.0.9",
       "js-yaml": "4.3.1",
-      "nanoid": "3.3.17",
+      "nanoid": "3.3.18",
       "postcss": "8.5.26",
       "sharp": "0.35.3",
       "svgo": "4.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ overrides:
   astro>esbuild: 0.28.1
   brace-expansion: 5.0.9
   js-yaml: 4.3.1
-  nanoid: 3.3.17
+  nanoid: 3.3.18
   postcss: 8.5.26
   sharp: 0.35.3
   svgo: 4.0.2
@@ -3103,8 +3103,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -6891,7 +6891,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   neotraverse@0.6.18: {}
 
@@ -7116,7 +7116,7 @@ snapshots:
 
   postcss@8.5.26:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 


### PR DESCRIPTION
## Summary

- update the existing Nano ID override from 3.3.17 to 3.3.18
- clear the high-severity audit finding without adding a dependency

## Verification

- `pnpm audit --audit-level high`: passed; only low/moderate findings remain
- patch size: 2 files, +6 / -6 lines
