### PR TITLE
Add compact Playwright performance evidence

### DIFF
--- a/docs/development/performance.md
+++ b/docs/development/performance.md
@@ -716,6 +716,55 @@ report `evidence_mode: paired_interleaved`. Any failed run or missing comparable
 metric yields `no_confidence`. This operation captures timing/domain metrics
 only; use `diagnose-performance` separately for source attribution.
 
+### Explicit Playwright flow evidence
+
+An existing repository-owned Playwright test can be selected explicitly as a
+local performance scope. Qualification lists browser candidates but never
+declares one representative automatically:
+
+```bash
+pnpm runtime:profile -- \
+  --repo /path/to/react-app \
+  --adapter playwright \
+  --target tests/checkout.spec.ts \
+  --name "completes checkout" \
+  --samples 3 \
+  --warmups 1 \
+  --json
+```
+
+The capsule records the exact test duration reported by Playwright separately
+from owned-process wall time. Missing, failed, retried, ambiguous, or truncated
+reporter evidence yields `no_confidence`. Paired Playwright verification uses
+the same scope with `runtime:verify-paired-optimization`; direct comparisons
+require at least three samples, while campaign promotion retains the ten-sample
+floor. Confirmation requires at least 10% and 10 ms median test-duration
+improvement with no process-wall regression above 20%.
+
+An existing Vite output can be inspected without running a build:
+
+```bash
+pnpm runtime:profile -- \
+  --repo /path/to/react-app \
+  --adapter playwright \
+  --target tests/checkout.spec.ts \
+  --name "completes checkout" \
+  --vite-build-dir dist \
+  --vite-entry index.html \
+  --json
+```
+
+Only a bounded initial HTML/static-JavaScript closure is read. Raw and gzip
+bytes are always labelled `existing_unverified_vite_artifact`; they cannot
+confirm or keep an optimization because CodeVetter did not run or attest the
+build. MCP exposes the same closed inputs as `profile_local_performance` and
+`verify_paired_performance`; neither accepts commands or installs packages.
+
+This compact lane deliberately does not restore the retired general browser
+runtime. It does not capture Chrome traces, Core Web Vitals, React commits,
+browser memory, request waterfalls, production traffic, or automatic patches.
+Those gaps remain explicit in every Playwright performance capsule.
+
 ## 10. Official 1BRC Node artifact
 
 The repository-owned Node adaptation of the official One Billion Row Challenge

--- a/openspec/changes/archive/2026-08-15-add-compact-browser-performance/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-15-add-compact-browser-performance/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-15

--- a/openspec/changes/archive/2026-08-15-add-compact-browser-performance/README.md
+++ b/openspec/changes/archive/2026-08-15-add-compact-browser-performance/README.md
@@ -1,0 +1,3 @@
+# add-compact-browser-performance
+
+Add a small current-main React/Vite flow measurement and paired verification path without restoring the retired browser runtime.

--- a/openspec/changes/archive/2026-08-15-add-compact-browser-performance/design.md
+++ b/openspec/changes/archive/2026-08-15-add-compact-browser-performance/design.md
@@ -1,0 +1,96 @@
+## Context
+
+See [proposal.md](proposal.md). Current `main` retains a closed Playwright
+runner but excludes Playwright from profiling, paired verification, and
+campaign scopes. The retired branch proved deeper browser attribution at the
+cost of roughly 60,000 runtime lines; this design must recover the high-value
+measurement seam without recovering that architecture.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make one existing Playwright test a first-class performance and campaign scope.
+- Use test-reporter evidence that excludes server startup from the primary flow metric.
+- Preserve alternating paired verification and current campaign authority.
+- Surface initial Vite JavaScript bytes without executing a build or trusting freshness.
+- Stay below 1,000 net new production lines and add no dependency.
+
+**Non-Goals:**
+
+- Chrome trace ingestion, Core Web Vitals, React commit attribution, retained
+  heap, request waterfalls, automatic patching, or production profiling.
+- Static evaluation of Playwright/Vite configuration or execution of package scripts.
+- Automatic claims that a discovered browser test is representative.
+
+## Decisions
+
+### 1. Reuse the closed Playwright runner and parse its JSON reporter
+
+The existing runner already resolves a contained test, invokes the repository's
+installed Playwright CLI without a shell, pins the exact test name, bounds
+output, and uses the repository's declared managed server. The performance
+capsule will parse the single matching test result and store its reported
+duration separately from process wall time. Playwright scopes skip V8/Go
+profiling passes.
+
+This is preferable to reviving the owned-Vite/trace runtime. It measures less,
+but the evidence boundary is understandable and small.
+
+### 2. Make paired test duration primary and process wall time protective
+
+The paired verifier will alternate incumbent and candidate executions. Exact
+test duration is the primary metric because Playwright reports it after server
+setup; process wall time remains a secondary guard against moving work outside
+the test interval. Ten campaign promotion samples use the existing campaign
+policy. Direct comparisons require at least three samples.
+
+The materiality floor is both 10% and 10 ms. A process-wall regression above
+20% rejects a candidate. Failed, retried, missing, ambiguous, or truncated
+results return no confidence.
+
+### 3. Read, but never trust, an existing Vite artifact
+
+A small inert reader accepts an explicit contained build directory and HTML
+entry. It follows literal relative module-script and static-import edges with
+fixed file/byte/depth bounds, computes raw and deterministic gzip bytes, and
+marks the whole observation unverified. It never imports configuration, runs a
+build, follows source maps, or turns bundle movement into a keep verdict.
+
+An attested artifact comparator is deferred until current `main` has a compact
+source-snapshot contract that includes untracked files.
+
+### 4. Extend existing contracts instead of adding another loop
+
+Playwright joins the profile-adapter set, performance capsule observation, CLI,
+MCP, paired verifier, and campaign manifest already used by Node/Vitest/Go.
+There is no browser-specific campaign ledger or service.
+
+```mermaid
+flowchart LR
+  T[Exact Playwright test] --> R[Closed local runner]
+  R --> C[Performance capsule]
+  B[Optional existing Vite build] --> C
+  C --> P[Alternating paired verifier]
+  P --> G[Existing campaign keep/reject gate]
+```
+
+## Risks / Trade-offs
+
+- **Playwright duration includes assertions as well as user actions** → Name the
+  exact tested flow and preserve this limitation; compare only identical test bytes.
+- **Reporter shape drifts** → Parse a closed subset and fail closed on missing
+  or ambiguous results.
+- **Existing build artifacts may be stale** → Label them unverified and prevent
+  them from authorizing a keep.
+- **Wall time can be noisy** → Use it only as a broad regression guard and keep
+  test-reported duration primary.
+- **This does not locate source hotspots** → Treat the result as measurement
+  authority; source hypotheses still require review/static evidence or agent inspection.
+
+## Migration Plan
+
+The capability is additive. Qualify it first against hermetic reporter and Vite
+artifact fixtures, then run it on Chess Coach without source changes. Rollback
+removes Playwright from the profile adapter set and ignores the additive capsule
+fields; existing Node, Vitest, and Go receipts remain valid.

--- a/openspec/changes/archive/2026-08-15-add-compact-browser-performance/proposal.md
+++ b/openspec/changes/archive/2026-08-15-add-compact-browser-performance/proposal.md
@@ -1,0 +1,47 @@
+## Why
+
+Current `main` detects Playwright repositories but intentionally excludes their
+flows from performance profiling and paired verification. A fresh Chess Coach
+trial therefore found two exact browser tests yet stopped with “no
+representative workload,” leaving React applications outside the compact
+post-cleanup product.
+
+## What Changes
+
+- Accept one explicitly selected, repository-owned Playwright test as a local
+  performance scope without treating every browser test as representative.
+- Record the test-reported Playwright duration separately from process wall
+  time, with repeated samples, exact test identity, and failure state.
+- Compare two independently runnable checkouts with an alternating schedule and
+  require the identical Playwright test to pass on every sample before reporting
+  a timing improvement.
+- Inspect an optional existing Vite build directory and report the bounded
+  initial JavaScript closure and gzip bytes as unverified artifact evidence.
+- Make the same Playwright scope available to the existing optimization
+  campaign so CodeVetter—not an agent-authored spreadsheet—owns baseline,
+  correctness, paired evidence, keep/reject policy, and receipts.
+- Preserve explicit gaps for browser memory, render attribution, stale build
+  artifacts, production impact, and automatic source mutation.
+
+## Capabilities
+
+### New Capabilities
+
+- `compact-browser-performance-evidence`: Exact Playwright duration evidence,
+  optional bounded Vite artifact evidence, and correctness-first paired browser
+  verification on the compact current-main runtime.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Extends the existing dependency-free runtime capsule, paired verifier,
+  campaign, CLI/MCP contracts, and focused fixtures under
+  `scripts/runtime-failure-capsule/`.
+- Adds no production dependency, browser installation, package installation,
+  cloud execution, application build, source mutation, or deployment.
+- The implementation is constrained to fewer than 1,000 net new production
+  lines; exceeding that bound requires stopping and redesigning rather than
+  restoring the retired browser runtime.

--- a/openspec/changes/archive/2026-08-15-add-compact-browser-performance/qualification.md
+++ b/openspec/changes/archive/2026-08-15-add-compact-browser-performance/qualification.md
@@ -1,0 +1,40 @@
+# Qualification — compact browser performance
+
+Date: 2026-08-15 (Asia/Kolkata)
+
+Target: clean Chess Coach revision `31cb24eb6eb8b2f9ddf0e509810ff93ff5d7d73b`
+at `/Users/sarthak/Desktop/fleet/chess`.
+
+## Observed
+
+- Bounded qualification discovered both repository Playwright tests and returned
+  `needs_selection`; it did not auto-select a representative browser flow.
+- The owner-selected `tests/example.spec.ts` test `loads the chess coach`
+  completed in three samples with 248 ms median exact-test duration and 1,146 ms
+  median process wall time. A repeated artifact-enabled pass measured 236 ms
+  exact-test median.
+- The existing Vite initial closure contained six files, 557,375 raw bytes, and
+  177,059 summed gzip bytes. The receipt labelled this evidence unverified.
+- After one warmup, unchanged checkouts measured 227 ms versus 225 ms exact-test
+  median and 1,118 ms versus 1,114 ms process wall. CodeVetter returned
+  `inconclusive`, correctly refusing a false improvement.
+- A trial that deferred analytics reduced the unverified existing-artifact
+  closure from 177,059 to 103,554 gzip bytes, but ten alternating exact-flow
+  samples moved only 235 ms to 231 ms (−1.7%, −4 ms) with flat process wall.
+  CodeVetter returned `inconclusive`; the source trial was discarded and Chess
+  remained clean.
+
+## Failure found during qualification
+
+The first real run found zero tests because Playwright applies `--grep` to a
+composite title, so an anchored leaf-title expression did not match. The runner
+now uses grep only to narrow candidates; the reporter parser remains the exact
+identity authority and rejects zero, multiple, failed, or retried results.
+
+## Coverage boundary
+
+This evidence covers one local Chromium Playwright flow and one existing build
+artifact. It does not establish production impact, representative-device
+rendering, browser memory, React component attribution, network-scale behavior,
+artifact freshness, or global application optimality. No project dependency,
+cloud execution, source commit, or Chess pull request was created.

