### PR TITLE
Sharpen review, test, and optimize positioning

### DIFF
--- a/apps/landing-page-astro/src/components/FAQ.astro
+++ b/apps/landing-page-astro/src/components/FAQ.astro
@@ -6,7 +6,7 @@
 const faqs = [
   {
     q: 'What is CodeVetter?',
-    a: 'CodeVetter is a desktop-first AI code review tool built for agent-generated code. It runs locally as a Tauri binary, reviews diffs through pluggable LLM providers, and focuses on finding bugs that normal AI review misses.',
+    a: 'CodeVetter is a local verification platform for agent-written code. It reviews diffs, runs tests, profiles representative flows, and preserves executable evidence so coding agents can fix correctness and performance problems instead of relying on another model’s opinion.',
   },
   {
     q: 'Is CodeVetter free?',
@@ -22,7 +22,7 @@ const faqs = [
   },
   {
     q: 'Can CodeVetter review code from AI agents?',
-    a: 'Yes, it is specifically designed for agent output. It verifies agent-written code by running reviews, emitting verification handoff proofs with per-finding evidence, and re-checking that issues are resolved.',
+    a: 'Yes. CodeVetter is designed for agent output: it reviews changed code, exercises behavior, measures representative performance, emits evidence for each finding, and re-checks the result after an agent makes a fix.',
   },
   {
     q: 'What LLM providers does CodeVetter support?',
@@ -63,7 +63,7 @@ const faqJsonLd = {
         Questions, <span class="text-gradient">answered.</span>
       </h2>
       <p class="mt-6 text-[18px] text-gray-400 leading-relaxed max-w-2xl mx-auto">
-        Everything you need to know about how CodeVetter vets agent-generated code.
+        How CodeVetter reviews, tests, and optimizes agent-generated code.
       </p>
     </div>
 

--- a/apps/landing-page-astro/src/components/Hero.astro
+++ b/apps/landing-page-astro/src/components/Hero.astro
@@ -38,16 +38,16 @@ const particles = Array.from({ length: PARTICLE_COUNT }, (_, i) => {
         </span>
         <span class="inline-flex items-center gap-1.5 px-3 py-1 border text-xs font-medium rounded-full transition-colors text-gray-400 bg-white/5 border-white/10 backdrop-blur-md font-mono uppercase tracking-[0.16em]">
           <Icon name="sparkles" class="w-3 h-3" width={12} height={12} strokeWidth={1.5} />
-          Built for the agent era
+          Review · test · optimize
         </span>
       </div>
 
       <h1 class="font-display font-bold text-[clamp(2.8rem,7vw,6.35rem)] leading-[1.02] tracking-tight max-w-5xl">
-        <span class="block text-white">Stop merging</span>
+        <span class="block text-white">AI writes code fast.</span>
         <span class="block">
-          <span class="text-gradient">unreviewed</span>{' '}
+          <span class="text-gradient">It writes unoptimized code.</span>{' '}
           <span class="relative inline-block">
-            <span class="relative z-10 text-white">AI code.</span>
+            <span class="relative z-10 text-white">A lot.</span>
             <svg
               class="absolute -bottom-3 left-0 hidden h-4 w-full text-[--color-accent]/70 sm:block"
               viewBox="0 0 200 12"
@@ -68,10 +68,9 @@ const particles = Array.from({ length: PARTICLE_COUNT }, (_, i) => {
       </h1>
 
       <p class="mt-8 max-w-2xl text-[18px] leading-relaxed text-gray-400">
-        CodeVetter is a desktop review tool for the diffs your agent
-        ships. It catches 14 vulnerability classes (SQLi, PII leaks, CSRF,
-        broken auth, and more) that Cursor, Claude Code, and Devin routinely miss.
-        Runs entirely offline.
+        CodeVetter reviews, tests, and profiles agent-written changes. It finds
+        redundant work, hidden bottlenecks, and broken behavior, then preserves
+        executable evidence so agents can improve the code and verify the result.
       </p>
 
       <div class="mt-12 flex flex-col sm:flex-row items-center justify-center gap-4">

--- a/apps/landing-page-astro/src/pages/index.astro
+++ b/apps/landing-page-astro/src/pages/index.astro
@@ -17,8 +17,8 @@ import Footer from '@/components/Footer.astro';
 ---
 
 <Layout
-  title="CodeVetter — Private AI code review for agent-written code"
-  description="Local desktop AI code review and verification for agent-written changes. Offline, multi-LLM, evidence-backed. Free open source."
+  title="CodeVetter — Review, test, and optimize AI-written code"
+  description="AI writes code fast—and often leaves redundant work and hidden bottlenecks. CodeVetter reviews, tests, and profiles agent-written changes with executable evidence."
   path="/"
 >
   <main>


### PR DESCRIPTION
## What changed

- leads with the product thesis: AI writes code fast and often leaves it unoptimized
- names the three product jobs clearly: review, test, and optimize
- updates supporting hero, FAQ, and SEO copy around executable evidence

## Scope

Copy only. Existing optimization case-study pages remain unchanged and separately addressable.

## Checks

- Astro production build: 22 pages
- full Biome: 745 files
- change-size and whitespace checks
