### PR TITLE
Add portfolio project strip

### DIFF
--- a/apps/landing-page-astro/src/layouts/Layout.astro
+++ b/apps/landing-page-astro/src/layouts/Layout.astro
@@ -93,5 +93,11 @@ const OG_IMAGE = `${SITE_URL}/og-image.png`;
 </head>
   <body>
     <slot />
+    <script
+      is:inline
+      src="https://sassmaker.com/project-strip.js"
+      data-project="codevetter"
+      defer
+    ></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary\n\n- add the shared portfolio project strip to the public landing page\n- exclude the current project while linking every other maintained public project\n- preserve the existing page design and replace any older cross-project promo where present\n\n## Validation\n\n- focused project build or typecheck passed\n- shared strip syntax and responsive browser review passed\n- catalog parity verified against sass-maker/fleet-workspace#341\n\nPart of sass-maker/fleet-workspace#341