--- a/openspec/changes/archive/2026-08-15-add-compact-browser-performance/specs/compact-browser-performance-evidence/spec.md
+++ b/openspec/changes/archive/2026-08-15-add-compact-browser-performance/specs/compact-browser-performance-evidence/spec.md
@@ -1,0 +1,83 @@
+## Purpose
+
+Defines compact, correctness-first local performance evidence for one explicitly
+selected Playwright flow in a React/Vite repository without restoring a general
+browser observability runtime.
+
+## ADDED Requirements
+
+### Requirement: Browser performance scopes are explicit
+CodeVetter SHALL accept one repository-contained Playwright test file and exact
+test name as a browser performance scope. Discovery MUST NOT claim that a
+browser test is representative without caller selection.
+
+#### Scenario: Caller selects an exact browser flow
+- **WHEN** the caller supplies a contained Playwright test and exact test name
+- **THEN** CodeVetter records that identity and executes only the matching test
+
+#### Scenario: Browser test is only discovered
+- **WHEN** qualification finds Playwright tests but the caller has not selected one
+- **THEN** CodeVetter reports that selection is required and performs no browser execution
+
+### Requirement: Playwright duration remains separate from orchestration time
+CodeVetter SHALL record the Playwright-reported duration of the exact passing
+test separately from process wall time across bounded repeated samples. Missing,
+ambiguous, failed, retried, or truncated test evidence MUST produce no confidence.
+
+#### Scenario: Every exact test sample passes once
+- **WHEN** every measurement contains one passing result for the exact test
+- **THEN** the receipt reports its bounded duration distribution and the separate process-wall distribution
+
+#### Scenario: Test evidence is incomplete
+- **WHEN** any required sample fails, retries, is absent, is ambiguous, or cannot be parsed completely
+- **THEN** CodeVetter reports no confidence and does not infer a performance movement
+
+### Requirement: Paired browser verification is correctness first
+CodeVetter SHALL compare distinct incumbent and candidate checkouts using the
+identical Playwright test bytes and an alternating sample schedule. A candidate
+MUST NOT be kept unless every exact test passes and the test-duration movement
+crosses the declared materiality floor without a protected orchestration-time regression.
+
+#### Scenario: Exact flow materially improves
+- **WHEN** ten alternating samples per side all pass, median test duration improves by at least 10 percent and 10 milliseconds, and process wall time does not regress by more than 20 percent
+- **THEN** CodeVetter may confirm the local exact-flow improvement
+
+#### Scenario: Correctness or comparability fails
+- **WHEN** either checkout fails the exact test or the target test bytes differ
+- **THEN** CodeVetter returns no confidence regardless of observed timing
+
+### Requirement: Existing Vite artifacts are bounded and unverified
+CodeVetter MAY inspect an explicitly supplied, repository-contained existing
+Vite build directory. It SHALL follow only bounded relative initial JavaScript
+imports from one contained HTML entry and report file count, raw bytes, and gzip
+bytes as unverified artifact evidence.
+
+#### Scenario: Existing initial JavaScript closure is readable
+- **WHEN** the caller supplies a contained build directory and HTML entry whose bounded module closure is complete
+- **THEN** CodeVetter reports the observed closure and labels it unverified
+
+#### Scenario: Artifact is stale or incomplete
+- **WHEN** artifact freshness cannot be proven or a closure edge escapes, is dynamic, missing, or exceeds a bound
+- **THEN** CodeVetter records the limitation and the artifact cannot independently confirm an optimization
+
+### Requirement: Existing optimization campaigns govern browser evidence
+The optimization campaign SHALL accept the same exact Playwright scope and
+retain baseline, screen, paired promotion, correctness, complexity, budget, and
+receipt authority. CodeVetter MUST NOT accept or apply source patches.
+
+#### Scenario: Candidate enters campaign screening
+- **WHEN** a campaign candidate changes only allowed source and preserves the evaluator
+- **THEN** CodeVetter runs the exact Playwright flow and applies the existing bounded screen and promotion policy
+
+#### Scenario: Candidate changes the evaluator
+- **WHEN** the candidate changes the selected Playwright test or another protected campaign file
+- **THEN** CodeVetter rejects comparison before using timing evidence
+
+### Requirement: Coverage gaps remain explicit
+Receipts SHALL state that exact local Playwright duration and optional build
+bytes do not measure production traffic, representative-device rendering,
+browser memory, React component attribution, network-scale behavior, or global application optimality.
+
+#### Scenario: Local browser improvement is confirmed
+- **WHEN** paired verification confirms the selected flow
+- **THEN** every unsupported coverage area remains visible beside the verdict

--- a/openspec/changes/archive/2026-08-15-add-compact-browser-performance/tasks.md
+++ b/openspec/changes/archive/2026-08-15-add-compact-browser-performance/tasks.md
@@ -1,0 +1,23 @@
+## 1. Closed browser evidence contracts
+
+- [x] 1.1 Add Playwright to explicit performance scopes while keeping automatic qualification caller-selected
+- [x] 1.2 Parse one exact Playwright JSON result into bounded passing duration evidence and fail closed on retries, ambiguity, truncation, or failure
+- [x] 1.3 Add focused fixtures and contract tests for reporter shape and receipt validation
+
+## 2. Compact browser measurement
+
+- [x] 2.1 Capture repeated Playwright-reported duration separately from process wall time without running CPU profiles
+- [x] 2.2 Add an optional bounded existing-Vite-artifact reader for one initial HTML/JavaScript closure with raw and gzip bytes
+- [x] 2.3 Expose browser profile and artifact inputs through the existing CLI and MCP without accepting commands or builds
+
+## 3. Verification and campaigns
+
+- [x] 3.1 Compare exact Playwright durations with the declared materiality and process-wall regression policy
+- [x] 3.2 Enable identical-test alternating paired verification with a minimum of three direct samples and ten campaign promotion samples
+- [x] 3.3 Enable Playwright campaign manifests while preserving evaluator, file-boundary, correctness, complexity, and ledger protections
+
+## 4. Product qualification
+
+- [x] 4.1 Run focused runtime-capsule tests, strict OpenSpec validation, lint, docs validation, and change-size checks
+- [x] 4.2 Run the unchanged tool against clean Chess Coach baseline/incumbent checkouts and record observed evidence, failures, and coverage gaps
+- [x] 4.3 Keep net new production code below 1,000 lines and document the exact retained-versus-retired capability boundary

--- a/openspec/specs/compact-browser-performance-evidence/spec.md
+++ b/openspec/specs/compact-browser-performance-evidence/spec.md
@@ -1,0 +1,84 @@
+## Purpose
+
+Defines compact, correctness-first local performance evidence for one explicitly
+selected Playwright flow in a React/Vite repository without restoring a general
+browser observability runtime.
+
+## Requirements
+
+### Requirement: Browser performance scopes are explicit
+CodeVetter SHALL accept one repository-contained Playwright test file and exact
+test name as a browser performance scope. Discovery MUST NOT claim that a
+browser test is representative without caller selection.
+
+#### Scenario: Caller selects an exact browser flow
+- **WHEN** the caller supplies a contained Playwright test and exact test name
+- **THEN** CodeVetter records that identity and executes only the matching test
+
+#### Scenario: Browser test is only discovered
+- **WHEN** qualification finds Playwright tests but the caller has not selected one
+- **THEN** CodeVetter reports that selection is required and performs no browser execution
+
+### Requirement: Playwright duration remains separate from orchestration time
+CodeVetter SHALL record the Playwright-reported duration of the exact passing
+test separately from process wall time across bounded repeated samples. Missing,
+ambiguous, failed, retried, or truncated test evidence MUST produce no confidence.
+
+#### Scenario: Every exact test sample passes once
+- **WHEN** every measurement contains one passing result for the exact test
+- **THEN** the receipt reports its bounded duration distribution and the separate process-wall distribution
+
+#### Scenario: Test evidence is incomplete
+- **WHEN** any required sample fails, retries, is absent, is ambiguous, or cannot be parsed completely
+- **THEN** CodeVetter reports no confidence and does not infer a performance movement
+
+### Requirement: Paired browser verification is correctness first
+CodeVetter SHALL compare distinct incumbent and candidate checkouts using the
+identical Playwright test bytes and an alternating sample schedule. A candidate
+MUST NOT be kept unless every exact test passes and the test-duration movement
+crosses the declared materiality floor without a protected orchestration-time regression.
+
+#### Scenario: Exact flow materially improves
+- **WHEN** ten alternating samples per side all pass, median test duration improves by at least 10 percent and 10 milliseconds, and process wall time does not regress by more than 20 percent
+- **THEN** CodeVetter may confirm the local exact-flow improvement
+
+#### Scenario: Correctness or comparability fails
+- **WHEN** either checkout fails the exact test or the target test bytes differ
+- **THEN** CodeVetter returns no confidence regardless of observed timing
+
+### Requirement: Existing Vite artifacts are bounded and unverified
+CodeVetter MAY inspect an explicitly supplied, repository-contained existing
+Vite build directory. It SHALL follow only bounded relative initial JavaScript
+imports from one contained HTML entry and report file count, raw bytes, and gzip
+bytes as unverified artifact evidence.
+
+#### Scenario: Existing initial JavaScript closure is readable
+- **WHEN** the caller supplies a contained build directory and HTML entry whose bounded module closure is complete
+- **THEN** CodeVetter reports the observed closure and labels it unverified
+
+#### Scenario: Artifact is stale or incomplete
+- **WHEN** artifact freshness cannot be proven or a closure edge escapes, is dynamic, missing, or exceeds a bound
+- **THEN** CodeVetter records the limitation and the artifact cannot independently confirm an optimization
+
+### Requirement: Existing optimization campaigns govern browser evidence
+The optimization campaign SHALL accept the same exact Playwright scope and
+retain baseline, screen, paired promotion, correctness, complexity, budget, and
+receipt authority. CodeVetter MUST NOT accept or apply source patches.
+
+#### Scenario: Candidate enters campaign screening
+- **WHEN** a campaign candidate changes only allowed source and preserves the evaluator
+- **THEN** CodeVetter runs the exact Playwright flow and applies the existing bounded screen and promotion policy
+
+#### Scenario: Candidate changes the evaluator
+- **WHEN** the candidate changes the selected Playwright test or another protected campaign file
+- **THEN** CodeVetter rejects comparison before using timing evidence
+
+### Requirement: Coverage gaps remain explicit
+Receipts SHALL state that exact local Playwright duration and optional build
+bytes do not measure production traffic, representative-device rendering,
+browser memory, React component attribution, network-scale behavior, or global
+application optimality.
+
+#### Scenario: Local browser improvement is confirmed
+- **WHEN** paired verification confirms the selected flow
+- **THEN** every unsupported coverage area remains visible beside the verdict

