### PR TITLE
Release v1.7.5

### DIFF
--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-utils/schema.json",
   "identifier": "com.codevetter.desktop",
   "productName": "CodeVetter",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "build": {
     "beforeDevCommand": "npm run dev",
     "beforeBuildCommand": "npm run prepare:mcp-sidecar:release && npm run prepare:cli-sidecar:release && npm run prepare:agent-island:release && npm run build",


### PR DESCRIPTION
Ships the compact Playwright performance evidence and updated product positioning already merged to `main`.

Validation: JSON version check and `git diff --check`; full `main` CI is green at `4ccbf04`.