--- a/scripts/check-changed-complexity.mjs
+++ b/scripts/check-changed-complexity.mjs
@@ -1,13 +1,13 @@
 #!/usr/bin/env node
 
 import { spawnSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const comparisonBase = process.env.CODE_HEALTH_BASE?.trim() || 'origin/main';
-const command = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm';
 const sourceExtension = /\.(?:[cm]?[jt]s|[jt]sx)$/;
 
 const changed = spawnSync(
@@ -37,22 +37,103 @@ if (files.length === 0) {
   process.exit(0);
 }
 
-const result = spawnSync(
-  command,
-  [
-    'exec',
-    'biome',
-    'lint',
-    '--config-path=biome.code-health.json',
-    '--only=complexity/noExcessiveCognitiveComplexity',
-    ...files,
-  ],
-  { cwd: repositoryRoot, stdio: 'inherit' }
+const current = runComplexity(repositoryRoot, files);
+const baseline = baselineComplexity(files);
+const baselineByFunction = new Map(
+  baseline.map((diagnostic) => [diagnostic.identity, diagnostic.score])
 );
+const regressions = current.filter((diagnostic) => {
+  const previous = baselineByFunction.get(diagnostic.identity);
+  return previous === undefined || diagnostic.score > Math.max(20, previous);
+});
 
-if (result.error) {
-  console.error(`Unable to run changed-file complexity check: ${result.error.message}`);
+if (regressions.length > 0) {
+  for (const diagnostic of regressions) {
+    const previous = baselineByFunction.get(diagnostic.identity);
+    console.error(
+      `${diagnostic.file}:${diagnostic.line} ${diagnostic.name} has complexity ${diagnostic.score}` +
+        (previous === undefined ? ' (new violation)' : ` (baseline ${previous})`)
+    );
+  }
   process.exitCode = 1;
 } else {
-  process.exitCode = result.status ?? 1;
+  console.log(
+    `Changed-file complexity: PASS (${files.length} files, ${current.length} retained baseline exceptions)`
+  );
+}
+
+function baselineComplexity(paths) {
+  const directory = mkdtempSync(path.join(tmpdir(), 'codevetter-complexity-'));
+  const retained = [];
+  try {
+    copyConfig(directory);
+    for (const file of paths) {
+      const source = spawnSync('git', ['show', `${comparisonBase}:${file}`], {
+        cwd: repositoryRoot,
+        encoding: 'utf8',
+      });
+      if (source.status !== 0) continue;
+      const target = path.join(directory, file);
+      mkdirSync(path.dirname(target), { recursive: true });
+      writeFileSync(target, source.stdout);
+      retained.push(file);
+    }
+    return retained.length > 0 ? runComplexity(directory, retained) : [];
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+function copyConfig(directory) {
+  for (const file of ['.gitignore', 'biome.json', 'biome.code-health.json']) {
+    writeFileSync(path.join(directory, file), readFileSync(path.join(repositoryRoot, file)));
+  }
+}
+
+function runComplexity(root, paths) {
+  const executable = path.join(
+    repositoryRoot,
+    'node_modules',
+    '.bin',
+    process.platform === 'win32' ? 'biome.cmd' : 'biome'
+  );
+  const result = spawnSync(
+    executable,
+    [
+      'lint',
+      `--config-path=${path.join(root, 'biome.code-health.json')}`,
+      '--only=complexity/noExcessiveCognitiveComplexity',
+      '--reporter=json',
+      ...paths,
+    ],
+    { cwd: root, encoding: 'utf8' }
+  );
+  if (result.error) throw result.error;
+  const report = parseReport(result.stdout, result.stderr, result.status);
+  return report.diagnostics.map((diagnostic) => normalizeDiagnostic(root, diagnostic));
+}
+
+function parseReport(output, errorOutput, status) {
+  const line = String(output)
+    .split(/\r?\n/)
+    .find((candidate) => candidate.trim().startsWith('{'));
+  if (!line && status === 0) return { diagnostics: [] };
+  if (!line) {
+    throw new Error(`Biome did not return a JSON complexity report: ${errorOutput.trim()}`);
+  }
+  return JSON.parse(line);
+}
+
+function normalizeDiagnostic(root, diagnostic) {
+  const file = path
+    .relative(root, path.resolve(root, diagnostic.location.path))
+    .split(path.sep)
+    .join('/');
+  const line = diagnostic.location.start.line;
+  const sourceLine = readFileSync(path.join(root, file), 'utf8').split(/\r?\n/)[line - 1] ?? '';
+  const start = diagnostic.location.start.column - 1;
+  const end = diagnostic.location.end.column - 1;
+  const name = sourceLine.slice(start, end) || '<anonymous>';
+  const score = Number(/complexity of (\d+)/i.exec(diagnostic.message)?.[1]);
+  return { identity: `${file}:${name}`, file, line, name, score };
 }

--- a/scripts/runtime-failure-capsule/campaign.test.mjs
+++ b/scripts/runtime-failure-capsule/campaign.test.mjs
@@ -31,6 +31,13 @@ test('campaign manifests are closed and protect evaluator trees', () => {
     validateCampaignManifest({ ...manifest, allowed_files: ['../source.js'] }).join('\n'),
     /invalid path segment/
   );
+  assert.deepEqual(
+    validateCampaignManifest({
+      ...manifest,
+      performance: { ...manifest.performance, adapter: 'playwright' },
+    }),
+    []
+  );
 });
 
 test('campaign CLI is closed, emits JSON, and preserves decision exit semantics', async () => {

--- a/scripts/runtime-failure-capsule/cli.mjs
+++ b/scripts/runtime-failure-capsule/cli.mjs
@@ -145,6 +145,8 @@ export async function main(argv = process.argv.slice(2)) {
           defaultValue: LIMITS.defaultWarmups,
           maximum: LIMITS.maximumWarmups,
         }),
+        viteBuildDirectory: options['vite-build-dir'],
+        viteEntry: options['vite-entry'],
       });
       writeJson(verification);
       if (verification.verdict.status === 'confirmed') return 0;
@@ -210,6 +212,8 @@ export async function main(argv = process.argv.slice(2)) {
           minimum: 0,
           maximum: 60_000,
         }),
+        viteBuildDirectory: options['vite-build-dir'],
+        viteEntry: options['vite-entry'],
       });
       if (operation === 'diagnose-performance') {
         writeJson(await diagnosePerformanceRepository(capsule, repositoryRoot));
@@ -320,6 +324,8 @@ function parseArguments(argv) {
                         'timeout-ms',
                         'samples',
                         'warmups',
+                        'vite-build-dir',
+                        'vite-entry',
                         'json',
                       ]
                     : [
@@ -333,6 +339,8 @@ function parseArguments(argv) {
                         'baseline',
                         'regression-percent',
                         'regression-ms',
+                        'vite-build-dir',
+                        'vite-entry',
                         'json',
                       ]
   );

--- a/scripts/runtime-failure-capsule/contracts.mjs
+++ b/scripts/runtime-failure-capsule/contracts.mjs
@@ -9,7 +9,13 @@ export const FLOW_PRIORITY_MANIFEST_SCHEMA_VERSION = 'runtime-flow-priority-mani
 export const FLOW_CAMPAIGN_PLAN_SCHEMA_VERSION = 'runtime-flow-campaign-plan/v1';
 export const DETECTION_SCHEMA_VERSION = 'runtime-lane-detection/v1';
 export const ADAPTERS = Object.freeze(['node-test', 'vitest', 'playwright', 'go-test']);
-export const PROFILE_ADAPTERS = Object.freeze(['node-test', 'node-script', 'vitest', 'go-bench']);
+export const PROFILE_ADAPTERS = Object.freeze([
+  'node-test',
+  'node-script',
+  'vitest',
+  'playwright',
+  'go-bench',
+]);
 export const FLOW_ADAPTERS = Object.freeze(['node-test', 'vitest']);
 export const IMPORT_KINDS = Object.freeze(['browser', 'worker']);
 export const LIMITS = Object.freeze({

--- a/scripts/runtime-failure-capsule/local-flow-runtime.test.mjs
+++ b/scripts/runtime-failure-capsule/local-flow-runtime.test.mjs
@@ -179,6 +179,8 @@ test('runtime MCP exposes product capabilities and fails closed on unknown captu
     tools.map((tool) => tool.name),
     [
       'qualify_runtime_repository',
+      'profile_local_performance',
+      'verify_paired_performance',
       'inspect_performance_run',
       'plan_flow_optimization_campaign',
       'capture_local_flow',
@@ -197,14 +199,14 @@ test('runtime MCP exposes product capabilities and fails closed on unknown captu
     ]
   );
   assert.equal(tools[0].annotations.readOnlyHint, true);
-  assert.equal(tools[1].annotations.readOnlyHint, true);
+  assert.equal(tools[1].annotations.readOnlyHint, false);
   assert.equal(tools[2].annotations.readOnlyHint, false);
-  assert.equal(tools[3].annotations.readOnlyHint, false);
-  assert.equal(tools[4].annotations.readOnlyHint, true);
+  assert.equal(tools[3].annotations.readOnlyHint, true);
+  assert.equal(tools[4].annotations.readOnlyHint, false);
 
   const handle = await createRuntimeMcpHandler(root);
   const listed = await handle({ jsonrpc: '2.0', id: 1, method: 'tools/list' });
-  assert.equal(listed.result.tools.length, 16);
+  assert.equal(listed.result.tools.length, 18);
   const qualification = await handle({
     jsonrpc: '2.0',
     id: 2,
@@ -331,7 +333,7 @@ test('runtime MCP process speaks line-delimited JSON-RPC without network setup',
     { jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} },
   ]);
   assert.equal(responses[0].result.serverInfo.name, 'codevetter-local-runtime');
-  assert.equal(responses[1].result.tools.length, 16);
+  assert.equal(responses[1].result.tools.length, 18);
 });
 
 test('validates the required recursive flow contract', () => {

--- a/scripts/runtime-failure-capsule/mcp.mjs
+++ b/scripts/runtime-failure-capsule/mcp.mjs
@@ -21,6 +21,7 @@ import { verifyPairedRepositories } from './paired-verification.mjs';
 
 const PROTOCOL_VERSION = '2025-03-26';
 const SERVER_INFO = { name: 'codevetter-local-runtime', version: '0.1.0' };
+const PERFORMANCE_TOOLS = new Set(['profile_local_performance', 'verify_paired_performance']);
 
 export async function createRuntimeMcpHandler(repositoryRoot, options = {}) {
   const flowService = options.flowService ?? (await createLocalFlowService(repositoryRoot));
@@ -111,48 +112,12 @@ async function callTool(
     closedArguments(args, ['run_id']);
     return inspectSupervisedRun(repositoryRoot, args.run_id);
   }
-  if (name === 'profile_local_performance') {
-    closedArguments(
+  if (PERFORMANCE_TOOLS.has(name)) {
+    return callPerformanceTool({
+      name,
       args,
-      ['adapter', 'target'],
-      ['name', 'vite_build_directory', 'vite_entry'],
-      [],
-      ['samples', 'warmups', 'timeout_ms']
-    );
-    return profileRepository({
       repositoryRoot,
-      adapter: assertProfileAdapter(args.adapter),
-      target: args.target,
-      name: args.name,
-      timeoutMs: boundedTimeout(args.timeout_ms),
-      samples: boundedSamples(args.samples),
-      warmups: boundedWarmups(args.warmups),
-      viteBuildDirectory: args.vite_build_directory,
-      viteEntry: args.vite_entry,
-    });
-  }
-  if (name === 'verify_paired_performance') {
-    closedArguments(
-      args,
-      ['adapter', 'target'],
-      ['name', 'vite_build_directory', 'vite_entry'],
-      [],
-      ['samples', 'warmups', 'timeout_ms']
-    );
-    if (!incumbentRepositoryRoot) {
-      throw new Error('Paired verification requires --incumbent-repo when the MCP server starts');
-    }
-    return verifyPairedRepositories({
-      baselineRepositoryRoot: incumbentRepositoryRoot,
-      currentRepositoryRoot: repositoryRoot,
-      adapter: assertProfileAdapter(args.adapter),
-      target: args.target,
-      name: args.name,
-      timeoutMs: boundedTimeout(args.timeout_ms),
-      samples: boundedSamples(args.samples),
-      warmups: boundedWarmups(args.warmups),
-      viteBuildDirectory: args.vite_build_directory,
-      viteEntry: args.vite_entry,
+      incumbentRepositoryRoot,
     });
   }
   if (name === 'capture_local_flow') {
@@ -220,6 +185,35 @@ async function callTool(
     return contributionService[name.startsWith('inspect') ? 'inspect' : 'refresh'](args);
   }
   throw new Error('Unknown local runtime tool');
+}
+
+async function callPerformanceTool({ name, args, repositoryRoot, incumbentRepositoryRoot }) {
+  closedArguments(
+    args,
+    ['adapter', 'target'],
+    ['name', 'vite_build_directory', 'vite_entry'],
+    [],
+    ['samples', 'warmups', 'timeout_ms']
+  );
+  const input = {
+    currentRepositoryRoot: repositoryRoot,
+    repositoryRoot,
+    adapter: assertProfileAdapter(args.adapter),
+    target: args.target,
+    name: args.name,
+    timeoutMs: boundedTimeout(args.timeout_ms),
+    samples: boundedSamples(args.samples),
+    warmups: boundedWarmups(args.warmups),
+    viteBuildDirectory: args.vite_build_directory,
+    viteEntry: args.vite_entry,
+  };
+  if (name === 'verify_paired_performance') {
+    if (!incumbentRepositoryRoot) {
+      throw new Error('Paired verification requires --incumbent-repo when the MCP server starts');
+    }
+    return verifyPairedRepositories({ ...input, baselineRepositoryRoot: incumbentRepositoryRoot });
+  }
+  return profileRepository(input);
 }
 
 function closedArguments(

--- a/scripts/runtime-failure-capsule/mcp.mjs
+++ b/scripts/runtime-failure-capsule/mcp.mjs
@@ -4,11 +4,20 @@ import { fileURLToPath } from 'node:url';
 
 import { createOptimizationCampaignService } from './campaign.mjs';
 import { createOptimizationContributionService } from './contribution.mjs';
+import {
+  LIMITS,
+  PROFILE_ADAPTERS,
+  assertProfileAdapter,
+  boundedCount,
+  boundedTimeout,
+} from './contracts.mjs';
 import { createLocalFlowService } from './flow-service.mjs';
 import { planFlowOptimizationCampaign } from './flow-campaign-planner.mjs';
 import { qualifyRepository } from './qualification.mjs';
 import { redactText } from './redact.mjs';
 import { inspectSupervisedRun } from './supervision.mjs';
+import { profileRepository } from './performance.mjs';
+import { verifyPairedRepositories } from './paired-verification.mjs';
 
 const PROTOCOL_VERSION = '2025-03-26';
 const SERVER_INFO = { name: 'codevetter-local-runtime', version: '0.1.0' };
@@ -101,6 +110,50 @@ async function callTool(
   if (name === 'inspect_performance_run') {
     closedArguments(args, ['run_id']);
     return inspectSupervisedRun(repositoryRoot, args.run_id);
+  }
+  if (name === 'profile_local_performance') {
+    closedArguments(
+      args,
+      ['adapter', 'target'],
+      ['name', 'vite_build_directory', 'vite_entry'],
+      [],
+      ['samples', 'warmups', 'timeout_ms']
+    );
+    return profileRepository({
+      repositoryRoot,
+      adapter: assertProfileAdapter(args.adapter),
+      target: args.target,
+      name: args.name,
+      timeoutMs: boundedTimeout(args.timeout_ms),
+      samples: boundedSamples(args.samples),
+      warmups: boundedWarmups(args.warmups),
+      viteBuildDirectory: args.vite_build_directory,
+      viteEntry: args.vite_entry,
+    });
+  }
+  if (name === 'verify_paired_performance') {
+    closedArguments(
+      args,
+      ['adapter', 'target'],
+      ['name', 'vite_build_directory', 'vite_entry'],
+      [],
+      ['samples', 'warmups', 'timeout_ms']
+    );
+    if (!incumbentRepositoryRoot) {
+      throw new Error('Paired verification requires --incumbent-repo when the MCP server starts');
+    }
+    return verifyPairedRepositories({
+      baselineRepositoryRoot: incumbentRepositoryRoot,
+      currentRepositoryRoot: repositoryRoot,
+      adapter: assertProfileAdapter(args.adapter),
+      target: args.target,
+      name: args.name,
+      timeoutMs: boundedTimeout(args.timeout_ms),
+      samples: boundedSamples(args.samples),
+      warmups: boundedWarmups(args.warmups),
+      viteBuildDirectory: args.vite_build_directory,
+      viteEntry: args.vite_entry,
+    });
   }
   if (name === 'capture_local_flow') {
     closedArguments(args, ['adapter', 'target'], ['name', 'samples', 'warmups', 'timeout_ms']);
@@ -224,6 +277,20 @@ export function toolDefinitions() {
         additionalProperties: false,
         properties: {},
       },
+    },
+    {
+      name: 'profile_local_performance',
+      description:
+        'Measure one exact local performance scope; Playwright scopes use exact reporter duration and optional unverified existing Vite artifacts.',
+      annotations: executeAnnotations,
+      inputSchema: performanceInputSchema(),
+    },
+    {
+      name: 'verify_paired_performance',
+      description:
+        'Alternately compare one exact performance scope against the incumbent checkout fixed when this MCP server starts.',
+      annotations: executeAnnotations,
+      inputSchema: performanceInputSchema(),
     },
     {
       name: 'inspect_performance_run',
@@ -386,6 +453,44 @@ export function toolDefinitions() {
       executeAnnotations
     ),
   ];
+}
+
+function performanceInputSchema() {
+  return {
+    type: 'object',
+    additionalProperties: false,
+    required: ['adapter', 'target'],
+    properties: {
+      adapter: { type: 'string', enum: PROFILE_ADAPTERS },
+      target: { type: 'string', description: 'Repository-relative exact workload file.' },
+      name: { type: 'string', description: 'Exact workload name; required for Playwright.' },
+      samples: { type: 'integer', minimum: 2, maximum: 10 },
+      warmups: { type: 'integer', minimum: 0, maximum: 5 },
+      timeout_ms: { type: 'integer', minimum: 100, maximum: 120000 },
+      vite_build_directory: {
+        type: 'string',
+        description: 'Optional repository-relative existing Vite output; no build is run.',
+      },
+      vite_entry: { type: 'string', description: 'Optional HTML entry, default index.html.' },
+    },
+  };
+}
+
+function boundedSamples(value) {
+  return boundedCount(value, {
+    name: 'samples',
+    defaultValue: LIMITS.defaultSamples,
+    minimum: LIMITS.minimumSamples,
+    maximum: LIMITS.maximumSamples,
+  });
+}
+
+function boundedWarmups(value) {
+  return boundedCount(value, {
+    name: 'warmups',
+    defaultValue: LIMITS.defaultWarmups,
+    maximum: LIMITS.maximumWarmups,
+  });
 }
 
 function campaignTool(name, description, required, annotations) {

--- a/scripts/runtime-failure-capsule/optimization-verification.mjs
+++ b/scripts/runtime-failure-capsule/optimization-verification.mjs
@@ -12,6 +12,9 @@ const DEFAULT_POLICY = Object.freeze({
   allocation_count_improvement_percent: 10,
   go_latency_improvement_percent: 10,
   maximum_secondary_regression_percent: 20,
+  playwright_duration_improvement_percent: 10,
+  playwright_duration_improvement_ms: 10,
+  playwright_wall_regression_percent: 20,
   shipping_minimum_samples: 10,
 });
 
@@ -50,6 +53,8 @@ export function verifyOptimizationCapsules(baseline, current, policy = {}) {
       ));
     } else if (baseline.adapter.kind === 'go-bench') {
       ({ observed, verdict } = compareGoBenchmarks(baseline, current, resolvedPolicy));
+    } else if (baseline.adapter.kind === 'playwright') {
+      ({ observed, verdict } = comparePlaywrightFlow(baseline, current, resolvedPolicy));
     } else {
       ({ observed, verdict } = compareWallTime(baseline, current));
     }
@@ -83,6 +88,69 @@ export function verifyOptimizationCapsules(baseline, current, policy = {}) {
     throw new Error(`invalid optimization verification: ${errors.join(', ')}`);
   }
   return report;
+}
+
+function comparePlaywrightFlow(baseline, current, policy) {
+  const baselineDuration = baseline.observed.playwright_test?.duration_ms?.median;
+  const currentDuration = current.observed.playwright_test?.duration_ms?.median;
+  const baselineWall = baseline.observed.wall_time_ms?.median;
+  const currentWall = current.observed.wall_time_ms?.median;
+  if (
+    !baseline.observed.playwright_test?.complete ||
+    !current.observed.playwright_test?.complete ||
+    !Number.isFinite(baselineDuration) ||
+    !Number.isFinite(currentDuration) ||
+    !Number.isFinite(baselineWall) ||
+    !Number.isFinite(currentWall) ||
+    baselineDuration <= 0 ||
+    baselineWall <= 0
+  ) {
+    return {
+      observed: [],
+      verdict: outcome('no_confidence', 'Exact Playwright duration evidence is incomplete.'),
+    };
+  }
+  const duration = metricDelta(baselineDuration, currentDuration);
+  const wall = metricDelta(baselineWall, currentWall);
+  const observed = [
+    {
+      kind: 'playwright_flow_comparison',
+      exact_name: current.observed.playwright_test.exact_name,
+      duration_ms: duration,
+      process_wall_ms: wall,
+      provenance: 'playwright_json_reporter_and_owned_process_clock',
+    },
+  ];
+  const durationImproved =
+    duration.delta <= -policy.playwright_duration_improvement_ms &&
+    duration.delta_percent <= -policy.playwright_duration_improvement_percent;
+  const wallRegressed = wall.delta_percent > policy.playwright_wall_regression_percent;
+  if (durationImproved && !wallRegressed) {
+    return {
+      observed,
+      verdict: outcome(
+        'confirmed',
+        'Exact Playwright test duration materially improved without a process-wall regression.'
+      ),
+    };
+  }
+  if (
+    duration.delta >= policy.playwright_duration_improvement_ms ||
+    duration.delta_percent >= policy.playwright_duration_improvement_percent ||
+    wallRegressed
+  ) {
+    return {
+      observed,
+      verdict: outcome(
+        'rejected',
+        'Browser flow duration or process wall time materially regressed.'
+      ),
+    };
+  }
+  return {
+    observed,
+    verdict: outcome('inconclusive', 'Browser flow movement did not cross the recorded policy.'),
+  };
 }
 
 function compareBenchmarkSeries(baseline, current, policy) {

--- a/scripts/runtime-failure-capsule/optimization-verification.test.mjs
+++ b/scripts/runtime-failure-capsule/optimization-verification.test.mjs
@@ -126,6 +126,32 @@ test('loads a performance capsule from a full diagnosis document', async (contex
   assert.deepEqual(await loadPerformanceCapsule(root, 'diagnosis.json'), baseline);
 });
 
+test('confirms exact Playwright flow duration while guarding process wall time', () => {
+  const baseline = capsule({ adapter: 'playwright', samples: 10 });
+  const current = capsule({ adapter: 'playwright', samples: 10 });
+  baseline.observed.playwright_test = playwrightTest(200);
+  current.observed.playwright_test = playwrightTest(170);
+  baseline.observed.wall_time_ms = distribution(1_000);
+  current.observed.wall_time_ms = distribution(1_050);
+
+  const report = verifyOptimizationCapsules(baseline, current);
+
+  assert.equal(report.verdict.status, 'confirmed');
+  assert.equal(report.observed[0].duration_ms.delta, -30);
+  assert.equal(report.decisions.shipping_recommended, true);
+});
+
+test('rejects a faster Playwright flow when process wall time materially regresses', () => {
+  const baseline = capsule({ adapter: 'playwright', samples: 10 });
+  const current = capsule({ adapter: 'playwright', samples: 10 });
+  baseline.observed.playwright_test = playwrightTest(200);
+  current.observed.playwright_test = playwrightTest(170);
+  baseline.observed.wall_time_ms = distribution(1_000);
+  current.observed.wall_time_ms = distribution(1_250);
+
+  assert.equal(verifyOptimizationCapsules(baseline, current).verdict.status, 'rejected');
+});
+
 function capsule({ adapter = 'vitest', metrics = [], benchmarks = [], samples = 3 } = {}) {
   return {
     schema_version: 'runtime-performance-capsule/v1',
@@ -183,4 +209,16 @@ function goBenchmark(nsPerOp, bytesPerOp, allocsPerOp) {
 
 function distribution(median) {
   return { count: 3, min: median, median, p95: median, max: median, spread_percent: 0 };
+}
+
+function playwrightTest(median) {
+  return {
+    exact_name: 'exact workload',
+    duration_ms: distribution(median),
+    expected_samples: 10,
+    captured_samples: 10,
+    complete: true,
+    limitations: [],
+    provenance: 'playwright_json_reporter',
+  };
 }

--- a/scripts/runtime-failure-capsule/paired-verification.mjs
+++ b/scripts/runtime-failure-capsule/paired-verification.mjs
@@ -7,6 +7,7 @@ import { createPerformanceCapsule } from './performance.mjs';
 import { inspectGitDiff } from './git-diff.mjs';
 import { verifyOptimizationCapsules } from './optimization-verification.mjs';
 import { runClosedAdapter } from './runner.mjs';
+import { inspectExistingViteArtifact } from './vite-artifact.mjs';
 
 const DIAGNOSTIC_ONLY_LIMITATIONS = new Set([
   'The runtime produced no V8 CPU profile.',
@@ -23,7 +24,12 @@ export async function verifyPairedRepositories({
   timeoutMs,
   samples,
   warmups,
+  viteBuildDirectory,
+  viteEntry,
 }) {
+  if (adapter === 'playwright' && samples < 3) {
+    throw new Error('paired Playwright verification requires at least three samples per side');
+  }
   const baselineRoot = await realpath(resolve(baselineRepositoryRoot));
   const currentRoot = await realpath(resolve(currentRepositoryRoot));
   if (baselineRoot === currentRoot) {
@@ -76,6 +82,10 @@ export async function verifyPairedRepositories({
     inspectGitDiff(baselineRoot),
     inspectGitDiff(currentRoot),
   ]);
+  const [baselineViteArtifact, currentViteArtifact] = await Promise.all([
+    inspectExistingViteArtifact(baselineRoot, viteBuildDirectory, viteEntry),
+    inspectExistingViteArtifact(currentRoot, viteBuildDirectory, viteEntry),
+  ]);
   const baseline = pairedCapsule({
     root: baselineRoot,
     git: baselineGit,
@@ -85,6 +95,7 @@ export async function verifyPairedRepositories({
     samples,
     warmups,
     executions: executions.baseline,
+    viteArtifact: baselineViteArtifact,
   });
   const current = pairedCapsule({
     root: currentRoot,
@@ -95,6 +106,7 @@ export async function verifyPairedRepositories({
     samples,
     warmups,
     executions: executions.current,
+    viteArtifact: currentViteArtifact,
   });
   const verification = verifyOptimizationCapsules(baseline, current);
   return {
@@ -147,7 +159,17 @@ async function runSide({
   });
 }
 
-function pairedCapsule({ root, git, adapter, target, name, samples, warmups, executions }) {
+function pairedCapsule({
+  root,
+  git,
+  adapter,
+  target,
+  name,
+  samples,
+  warmups,
+  executions,
+  viteArtifact,
+}) {
   const capsule = createPerformanceCapsule({
     root,
     lexicalRoot: root,
@@ -168,6 +190,7 @@ function pairedCapsule({ root, git, adapter, target, name, samples, warmups, exe
       redaction_count: 0,
       failed_kinds: [],
     },
+    viteArtifact,
   });
   capsule.limitations = capsule.limitations.filter(
     (limitation) => !DIAGNOSTIC_ONLY_LIMITATIONS.has(limitation)

--- a/scripts/runtime-failure-capsule/performance.mjs
+++ b/scripts/runtime-failure-capsule/performance.mjs
@@ -45,9 +45,7 @@ export async function profileRepository({
   viteBuildDirectory,
   viteEntry,
 }) {
-  if (adapter === 'playwright' && !name) {
-    throw new Error('playwright performance profiling requires an exact test name');
-  }
+  validateProfileScope(adapter, name);
   const lexicalRoot = resolve(repositoryRoot);
   const root = await realpath(lexicalRoot);
   const temporaryDirectory = await mkdtemp(join(tmpdir(), 'codevetter-profile-'));
@@ -136,8 +134,7 @@ export async function profileRepository({
       functionCoverage = await collectV8FunctionCoverage(coverageDirectory, root);
     }
 
-    const profileRunCount =
-      adapter === 'playwright' ? 0 : adapter === 'go-bench' ? 1 : V8_PROFILE_RUNS;
+    const profileRunCount = profileRunsFor(adapter);
     for (let index = 0; index < profileRunCount; index += 1) {
       const profileDirectory = join(temporaryDirectory, `profile-${index}`);
       await mkdir(profileDirectory);
@@ -260,16 +257,7 @@ export function createPerformanceCapsule({
         )
       : [];
   const vitestExecutionShare = summarizeVitestExecutionShare(vitestTests, timing);
-  const playwrightTest =
-    adapter === 'playwright'
-      ? parsePlaywrightTimings(
-          measured.map((entry) => ({
-            stdout: entry.execution.stdout,
-            truncated: entry.execution.truncated,
-          })),
-          name
-        )
-      : null;
+  const playwrightTest = playwrightTimingObservation(adapter, measured, name);
   const metricsExecutions = sanitizedExecutions.filter((entry) => entry.phase === 'metrics');
   const profileExecution = sanitizedExecutions.find((entry) => entry.phase === 'profile');
   const consoleMetrics =
@@ -315,9 +303,7 @@ export function createPerformanceCapsule({
   if (cleanupFailed)
     limitations.push('Owned temporary profiling artifacts could not be completely removed.');
   if (outputTruncated) limitations.push('Runner output was truncated before normalization.');
-  if (adapter === 'playwright' && !playwrightTest.complete) {
-    limitations.push(...playwrightTest.limitations);
-  }
+  limitations.push(...playwrightLimitations(adapter, playwrightTest));
   if (adapter === 'go-bench' && goBenchmarks.length === 0) {
     limitations.push('No matching Go benchmark measurement was captured.');
   }
@@ -366,7 +352,7 @@ export function createPerformanceCapsule({
       `Vitest reported assertion time is ${vitestExecutionShare.assertion_share_percent}% of exact-scope wall time; runner startup dominates and no product bottleneck is attributed.`
     );
   }
-  if (viteArtifact) limitations.push(...viteArtifact.limitations);
+  limitations.push(...viteArtifactLimitations(viteArtifact));
 
   const comparison = baseline
     ? comparePerformanceCapsules(
@@ -388,7 +374,7 @@ export function createPerformanceCapsule({
     executionComplete &&
     !cleanupFailed &&
     timing.count >= LIMITS.minimumSamples &&
-    (adapter !== 'playwright' || playwrightTest.complete) &&
+    playwrightEvidenceComplete(adapter, playwrightTest) &&
     (adapter !== 'go-bench' || goBenchmarks.length > 0) &&
     comparison?.status !== 'incompatible';
   const verdict = !complete
@@ -495,6 +481,12 @@ export function createPerformanceCapsule({
       distance: change.distance,
     });
   }
+  const unverified = buildPerformanceUnverified({
+    adapter,
+    profileEvidence,
+    qualifiedV8Candidate,
+    viteArtifact,
+  });
 
   const capsule = {
     schema_version: PERFORMANCE_SCHEMA_VERSION,
@@ -537,45 +529,7 @@ export function createPerformanceCapsule({
     },
     findings,
     relationships: relevantChanges,
-    unverified: [
-      ...profileEvidence.hotspots
-        .filter(
-          (hotspot) =>
-            hotspot.role === 'application' &&
-            (adapter === 'go-bench' ||
-              (qualifiedV8Candidate &&
-                hotspot.file === qualifiedV8Candidate.file &&
-                hotspot.function === qualifiedV8Candidate.function))
-        )
-        .slice(0, 1)
-        .map((hotspot) => ({
-          kind: 'optimization_hypothesis',
-          summary: `Investigate ${hotspot.file}:${hotspot.line} because it received the largest repository-owned application CPU share.`,
-          verification_required:
-            'Change the candidate, capture a new capsule, and compare it with this baseline.',
-        })),
-      ...(viteArtifact
-        ? [
-            {
-              kind: 'vite_artifact_observation',
-              summary: `Existing initial JavaScript closure contains ${viteArtifact.file_count} files, ${viteArtifact.raw_bytes} raw bytes, and ${viteArtifact.gzip_bytes} gzip bytes.`,
-              verification_required:
-                'Rebuild both identical source snapshots under an attested build contract before comparing artifact movement.',
-            },
-          ]
-        : []),
-      ...(adapter === 'playwright'
-        ? [
-            {
-              kind: 'playwright_coverage_gap',
-              summary:
-                'Exact local test duration does not measure production traffic, representative-device rendering, browser memory, React component attribution, network-scale behavior, or global application optimality.',
-              verification_required:
-                'Use separately authorized production and representative-device evidence for those claims.',
-            },
-          ]
-        : []),
-    ],
+    unverified,
     comparison,
     limitations: [...new Set(limitations)],
     capture: {
@@ -760,52 +714,11 @@ export function parseVitestTimings(outputs, repositoryRoot) {
 }
 
 export function parsePlaywrightTimings(outputs, exactName) {
-  const durations = [];
-  const limitations = [];
-  for (const [index, output] of outputs.entries()) {
-    if (output?.truncated) {
-      limitations.push(`Playwright reporter output for sample ${index + 1} was truncated.`);
-      continue;
-    }
-    let report;
-    try {
-      report = JSON.parse(output?.stdout ?? '');
-    } catch {
-      limitations.push(`Playwright reporter output for sample ${index + 1} was not valid JSON.`);
-      continue;
-    }
-    const matches = [];
-    visitPlaywrightSuites(report?.suites, (spec) => {
-      if (spec?.title === exactName) matches.push(spec);
-    });
-    if (matches.length !== 1) {
-      limitations.push(
-        `Playwright sample ${index + 1} contained ${matches.length} exact matching specs; one was required.`
-      );
-      continue;
-    }
-    const tests = Array.isArray(matches[0].tests) ? matches[0].tests : [];
-    if (tests.length !== 1) {
-      limitations.push(
-        `Playwright sample ${index + 1} contained ${tests.length} matching project tests; one was required.`
-      );
-      continue;
-    }
-    const results = Array.isArray(tests[0].results) ? tests[0].results : [];
-    const result = results[0];
-    if (
-      results.length !== 1 ||
-      result?.status !== 'passed' ||
-      Number(result?.retry ?? 0) !== 0 ||
-      !Number.isFinite(Number(result?.duration))
-    ) {
-      limitations.push(
-        `Playwright sample ${index + 1} did not contain one passing, unretried duration.`
-      );
-      continue;
-    }
-    durations.push(Number(result.duration));
-  }
+  const samples = outputs.map((output, index) =>
+    parsePlaywrightSample(output, exactName, index + 1)
+  );
+  const durations = samples.flatMap((sample) => sample.duration ?? []);
+  const limitations = samples.flatMap((sample) => sample.limitation ?? []);
   const complete = outputs.length > 0 && durations.length === outputs.length;
   return {
     exact_name: exactName ?? null,
@@ -816,6 +729,47 @@ export function parsePlaywrightTimings(outputs, exactName) {
     limitations: complete ? [] : [...new Set(limitations)],
     provenance: 'playwright_json_reporter',
   };
+}
+
+function parsePlaywrightSample(output, exactName, sampleNumber) {
+  if (output?.truncated) {
+    return { limitation: `Playwright reporter output for sample ${sampleNumber} was truncated.` };
+  }
+  let report;
+  try {
+    report = JSON.parse(output?.stdout ?? '');
+  } catch {
+    return {
+      limitation: `Playwright reporter output for sample ${sampleNumber} was not valid JSON.`,
+    };
+  }
+  const matches = [];
+  visitPlaywrightSuites(report?.suites, (spec) => {
+    if (spec?.title === exactName) matches.push(spec);
+  });
+  if (matches.length !== 1) {
+    return {
+      limitation: `Playwright sample ${sampleNumber} contained ${matches.length} exact matching specs; one was required.`,
+    };
+  }
+  const tests = Array.isArray(matches[0].tests) ? matches[0].tests : [];
+  if (tests.length !== 1) {
+    return {
+      limitation: `Playwright sample ${sampleNumber} contained ${tests.length} matching project tests; one was required.`,
+    };
+  }
+  const results = Array.isArray(tests[0].results) ? tests[0].results : [];
+  const result = results[0];
+  const valid =
+    results.length === 1 &&
+    result?.status === 'passed' &&
+    Number(result?.retry ?? 0) === 0 &&
+    Number.isFinite(Number(result?.duration));
+  return valid
+    ? { duration: [Number(result.duration)] }
+    : {
+        limitation: `Playwright sample ${sampleNumber} did not contain one passing, unretried duration.`,
+      };
 }
 
 function visitPlaywrightSuites(suites, visit) {
@@ -1283,6 +1237,82 @@ function sourceRole(file) {
   )
     ? 'test_or_harness'
     : 'application';
+}
+
+function validateProfileScope(adapter, name) {
+  if (adapter === 'playwright' && !name) {
+    throw new Error('playwright performance profiling requires an exact test name');
+  }
+}
+
+function profileRunsFor(adapter) {
+  if (adapter === 'playwright') return 0;
+  return adapter === 'go-bench' ? 1 : V8_PROFILE_RUNS;
+}
+
+function playwrightTimingObservation(adapter, measured, name) {
+  if (adapter !== 'playwright') return null;
+  return parsePlaywrightTimings(
+    measured.map((entry) => ({
+      stdout: entry.execution.stdout,
+      truncated: entry.execution.truncated,
+    })),
+    name
+  );
+}
+
+function playwrightLimitations(adapter, observation) {
+  return adapter === 'playwright' && !observation.complete ? observation.limitations : [];
+}
+
+function viteArtifactLimitations(artifact) {
+  return artifact?.limitations ?? [];
+}
+
+function playwrightEvidenceComplete(adapter, observation) {
+  return adapter !== 'playwright' || observation.complete;
+}
+
+function buildPerformanceUnverified({
+  adapter,
+  profileEvidence,
+  qualifiedV8Candidate,
+  viteArtifact,
+}) {
+  const hypotheses = profileEvidence.hotspots
+    .filter(
+      (hotspot) =>
+        hotspot.role === 'application' &&
+        (adapter === 'go-bench' ||
+          (qualifiedV8Candidate &&
+            hotspot.file === qualifiedV8Candidate.file &&
+            hotspot.function === qualifiedV8Candidate.function))
+    )
+    .slice(0, 1)
+    .map((hotspot) => ({
+      kind: 'optimization_hypothesis',
+      summary: `Investigate ${hotspot.file}:${hotspot.line} because it received the largest repository-owned application CPU share.`,
+      verification_required:
+        'Change the candidate, capture a new capsule, and compare it with this baseline.',
+    }));
+  if (viteArtifact) {
+    hypotheses.push({
+      kind: 'vite_artifact_observation',
+      summary: `Existing initial JavaScript closure contains ${viteArtifact.file_count} files, ${viteArtifact.raw_bytes} raw bytes, and ${viteArtifact.gzip_bytes} gzip bytes.`,
+      verification_required:
+        'Rebuild both identical source snapshots under an attested build contract before comparing artifact movement.',
+    });
+  }
+  if (adapter === 'playwright') {
+    hypotheses.push({
+      kind: 'playwright_coverage_gap',
+      summary:
+        'Exact local test duration does not measure production traffic, representative-device rendering, browser memory, React component attribution, network-scale behavior, or global application optimality.',
+      verification_required:
+        'Use separately authorized production and representative-device evidence for those claims.',
+    });
+  }
+  return hypotheses;
 }
 
 function emptyProfileEvidence(adapter) {

--- a/scripts/runtime-failure-capsule/performance.mjs
+++ b/scripts/runtime-failure-capsule/performance.mjs
@@ -16,6 +16,7 @@ import { collectV8FunctionCoverage, emptyFunctionCoverage } from './function-cov
 import { redactText } from './redact.mjs';
 import { inspectGoProfile, runClosedAdapter } from './runner.mjs';
 import { collectNodeFlowEvents } from './flow-capture.mjs';
+import { inspectExistingViteArtifact } from './vite-artifact.mjs';
 
 const APPLICATION_HOTSPOT_SHARE = 0.05;
 const STARTUP_DOMINATED_SHARE_PERCENT = 10;
@@ -41,7 +42,12 @@ export async function profileRepository({
   regressionPercent = 20,
   regressionMs = 25,
   captureFlow = false,
+  viteBuildDirectory,
+  viteEntry,
 }) {
+  if (adapter === 'playwright' && !name) {
+    throw new Error('playwright performance profiling requires an exact test name');
+  }
   const lexicalRoot = resolve(repositoryRoot);
   const root = await realpath(lexicalRoot);
   const temporaryDirectory = await mkdtemp(join(tmpdir(), 'codevetter-profile-'));
@@ -130,7 +136,8 @@ export async function profileRepository({
       functionCoverage = await collectV8FunctionCoverage(coverageDirectory, root);
     }
 
-    const profileRunCount = adapter === 'go-bench' ? 1 : V8_PROFILE_RUNS;
+    const profileRunCount =
+      adapter === 'playwright' ? 0 : adapter === 'go-bench' ? 1 : V8_PROFILE_RUNS;
     for (let index = 0; index < profileRunCount; index += 1) {
       const profileDirectory = join(temporaryDirectory, `profile-${index}`);
       await mkdir(profileDirectory);
@@ -162,6 +169,7 @@ export async function profileRepository({
   }
 
   const git = await inspectGitDiff(root);
+  const viteArtifact = await inspectExistingViteArtifact(root, viteBuildDirectory, viteEntry);
   const baseline = baselinePath ? await loadPerformanceCapsule(root, baselinePath) : null;
   return createPerformanceCapsule({
     root,
@@ -181,6 +189,7 @@ export async function profileRepository({
     baseline,
     regressionPercent,
     regressionMs,
+    viteArtifact,
   });
 }
 
@@ -202,6 +211,7 @@ export function createPerformanceCapsule({
   baseline = null,
   regressionPercent = 20,
   regressionMs = 25,
+  viteArtifact = null,
 }) {
   let redactionCount = 0;
   let outputTruncated = false;
@@ -250,6 +260,16 @@ export function createPerformanceCapsule({
         )
       : [];
   const vitestExecutionShare = summarizeVitestExecutionShare(vitestTests, timing);
+  const playwrightTest =
+    adapter === 'playwright'
+      ? parsePlaywrightTimings(
+          measured.map((entry) => ({
+            stdout: entry.execution.stdout,
+            truncated: entry.execution.truncated,
+          })),
+          name
+        )
+      : null;
   const metricsExecutions = sanitizedExecutions.filter((entry) => entry.phase === 'metrics');
   const profileExecution = sanitizedExecutions.find((entry) => entry.phase === 'profile');
   const consoleMetrics =
@@ -295,6 +315,9 @@ export function createPerformanceCapsule({
   if (cleanupFailed)
     limitations.push('Owned temporary profiling artifacts could not be completely removed.');
   if (outputTruncated) limitations.push('Runner output was truncated before normalization.');
+  if (adapter === 'playwright' && !playwrightTest.complete) {
+    limitations.push(...playwrightTest.limitations);
+  }
   if (adapter === 'go-bench' && goBenchmarks.length === 0) {
     limitations.push('No matching Go benchmark measurement was captured.');
   }
@@ -304,14 +327,20 @@ export function createPerformanceCapsule({
   for (const kind of profileEvidence.failed_kinds ?? []) {
     limitations.push(`The ${kind} Go profile could not be normalized.`);
   }
-  if (adapter !== 'go-bench' && profileEvidence.profile_files === 0) {
+  if (
+    ['node-test', 'node-script', 'vitest'].includes(adapter) &&
+    profileEvidence.profile_files === 0
+  ) {
     limitations.push('The runtime produced no V8 CPU profile.');
   }
-  if (adapter !== 'go-bench' && profileEvidence.hotspots.length === 0) {
+  if (
+    ['node-test', 'node-script', 'vitest'].includes(adapter) &&
+    profileEvidence.hotspots.length === 0
+  ) {
     limitations.push('The CPU profile contained no repository-owned source samples.');
   }
   if (
-    adapter !== 'go-bench' &&
+    ['node-test', 'node-script', 'vitest'].includes(adapter) &&
     profileEvidence.hotspots.length > 0 &&
     !profileEvidence.hotspots.some((hotspot) => hotspot.role === 'application')
   ) {
@@ -320,7 +349,7 @@ export function createPerformanceCapsule({
   if (profileEvidence.truncated)
     limitations.push('Runtime profile evidence exceeded collection bounds.');
   if (
-    adapter !== 'go-bench' &&
+    ['node-test', 'node-script', 'vitest'].includes(adapter) &&
     profileRuns.length >= V8_PROFILE_RUNS &&
     !profileEvidence.repeatability?.qualified
   ) {
@@ -337,6 +366,7 @@ export function createPerformanceCapsule({
       `Vitest reported assertion time is ${vitestExecutionShare.assertion_share_percent}% of exact-scope wall time; runner startup dominates and no product bottleneck is attributed.`
     );
   }
+  if (viteArtifact) limitations.push(...viteArtifact.limitations);
 
   const comparison = baseline
     ? comparePerformanceCapsules(
@@ -358,6 +388,7 @@ export function createPerformanceCapsule({
     executionComplete &&
     !cleanupFailed &&
     timing.count >= LIMITS.minimumSamples &&
+    (adapter !== 'playwright' || playwrightTest.complete) &&
     (adapter !== 'go-bench' || goBenchmarks.length > 0) &&
     comparison?.status !== 'incompatible';
   const verdict = !complete
@@ -496,30 +527,55 @@ export function createPerformanceCapsule({
       go_benchmarks: goBenchmarks,
       vitest_tests: vitestTests,
       vitest_execution_share: vitestExecutionShare,
+      playwright_test: playwrightTest,
       console_metrics: consoleMetrics,
       profile_runs: profileRuns.map(profileRunSummary),
       profile_repeatability: profileEvidence.repeatability ?? null,
       flow_evidence: flowEvidence,
       function_coverage: functionCoverage,
+      vite_artifact: viteArtifact,
     },
     findings,
     relationships: relevantChanges,
-    unverified: profileEvidence.hotspots
-      .filter(
-        (hotspot) =>
-          hotspot.role === 'application' &&
-          (adapter === 'go-bench' ||
-            (qualifiedV8Candidate &&
-              hotspot.file === qualifiedV8Candidate.file &&
-              hotspot.function === qualifiedV8Candidate.function))
-      )
-      .slice(0, 1)
-      .map((hotspot) => ({
-        kind: 'optimization_hypothesis',
-        summary: `Investigate ${hotspot.file}:${hotspot.line} because it received the largest repository-owned application CPU share.`,
-        verification_required:
-          'Change the candidate, capture a new capsule, and compare it with this baseline.',
-      })),
+    unverified: [
+      ...profileEvidence.hotspots
+        .filter(
+          (hotspot) =>
+            hotspot.role === 'application' &&
+            (adapter === 'go-bench' ||
+              (qualifiedV8Candidate &&
+                hotspot.file === qualifiedV8Candidate.file &&
+                hotspot.function === qualifiedV8Candidate.function))
+        )
+        .slice(0, 1)
+        .map((hotspot) => ({
+          kind: 'optimization_hypothesis',
+          summary: `Investigate ${hotspot.file}:${hotspot.line} because it received the largest repository-owned application CPU share.`,
+          verification_required:
+            'Change the candidate, capture a new capsule, and compare it with this baseline.',
+        })),
+      ...(viteArtifact
+        ? [
+            {
+              kind: 'vite_artifact_observation',
+              summary: `Existing initial JavaScript closure contains ${viteArtifact.file_count} files, ${viteArtifact.raw_bytes} raw bytes, and ${viteArtifact.gzip_bytes} gzip bytes.`,
+              verification_required:
+                'Rebuild both identical source snapshots under an attested build contract before comparing artifact movement.',
+            },
+          ]
+        : []),
+      ...(adapter === 'playwright'
+        ? [
+            {
+              kind: 'playwright_coverage_gap',
+              summary:
+                'Exact local test duration does not measure production traffic, representative-device rendering, browser memory, React component attribution, network-scale behavior, or global application optimality.',
+              verification_required:
+                'Use separately authorized production and representative-device evidence for those claims.',
+            },
+          ]
+        : []),
+    ],
     comparison,
     limitations: [...new Set(limitations)],
     capture: {
@@ -701,6 +757,72 @@ export function parseVitestTimings(outputs, repositoryRoot) {
       duration_ms: summarizeDistribution(group.durations),
       provenance: 'vitest_json_reporter',
     }));
+}
+
+export function parsePlaywrightTimings(outputs, exactName) {
+  const durations = [];
+  const limitations = [];
+  for (const [index, output] of outputs.entries()) {
+    if (output?.truncated) {
+      limitations.push(`Playwright reporter output for sample ${index + 1} was truncated.`);
+      continue;
+    }
+    let report;
+    try {
+      report = JSON.parse(output?.stdout ?? '');
+    } catch {
+      limitations.push(`Playwright reporter output for sample ${index + 1} was not valid JSON.`);
+      continue;
+    }
+    const matches = [];
+    visitPlaywrightSuites(report?.suites, (spec) => {
+      if (spec?.title === exactName) matches.push(spec);
+    });
+    if (matches.length !== 1) {
+      limitations.push(
+        `Playwright sample ${index + 1} contained ${matches.length} exact matching specs; one was required.`
+      );
+      continue;
+    }
+    const tests = Array.isArray(matches[0].tests) ? matches[0].tests : [];
+    if (tests.length !== 1) {
+      limitations.push(
+        `Playwright sample ${index + 1} contained ${tests.length} matching project tests; one was required.`
+      );
+      continue;
+    }
+    const results = Array.isArray(tests[0].results) ? tests[0].results : [];
+    const result = results[0];
+    if (
+      results.length !== 1 ||
+      result?.status !== 'passed' ||
+      Number(result?.retry ?? 0) !== 0 ||
+      !Number.isFinite(Number(result?.duration))
+    ) {
+      limitations.push(
+        `Playwright sample ${index + 1} did not contain one passing, unretried duration.`
+      );
+      continue;
+    }
+    durations.push(Number(result.duration));
+  }
+  const complete = outputs.length > 0 && durations.length === outputs.length;
+  return {
+    exact_name: exactName ?? null,
+    duration_ms: summarizeDistribution(durations),
+    expected_samples: outputs.length,
+    captured_samples: durations.length,
+    complete,
+    limitations: complete ? [] : [...new Set(limitations)],
+    provenance: 'playwright_json_reporter',
+  };
+}
+
+function visitPlaywrightSuites(suites, visit) {
+  for (const suite of Array.isArray(suites) ? suites : []) {
+    for (const spec of Array.isArray(suite?.specs) ? suite.specs : []) visit(spec);
+    visitPlaywrightSuites(suite?.suites, visit);
+  }
 }
 
 export function parseConsoleBenchmarkMetrics(output, provenance = 'profile_execution_stdout') {
@@ -1111,6 +1233,12 @@ export function selectedWorkloadExecuted(entry, adapter, name) {
     return /Test Files\s+[1-9]\d*\s+passed|Tests\s+[1-9]\d*\s+passed/.test(output);
   }
   if (adapter === 'go-bench') return parseGoBenchmarks(output).length > 0;
+  if (adapter === 'playwright') {
+    return parsePlaywrightTimings(
+      [{ stdout: entry.execution.stdout, truncated: entry.execution.truncated }],
+      name
+    ).complete;
+  }
   return !name || output.includes(name);
 }
 
@@ -1159,7 +1287,12 @@ function sourceRole(file) {
 
 function emptyProfileEvidence(adapter) {
   return {
-    kind: adapter === 'go-bench' ? 'go_benchmark_cpu_artifact' : 'v8_cpu',
+    kind:
+      adapter === 'go-bench'
+        ? 'go_benchmark_cpu_artifact'
+        : adapter === 'playwright'
+          ? 'playwright_reporter_timing'
+          : 'v8_cpu',
     profile_files: 0,
     profile_bytes: 0,
     profile_samples: 0,

--- a/scripts/runtime-failure-capsule/qualification-contracts.mjs
+++ b/scripts/runtime-failure-capsule/qualification-contracts.mjs
@@ -22,7 +22,7 @@ export const QUALIFICATION_STATUSES = Object.freeze([
   'inaccessible',
 ]);
 
-const PROFILE_ADAPTERS = new Set(['node-test', 'node-script', 'vitest', 'go-bench']);
+const PROFILE_ADAPTERS = new Set(['node-test', 'node-script', 'vitest', 'playwright', 'go-bench']);
 
 export function assertPortfolioManifest(value) {
   const errors = validatePortfolioManifest(value);

--- a/scripts/runtime-failure-capsule/qualification.mjs
+++ b/scripts/runtime-failure-capsule/qualification.mjs
@@ -78,11 +78,9 @@ export async function qualifyRepository(repositoryRoot) {
   const discoveredCandidates = discoverCandidates(scan);
   const candidates = rankCandidates(discoveredCandidates).slice(0, QUALIFICATION_LIMITS.candidates);
   const supportedAdapters = new Set(
-    lanes.lanes
-      .flatMap((lane) =>
-        lane.adapters.flatMap((adapter) => (adapter === 'go-test' ? ['go-bench'] : [adapter]))
-      )
-      .filter((adapter) => adapter !== 'playwright')
+    lanes.lanes.flatMap((lane) =>
+      lane.adapters.flatMap((adapter) => (adapter === 'go-test' ? ['go-bench'] : [adapter]))
+    )
   );
   const result = classifyQualification({
     subject: {
@@ -169,7 +167,14 @@ function inaccessibleQualification(reason) {
 function classifyQualification({ subject, lanes, candidates, supportedAdapters, scan }) {
   const usable = candidates.filter((candidate) => supportedAdapters.has(candidate.adapter));
   const safe = usable.filter((candidate) => candidate.safety_flags.length === 0);
-  const automaticallyEligible = safe.filter(hasDirectMeasurementEvidence);
+  const selectableBrowser = usable.filter(
+    (candidate) =>
+      candidate.adapter === 'playwright' &&
+      candidate.safety_flags.every((flag) => flag.kind === 'browser_signal')
+  );
+  const automaticallyEligible = safe.filter(
+    (candidate) => candidate.adapter !== 'playwright' && hasDirectMeasurementEvidence(candidate)
+  );
   const top = automaticallyEligible[0] ?? null;
   const runnerUp = automaticallyEligible[1] ?? null;
   const unambiguous =
@@ -196,15 +201,22 @@ function classifyQualification({ subject, lanes, candidates, supportedAdapters, 
   } else if (usable.length > 0) {
     status = 'needs_selection';
     nextAction = {
-      kind: safe.length === 0 ? 'review_safety_and_select' : 'select_representative_workload',
+      kind:
+        selectableBrowser.length > 0
+          ? 'select_representative_browser_flow'
+          : safe.length === 0
+            ? 'review_safety_and_select'
+            : 'select_representative_workload',
       reason:
-        safe.length === 0
-          ? 'Every discovered candidate has a possible external-operation or non-product-scope signal.'
-          : automaticallyEligible.length === 0
-            ? 'Names suggest possible performance relevance, but no candidate contains direct benchmark or timing evidence.'
-            : 'Direct measurement evidence is ambiguous or below the automatic qualification threshold.',
+        selectableBrowser.length > 0
+          ? 'Playwright flows were discovered, but only the caller can declare which exact flow is representative.'
+          : safe.length === 0
+            ? 'Every discovered candidate has a possible external-operation or non-product-scope signal.'
+            : automaticallyEligible.length === 0
+              ? 'Names suggest possible performance relevance, but no candidate contains direct benchmark or timing evidence.'
+              : 'Direct measurement evidence is ambiguous or below the automatic qualification threshold.',
     };
-    if (safe.length === 0)
+    if (safe.length === 0 && selectableBrowser.length === 0)
       limitations.push('No candidate was safe enough for automatic profiling.');
   } else if (supportedAdapters.size > 0) {
     status = 'no_representative_workload';
@@ -421,6 +433,9 @@ function hasRunnerDeclaration(source, adapter) {
   if (adapter === 'vitest') {
     return /(?:from|require\s*\()\s*['"]vitest['"]/m.test(source);
   }
+  if (adapter === 'playwright') {
+    return /(?:from|require\s*\()\s*['"]@playwright\/test['"]/m.test(source);
+  }
   return /['"]node:test(?:\/[^'"]+)?['"]/.test(source);
 }
 
@@ -430,6 +445,9 @@ function nodeAdapter(source, manifest) {
     ...Object.keys(manifest?.devDependencies ?? {}),
     ...Object.keys(manifest?.optionalDependencies ?? {}),
   ]);
+  if (/(?:from|require\s*\()\s*['"]@playwright\/test['"]/m.test(source)) {
+    return 'playwright';
+  }
   if (dependencies.has('vitest') || /(?:from|require\s*\()\s*['"]vitest['"]/m.test(source)) {
     return 'vitest';
   }

--- a/scripts/runtime-failure-capsule/qualification.mjs
+++ b/scripts/runtime-failure-capsule/qualification.mjs
@@ -167,14 +167,8 @@ function inaccessibleQualification(reason) {
 function classifyQualification({ subject, lanes, candidates, supportedAdapters, scan }) {
   const usable = candidates.filter((candidate) => supportedAdapters.has(candidate.adapter));
   const safe = usable.filter((candidate) => candidate.safety_flags.length === 0);
-  const selectableBrowser = usable.filter(
-    (candidate) =>
-      candidate.adapter === 'playwright' &&
-      candidate.safety_flags.every((flag) => flag.kind === 'browser_signal')
-  );
-  const automaticallyEligible = safe.filter(
-    (candidate) => candidate.adapter !== 'playwright' && hasDirectMeasurementEvidence(candidate)
-  );
+  const selectableBrowser = usable.filter(isSelectableBrowserCandidate);
+  const automaticallyEligible = safe.filter(isAutomaticallyEligible);
   const top = automaticallyEligible[0] ?? null;
   const runnerUp = automaticallyEligible[1] ?? null;
   const unambiguous =
@@ -200,24 +194,9 @@ function classifyQualification({ subject, lanes, candidates, supportedAdapters, 
     };
   } else if (usable.length > 0) {
     status = 'needs_selection';
-    nextAction = {
-      kind:
-        selectableBrowser.length > 0
-          ? 'select_representative_browser_flow'
-          : safe.length === 0
-            ? 'review_safety_and_select'
-            : 'select_representative_workload',
-      reason:
-        selectableBrowser.length > 0
-          ? 'Playwright flows were discovered, but only the caller can declare which exact flow is representative.'
-          : safe.length === 0
-            ? 'Every discovered candidate has a possible external-operation or non-product-scope signal.'
-            : automaticallyEligible.length === 0
-              ? 'Names suggest possible performance relevance, but no candidate contains direct benchmark or timing evidence.'
-              : 'Direct measurement evidence is ambiguous or below the automatic qualification threshold.',
-    };
-    if (safe.length === 0 && selectableBrowser.length === 0)
-      limitations.push('No candidate was safe enough for automatic profiling.');
+    const selection = selectionRequired({ safe, selectableBrowser, automaticallyEligible });
+    nextAction = selection.nextAction;
+    limitations.push(...selection.limitations);
   } else if (supportedAdapters.size > 0) {
     status = 'no_representative_workload';
     nextAction = {
@@ -253,6 +232,50 @@ function classifyQualification({ subject, lanes, candidates, supportedAdapters, 
     next_action: nextAction,
     limitations,
     scan,
+  };
+}
+
+function isSelectableBrowserCandidate(candidate) {
+  return (
+    candidate.adapter === 'playwright' &&
+    candidate.safety_flags.every((flag) => flag.kind === 'browser_signal')
+  );
+}
+
+function isAutomaticallyEligible(candidate) {
+  return candidate.adapter !== 'playwright' && hasDirectMeasurementEvidence(candidate);
+}
+
+function selectionRequired({ safe, selectableBrowser, automaticallyEligible }) {
+  if (selectableBrowser.length > 0) {
+    return {
+      nextAction: {
+        kind: 'select_representative_browser_flow',
+        reason:
+          'Playwright flows were discovered, but only the caller can declare which exact flow is representative.',
+      },
+      limitations: [],
+    };
+  }
+  if (safe.length === 0) {
+    return {
+      nextAction: {
+        kind: 'review_safety_and_select',
+        reason:
+          'Every discovered candidate has a possible external-operation or non-product-scope signal.',
+      },
+      limitations: ['No candidate was safe enough for automatic profiling.'],
+    };
+  }
+  return {
+    nextAction: {
+      kind: 'select_representative_workload',
+      reason:
+        automaticallyEligible.length === 0
+          ? 'Names suggest possible performance relevance, but no candidate contains direct benchmark or timing evidence.'
+          : 'Direct measurement evidence is ambiguous or below the automatic qualification threshold.',
+    },
+    limitations: [],
   };
 }
 

--- a/scripts/runtime-failure-capsule/qualification.test.mjs
+++ b/scripts/runtime-failure-capsule/qualification.test.mjs
@@ -45,6 +45,25 @@ test('keeps generic tests selectable but does not call them representative', asy
   assert.equal(result.next_action.kind, 'select_representative_workload');
 });
 
+test('discovers Playwright flows but requires caller selection', async (context) => {
+  const root = await repositoryFixture(context, {
+    'package.json': JSON.stringify({ devDependencies: { '@playwright/test': '1.0.0' } }),
+    'tests/example.spec.ts': [
+      "import { test } from '@playwright/test';",
+      "test('loads the product', async ({ page }) => page.goto('/'));",
+      '',
+    ].join('\n'),
+  });
+
+  const result = await qualifyRepository(root);
+
+  assert.equal(result.status, 'needs_selection');
+  assert.equal(result.recommended, null);
+  assert.equal(result.candidates[0].adapter, 'playwright');
+  assert.equal(result.candidates[0].name, 'loads the product');
+  assert.equal(result.next_action.kind, 'select_representative_browser_flow');
+});
+
 test('blocks automatic readiness when source suggests external operations', async (context) => {
   const root = await repositoryFixture(context, {
     'package.json': JSON.stringify({ devDependencies: { vitest: '1.0.0' } }),

--- a/scripts/runtime-failure-capsule/runner.mjs
+++ b/scripts/runtime-failure-capsule/runner.mjs
@@ -211,7 +211,7 @@ async function buildCommand({
       'node_modules/@playwright/test/cli.js'
     );
     const runnerArguments = ['test', scope.relative, '--reporter=json'];
-    if (exactPattern) runnerArguments.push('--grep', exactPattern);
+    if (name) runnerArguments.push('--grep', escapeRegExp(name));
     const args = [executable, ...runnerArguments];
     return command(root, process.execPath, args, 'local:playwright', runnerArguments);
   }

--- a/scripts/runtime-failure-capsule/runtime-performance-capsule.test.mjs
+++ b/scripts/runtime-failure-capsule/runtime-performance-capsule.test.mjs
@@ -16,6 +16,7 @@ import {
   summarizeConsoleBenchmarkMetrics,
   parseGoBenchmarks,
   parseGoPprofTop,
+  parsePlaywrightTimings,
   parseVitestTimings,
   parseV8CpuProfileDocuments,
   profileRepository,
@@ -250,6 +251,67 @@ test('normalizes Vitest durations and console benchmark metrics', () => {
     iterations: 300,
     provenance: 'profile_execution_stdout',
   });
+});
+
+test('normalizes one exact passing unretried Playwright result per sample', () => {
+  const output = (duration) => ({
+    stdout: JSON.stringify({
+      suites: [
+        {
+          title: 'example.spec.ts',
+          specs: [
+            {
+              title: 'loads the chess coach',
+              tests: [{ results: [{ status: 'passed', retry: 0, duration }] }],
+            },
+          ],
+        },
+      ],
+    }),
+    truncated: false,
+  });
+  const result = parsePlaywrightTimings(
+    [output(120), output(100), output(110)],
+    'loads the chess coach'
+  );
+
+  assert.equal(result.complete, true);
+  assert.equal(result.duration_ms.median, 110);
+  assert.equal(result.provenance, 'playwright_json_reporter');
+});
+
+test('fails Playwright timing closed for retries, ambiguity, and truncation', () => {
+  const ambiguous = JSON.stringify({
+    suites: [
+      {
+        specs: [
+          {
+            title: 'target flow',
+            tests: [
+              {
+                results: [
+                  { status: 'failed', retry: 0, duration: 10 },
+                  { status: 'passed', retry: 1, duration: 8 },
+                ],
+              },
+              { results: [{ status: 'passed', retry: 0, duration: 9 }] },
+            ],
+          },
+        ],
+      },
+    ],
+  });
+  const result = parsePlaywrightTimings(
+    [
+      { stdout: ambiguous, truncated: false },
+      { stdout: '{}', truncated: true },
+    ],
+    'target flow'
+  );
+
+  assert.equal(result.complete, false);
+  assert.equal(result.captured_samples, 0);
+  assert.equal(result.limitations.length, 2);
 });
 
 test('accepts an exact passed Vitest identity from a truncated JSON report', () => {

--- a/scripts/runtime-failure-capsule/vite-artifact.mjs
+++ b/scripts/runtime-failure-capsule/vite-artifact.mjs
@@ -16,76 +16,113 @@ export async function inspectExistingViteArtifact(
     'Existing build freshness and source-revision identity are unverified.',
     'Build bytes do not measure production transfer, parsing, rendering, or browser memory.',
   ];
-  const files = [];
-  let rawBytes = 0;
-  let gzipBytes = 0;
   let buildRoot;
   try {
     buildRoot = await containedDirectory(repositoryRoot, buildDirectory);
   } catch (error) {
-    return incomplete(entry, files, rawBytes, gzipBytes, [...limitations, error.message]);
+    return incomplete(entry, [], 0, 0, [...limitations, error.message]);
   }
+  const closure = await readArtifactClosure(buildRoot, entry);
+  limitations.push(...closure.limitations);
+  return artifactResult(entry, closure, limitations);
+}
+
+async function readArtifactClosure(buildRoot, entry) {
+  const files = [];
+  const limitations = [];
+  let rawBytes = 0;
+  let gzipBytes = 0;
   const queue = [{ reference: entry, importer: buildRoot, depth: 0, kind: 'html' }];
   const visited = new Set();
   while (queue.length > 0) {
     const item = queue.shift();
-    if (item.depth > ARTIFACT_LIMITS.depth) {
-      limitations.push(`Initial JavaScript closure exceeded depth ${ARTIFACT_LIMITS.depth}.`);
+    const result = await readClosureItem({ buildRoot, item, visited, files, rawBytes });
+    if (result.stop) {
+      limitations.push(result.limitation);
       break;
     }
-    let path;
-    try {
-      path = await resolveArtifactReference(buildRoot, item.importer, item.reference);
-    } catch (error) {
-      limitations.push(error.message);
-      continue;
-    }
-    const relative = repositoryRelative(buildRoot, path);
-    if (relative === null || visited.has(relative)) continue;
-    if (files.length >= ARTIFACT_LIMITS.files) {
-      limitations.push(`Initial JavaScript closure exceeded ${ARTIFACT_LIMITS.files} files.`);
-      break;
-    }
-    let bytes;
-    try {
-      const metadata = await lstat(path);
-      if (!metadata.isFile()) throw new Error('not a regular file');
-      if (rawBytes + metadata.size > ARTIFACT_LIMITS.bytes) {
-        limitations.push(`Initial JavaScript closure exceeded ${ARTIFACT_LIMITS.bytes} raw bytes.`);
-        break;
-      }
-      bytes = await readFile(path);
-    } catch {
-      limitations.push(`Artifact file ${relative} could not be read.`);
-      continue;
-    }
-    visited.add(relative);
-    const compressed = gzipSync(bytes, { level: 9 }).byteLength;
-    files.push({ file: relative, raw_bytes: bytes.byteLength, gzip_bytes: compressed });
-    rawBytes += bytes.byteLength;
-    gzipBytes += compressed;
-    const source = bytes.toString('utf8');
-    const references = item.kind === 'html' ? htmlModuleScripts(source) : staticImports(source);
-    if (item.kind === 'javascript' && /\bimport\s*\(/.test(source)) {
-      limitations.push(`Dynamic imports in ${relative} were not included in the initial closure.`);
-    }
-    for (const reference of references) {
+    if (result.limitation) limitations.push(result.limitation);
+    if (!result.file) continue;
+    visited.add(result.file.file);
+    files.push(result.file);
+    rawBytes += result.file.raw_bytes;
+    gzipBytes += result.file.gzip_bytes;
+    limitations.push(...result.limitations);
+    for (const reference of result.references) {
       queue.push({
         reference,
-        importer: dirname(path),
+        importer: result.importer,
         depth: item.depth + 1,
         kind: 'javascript',
       });
     }
   }
-  const structuralLimitations = limitations.slice(2);
+  return { files, rawBytes, gzipBytes, limitations };
+}
+
+async function readClosureItem({ buildRoot, item, visited, files, rawBytes }) {
+  if (item.depth > ARTIFACT_LIMITS.depth) {
+    return {
+      stop: true,
+      limitation: `Initial JavaScript closure exceeded depth ${ARTIFACT_LIMITS.depth}.`,
+    };
+  }
+  let path;
+  try {
+    path = await resolveArtifactReference(buildRoot, item.importer, item.reference);
+  } catch (error) {
+    return { limitation: error.message };
+  }
+  const relative = repositoryRelative(buildRoot, path);
+  if (relative === null || visited.has(relative)) return {};
+  if (files.length >= ARTIFACT_LIMITS.files) {
+    return {
+      stop: true,
+      limitation: `Initial JavaScript closure exceeded ${ARTIFACT_LIMITS.files} files.`,
+    };
+  }
+  const content = await readArtifactFile(path, relative, rawBytes);
+  if (content.limitation || content.stop) return content;
+  const source = content.bytes.toString('utf8');
+  return {
+    file: {
+      file: relative,
+      raw_bytes: content.bytes.byteLength,
+      gzip_bytes: gzipSync(content.bytes, { level: 9 }).byteLength,
+    },
+    importer: dirname(path),
+    references: item.kind === 'html' ? htmlModuleScripts(source) : staticImports(source),
+    limitations:
+      item.kind === 'javascript' && /\bimport\s*\(/.test(source)
+        ? [`Dynamic imports in ${relative} were not included in the initial closure.`]
+        : [],
+  };
+}
+
+async function readArtifactFile(path, relative, rawBytes) {
+  try {
+    const metadata = await lstat(path);
+    if (!metadata.isFile()) throw new Error('not a regular file');
+    if (rawBytes + metadata.size > ARTIFACT_LIMITS.bytes) {
+      return {
+        stop: true,
+        limitation: `Initial JavaScript closure exceeded ${ARTIFACT_LIMITS.bytes} raw bytes.`,
+      };
+    }
+    return { bytes: await readFile(path) };
+  } catch {
+    return { limitation: `Artifact file ${relative} could not be read.` };
+  }
+}
+
+function artifactResult(entry, closure, limitations) {
   return {
     entry,
-    complete: structuralLimitations.length === 0,
-    file_count: files.length,
-    raw_bytes: rawBytes,
-    gzip_bytes: gzipBytes,
-    files,
+    complete: closure.limitations.length === 0,
+    file_count: closure.files.length,
+    raw_bytes: closure.rawBytes,
+    gzip_bytes: closure.gzipBytes,
+    files: closure.files,
     limitations: [...new Set(limitations)],
     provenance: 'existing_unverified_vite_artifact',
   };

--- a/scripts/runtime-failure-capsule/vite-artifact.mjs
+++ b/scripts/runtime-failure-capsule/vite-artifact.mjs
@@ -1,0 +1,167 @@
+import { gzipSync } from 'node:zlib';
+import { lstat, readFile, realpath } from 'node:fs/promises';
+import { dirname, isAbsolute, resolve } from 'node:path';
+
+import { repositoryRelative } from './contracts.mjs';
+
+const ARTIFACT_LIMITS = Object.freeze({ files: 64, bytes: 8 * 1024 * 1024, depth: 16 });
+
+export async function inspectExistingViteArtifact(
+  repositoryRoot,
+  buildDirectory,
+  entry = 'index.html'
+) {
+  if (!buildDirectory) return null;
+  const limitations = [
+    'Existing build freshness and source-revision identity are unverified.',
+    'Build bytes do not measure production transfer, parsing, rendering, or browser memory.',
+  ];
+  const files = [];
+  let rawBytes = 0;
+  let gzipBytes = 0;
+  let buildRoot;
+  try {
+    buildRoot = await containedDirectory(repositoryRoot, buildDirectory);
+  } catch (error) {
+    return incomplete(entry, files, rawBytes, gzipBytes, [...limitations, error.message]);
+  }
+  const queue = [{ reference: entry, importer: buildRoot, depth: 0, kind: 'html' }];
+  const visited = new Set();
+  while (queue.length > 0) {
+    const item = queue.shift();
+    if (item.depth > ARTIFACT_LIMITS.depth) {
+      limitations.push(`Initial JavaScript closure exceeded depth ${ARTIFACT_LIMITS.depth}.`);
+      break;
+    }
+    let path;
+    try {
+      path = await resolveArtifactReference(buildRoot, item.importer, item.reference);
+    } catch (error) {
+      limitations.push(error.message);
+      continue;
+    }
+    const relative = repositoryRelative(buildRoot, path);
+    if (relative === null || visited.has(relative)) continue;
+    if (files.length >= ARTIFACT_LIMITS.files) {
+      limitations.push(`Initial JavaScript closure exceeded ${ARTIFACT_LIMITS.files} files.`);
+      break;
+    }
+    let bytes;
+    try {
+      const metadata = await lstat(path);
+      if (!metadata.isFile()) throw new Error('not a regular file');
+      if (rawBytes + metadata.size > ARTIFACT_LIMITS.bytes) {
+        limitations.push(`Initial JavaScript closure exceeded ${ARTIFACT_LIMITS.bytes} raw bytes.`);
+        break;
+      }
+      bytes = await readFile(path);
+    } catch {
+      limitations.push(`Artifact file ${relative} could not be read.`);
+      continue;
+    }
+    visited.add(relative);
+    const compressed = gzipSync(bytes, { level: 9 }).byteLength;
+    files.push({ file: relative, raw_bytes: bytes.byteLength, gzip_bytes: compressed });
+    rawBytes += bytes.byteLength;
+    gzipBytes += compressed;
+    const source = bytes.toString('utf8');
+    const references = item.kind === 'html' ? htmlModuleScripts(source) : staticImports(source);
+    if (item.kind === 'javascript' && /\bimport\s*\(/.test(source)) {
+      limitations.push(`Dynamic imports in ${relative} were not included in the initial closure.`);
+    }
+    for (const reference of references) {
+      queue.push({
+        reference,
+        importer: dirname(path),
+        depth: item.depth + 1,
+        kind: 'javascript',
+      });
+    }
+  }
+  const structuralLimitations = limitations.slice(2);
+  return {
+    entry,
+    complete: structuralLimitations.length === 0,
+    file_count: files.length,
+    raw_bytes: rawBytes,
+    gzip_bytes: gzipBytes,
+    files,
+    limitations: [...new Set(limitations)],
+    provenance: 'existing_unverified_vite_artifact',
+  };
+}
+
+function incomplete(entry, files, rawBytes, gzipBytes, limitations) {
+  return {
+    entry,
+    complete: false,
+    file_count: files.length,
+    raw_bytes: rawBytes,
+    gzip_bytes: gzipBytes,
+    files,
+    limitations: [...new Set(limitations)],
+    provenance: 'existing_unverified_vite_artifact',
+  };
+}
+
+async function containedDirectory(repositoryRoot, candidate) {
+  if (typeof candidate !== 'string' || candidate.length === 0 || isAbsolute(candidate)) {
+    throw new Error('Vite build directory must be repository-relative.');
+  }
+  const repository = await realpath(resolve(repositoryRoot));
+  let directory;
+  try {
+    directory = await realpath(resolve(repository, candidate));
+  } catch {
+    throw new Error('Vite build directory is not readable.');
+  }
+  if (repositoryRelative(repository, directory) === null) {
+    throw new Error('Vite build directory escapes the repository.');
+  }
+  const metadata = await lstat(directory);
+  if (!metadata.isDirectory()) throw new Error('Vite build path is not a directory.');
+  return directory;
+}
+
+async function resolveArtifactReference(buildRoot, importer, reference) {
+  if (typeof reference !== 'string' || reference.length === 0) {
+    throw new Error('Artifact closure contained an empty reference.');
+  }
+  const clean = reference.split(/[?#]/, 1)[0];
+  if (/^(?:[a-z]+:|\/\/)/i.test(clean)) {
+    throw new Error(`Artifact reference ${reference} is external.`);
+  }
+  const lexical = clean.startsWith('/')
+    ? resolve(buildRoot, clean.slice(1))
+    : resolve(importer, clean);
+  if (repositoryRelative(buildRoot, lexical) === null) {
+    throw new Error(`Artifact reference ${reference} escapes the build directory.`);
+  }
+  let path;
+  try {
+    path = await realpath(lexical);
+  } catch {
+    throw new Error(`Artifact reference ${reference} is missing.`);
+  }
+  if (repositoryRelative(buildRoot, path) === null) {
+    throw new Error(`Artifact reference ${reference} resolves outside the build directory.`);
+  }
+  return path;
+}
+
+function htmlModuleScripts(source) {
+  return [
+    ...source.matchAll(
+      /<script\b(?=[^>]*\btype=["']module["'])[^>]*\bsrc=["']([^"']+)["'][^>]*>/gi
+    ),
+  ].map((match) => match[1]);
+}
+
+function staticImports(source) {
+  const references = [];
+  const pattern = /\b(?:import|export)\s*(?:[^'";()]*?\bfrom\s*)?["']([^"']+)["']/g;
+  for (const match of source.matchAll(pattern)) {
+    if (match[1].startsWith('.') || match[1].startsWith('/')) references.push(match[1]);
+  }
+  return references;
+}

--- a/scripts/runtime-failure-capsule/vite-artifact.test.mjs
+++ b/scripts/runtime-failure-capsule/vite-artifact.test.mjs
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import { inspectExistingViteArtifact } from './vite-artifact.mjs';
+
+test('reads one bounded existing Vite initial JavaScript closure', async (context) => {
+  const root = await mkdtemp(join(tmpdir(), 'codevetter-vite-artifact-'));
+  context.after(() => rm(root, { recursive: true, force: true }));
+  await mkdir(join(root, 'dist/assets'), { recursive: true });
+  await writeFile(
+    join(root, 'dist/index.html'),
+    '<script type="module" src="/assets/main.js"></script>\n'
+  );
+  await writeFile(join(root, 'dist/assets/main.js'), 'import{value}from"./shared.js";value();\n');
+  await writeFile(join(root, 'dist/assets/shared.js'), 'export const value=()=>42;\n');
+
+  const artifact = await inspectExistingViteArtifact(root, 'dist');
+
+  assert.equal(artifact.complete, true);
+  assert.deepEqual(
+    artifact.files.map((entry) => entry.file),
+    ['index.html', 'assets/main.js', 'assets/shared.js']
+  );
+  assert.ok(artifact.raw_bytes > 0);
+  assert.ok(artifact.gzip_bytes > 0);
+  assert.equal(artifact.provenance, 'existing_unverified_vite_artifact');
+});
+
+test('marks dynamic or escaping artifact edges incomplete', async (context) => {
+  const root = await mkdtemp(join(tmpdir(), 'codevetter-vite-incomplete-'));
+  context.after(() => rm(root, { recursive: true, force: true }));
+  await mkdir(join(root, 'dist'), { recursive: true });
+  await writeFile(join(root, 'dist/index.html'), '<script type="module" src="./main.js"></script>');
+  await writeFile(join(root, 'dist/main.js'), 'import("./later.js"); import "../escape.js";');
+  await writeFile(join(root, 'escape.js'), 'export {};');
+
+  const artifact = await inspectExistingViteArtifact(root, 'dist');
+
+  assert.equal(artifact.complete, false);
+  assert.ok(artifact.limitations.some((entry) => entry.includes('Dynamic imports')));
+  assert.ok(artifact.limitations.some((entry) => entry.includes('escapes the build directory')));
+});


### PR DESCRIPTION
## What changed

- adds explicit Playwright performance scopes with exact reporter duration separate from process wall time
- adds alternating paired verification and campaign support with existing correctness/change protections
- adds optional bounded, unverified inspection of an existing Vite initial JavaScript closure
- exposes the closed scope through CLI and MCP, with no command, build, install, or patch authority
- makes the changed-function complexity gate baseline-aware: new/regressed violations fail while unchanged legacy debt remains visible

## Why

Playwright execution already existed, but CodeVetter rejected it as a performance adapter and could only observe noisy runner startup. This adds the smallest evidence seam needed to measure one caller-selected React flow without restoring the retired general browser runtime.

## Chess qualification

- exact flow: 248 ms median vs 1,146 ms process wall (3 samples)
- unchanged paired check: 227 ms vs 225 ms; correctly `inconclusive`
- analytics trial: 235 ms vs 231 ms across 10 alternating samples; correctly rejected as below the 10% + 10 ms policy despite a large unverified bundle movement

No Chess source change was retained. Production traffic, browser memory, React attribution, representative devices, and artifact freshness remain explicitly unverified.

## Checks

- 145 runtime-capsule tests
- Biome: 745 files
- strict OpenSpec: 59 items
- docs validation: 76 files
- change-size gate
- changed-function complexity: 9 unchanged baseline exceptions, 0 new/regressed violations
