### PR TITLE
fix: repair Claude usage config and local accounting

### DIFF
--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -38,7 +38,7 @@ separately approved safety design justify renewed investment.
 ## Dependencies
 
 External:
-- Bundled `ccusage` 20.0.20 sidecar — local, offline Claude/Codex usage accounting; exact updates are opened weekly and remain qualification-gated.
+- Bundled `ccusage` 20.0.20 sidecar — local, offline Claude/Codex/Grok usage accounting; exact updates are opened weekly and remain qualification-gated.
 - User-supplied LLM API keys (Anthropic / OpenAI / OpenRouter) stored in user settings — no server-side auth.
 - Installed and authenticated Codex or Claude CLI for Work conversations; provider account policy remains external to CodeVetter.
 - GitHub Releases + GitHub Actions — `auto-release.yml` cuts a `v<version>` release on `tauri.conf.json` version bumps, dispatching `release.yml` to build/sign/upload Tauri binaries; `@tauri-apps/plugin-updater` consumes the `latest.json` manifest.
@@ -55,11 +55,20 @@ Internal (fleet):
 
 ## Timeline
 
-- **2026-08-16 — ccusage local-accounting cutover (unreleased):** Replaced the
-  Usage chart's custom Claude/Codex accounting with one cached report from the
-  pinned bundled `ccusage` sidecar. The chart now contains ccusage-backed
-  Claude/Codex data plus the existing Devin tracker only; Cursor and Grok are
-  excluded. Reliable provider remaining-usage and quota cards are unchanged.
+- **2026-08-19 — Claude/Grok local-accounting correction (v1.9.1):** Expanded
+  the pinned `ccusage` report to Claude, Codex, and Grok while keeping Devin as
+  an independently queried local source. Devin query failures no longer hide
+  healthy ccusage data, and fresh/generated totals now include cache-creation
+  input. Claude live-quota checks now consider configured profile files and
+  Keychain candidates, selecting the freshest expiry instead of
+  unconditionally preferring a stale default file.
+
+- **2026-08-16 — ccusage local-accounting cutover (shipped in v1.9.0):** Replaced
+  the Usage chart's custom Claude/Codex accounting with one cached report from
+  the pinned bundled `ccusage` sidecar. The chart contained ccusage-backed
+  Claude/Codex data plus the existing Devin tracker; Cursor and Grok were
+  excluded. Reliable provider remaining-usage and quota cards remained a
+  separate surface.
   Retired the Codex reconciliation UI, startup repairs, observation writes, and
   bespoke ledger pricing/qualification code while leaving historical SQLite
   tables intact. Devin remains separate because upstream ccusage does not

--- a/apps/desktop/src-tauri/src/commands/accounts.rs
+++ b/apps/desktop/src-tauri/src/commands/accounts.rs
@@ -3,6 +3,7 @@ use crate::DbState;
 use serde_json::{json, Value};
 use std::collections::BTreeMap;
 use std::io::BufRead;
+use std::path::PathBuf;
 use tauri::State;
 
 #[tauri::command]
@@ -592,7 +593,7 @@ async fn detect_claude_accounts() -> Vec<DetectedAccount> {
     let mut accounts: Vec<DetectedAccount> = Vec::new();
     for service in services {
         let svc = service.clone();
-        let result = tokio::task::spawn_blocking(move || read_keychain_account_info(&svc))
+        let result = tokio::task::spawn_blocking(move || read_credential_account_info(&svc))
             .await
             .ok()
             .flatten();
@@ -908,38 +909,33 @@ fn find_claude_keychain_services() -> Vec<String> {
         }
     }
 
-    // Ensure the default one is tried even if dump-keychain fails
-    if services.is_empty() {
+    // The current CLI may use a config-root file while stale profile entries
+    // remain in Keychain, so always include the default logical account when a
+    // credential file exists. Also keep the legacy fallback when discovery
+    // itself fails.
+    if (!claude_credential_files().is_empty() || services.is_empty())
+        && !services
+            .iter()
+            .any(|service| service == "Claude Code-credentials")
+    {
         services.push("Claude Code-credentials".to_string());
     }
 
     services
 }
 
-/// Read account metadata + expiry from a specific Claude keychain entry.
+/// Read account metadata + expiry from the freshest credential candidate for a
+/// logical Claude account.
 /// Returns `(DetectedAccount, expires_at_ms)` for dedup by freshest token.
-fn read_keychain_account_info(service: &str) -> Option<(DetectedAccount, i64)> {
-    let output = std::process::Command::new("security")
-        .args(["find-generic-password", "-s", service, "-w"])
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .output()
-        .ok()?;
-
-    if !output.status.success() {
-        return None;
-    }
-
-    let raw = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    let parsed: Value = serde_json::from_str(&raw).ok()?;
-
-    let oauth = parsed.get("claudeAiOauth")?;
+fn read_credential_account_info(service: &str) -> Option<(DetectedAccount, i64)> {
+    let credential = read_full_credential(service).ok()?;
+    let oauth = credential.wrapper.get("claudeAiOauth")?;
     let subscription_type = oauth
         .get("subscriptionType")
         .and_then(|v| v.as_str())
         .unwrap_or("unknown")
         .to_string();
-    let expires_at = oauth.get("expiresAt").and_then(|v| v.as_i64()).unwrap_or(0);
+    let expires_at = credential.expires_at;
 
     let name = match subscription_type.as_str() {
         "team" => "Claude Team".to_string(),
@@ -1038,19 +1034,21 @@ fn parse_credential_wrapper(
 
 /// Read the full Claude Code credential so it can be refreshed in place.
 ///
-/// Newer Claude Code stores the active account's OAuth in
-/// `~/.claude/.credentials.json` (a file it refreshes in place); older versions
-/// used the macOS keychain. The keychain entries are frequently stale leftovers,
-/// so for the primary account prefer the file and fall back to the keychain.
+/// Newer Claude Code can store OAuth in a config-root `.credentials.json` file;
+/// older versions used the macOS keychain. Both locations can remain after a
+/// migration, so collect every candidate and use the one with the newest expiry
+/// instead of blindly preferring one storage mechanism.
 fn read_full_credential(service: &str) -> Result<KeychainCred, String> {
+    let mut candidates = Vec::new();
     if service == "Claude Code-credentials" {
-        if let Ok(home) = std::env::var("HOME") {
-            let path = format!("{home}/.claude/.credentials.json");
+        for path in claude_credential_files() {
             if let Ok(raw) = std::fs::read_to_string(&path) {
-                if let Ok(cred) =
-                    parse_credential_wrapper(raw.trim(), service, CredLocation::File(path))
-                {
-                    return Ok(cred);
+                if let Ok(cred) = parse_credential_wrapper(
+                    raw.trim(),
+                    service,
+                    CredLocation::File(path.to_string_lossy().to_string()),
+                ) {
+                    candidates.push(cred);
                 }
             }
         }
@@ -1072,10 +1070,16 @@ fn read_full_credential(service: &str) -> Result<KeychainCred, String> {
         if let Some(k) = kc {
             pw_args.push(k.clone());
         }
-        let pw_out = std::process::Command::new("security")
+        let pw_out = match std::process::Command::new("security")
             .args(&pw_args)
             .output()
-            .map_err(|e| format!("Failed to run security command: {e}"))?;
+        {
+            Ok(output) => output,
+            Err(error) => {
+                last_err = format!("Failed to run security command: {error}");
+                continue;
+            }
+        };
         if !pw_out.status.success() {
             continue;
         }
@@ -1106,14 +1110,58 @@ fn read_full_credential(service: &str) -> Result<KeychainCred, String> {
                 keychain: kc.clone(),
             },
         ) {
-            Ok(cred) => return Ok(cred),
+            Ok(cred) => candidates.push(cred),
             Err(e) => {
                 last_err = e;
                 continue;
             }
         }
     }
-    Err(last_err)
+    freshest_credential(candidates).ok_or(last_err)
+}
+
+fn claude_credential_files() -> Vec<PathBuf> {
+    let Some(home) = std::env::var_os("HOME").map(PathBuf::from) else {
+        return Vec::new();
+    };
+    let mut roots = Vec::new();
+    if let Ok(config_dirs) = std::env::var("CLAUDE_CONFIG_DIR") {
+        for raw in config_dirs
+            .split(',')
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            roots.push(PathBuf::from(raw));
+        }
+    }
+    roots.extend([
+        home.join(".claude"),
+        home.join(".config").join("claude"),
+        home.join("Library")
+            .join("Application Support")
+            .join("Claude"),
+    ]);
+    if let Ok(entries) = std::fs::read_dir(&home) {
+        for entry in entries.flatten() {
+            if entry.path().is_dir() && entry.file_name().to_string_lossy().starts_with(".claude-")
+            {
+                roots.push(entry.path());
+            }
+        }
+    }
+
+    let mut files = Vec::new();
+    for root in roots {
+        let path = root.join(".credentials.json");
+        if path.is_file() && !files.contains(&path) {
+            files.push(path);
+        }
+    }
+    files
+}
+
+fn freshest_credential(candidates: Vec<KeychainCred>) -> Option<KeychainCred> {
+    candidates.into_iter().max_by_key(|cred| cred.expires_at)
 }
 
 /// Write rotated tokens back to wherever the credential came from (the
@@ -2817,6 +2865,35 @@ fn json_i64(value: &Value) -> Option<i64> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn test_claude_credential(label: &str, expires_at: i64) -> KeychainCred {
+        let raw = json!({
+            "claudeAiOauth": {
+                "accessToken": format!("access-{label}"),
+                "refreshToken": format!("refresh-{label}"),
+                "expiresAt": expires_at,
+                "subscriptionType": "team"
+            }
+        })
+        .to_string();
+        parse_credential_wrapper(
+            &raw,
+            "Claude Code-credentials",
+            CredLocation::File(format!("/{label}/.credentials.json")),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn claude_credential_resolution_uses_freshest_candidate() {
+        let stale_file = test_claude_credential("stale", 100);
+        let active_profile = test_claude_credential("active", 300);
+
+        let selected = freshest_credential(vec![active_profile, stale_file]).unwrap();
+
+        assert_eq!(selected.expires_at, 300);
+        assert_eq!(selected.access_token, "access-active");
+    }
 
     #[test]
     fn parse_devin_credentials_toml_values() {

--- a/apps/desktop/src-tauri/src/commands/local_usage.rs
+++ b/apps/desktop/src-tauri/src/commands/local_usage.rs
@@ -18,7 +18,7 @@ const CACHE_TTL: Duration = Duration::from_secs(30);
 const EXECUTION_TIMEOUT: Duration = Duration::from_secs(30);
 const MAX_STDOUT_BYTES: usize = 32 * 1024 * 1024;
 const MAX_STDERR_BYTES: usize = 1024 * 1024;
-const ACCOUNTED_AGENTS: [&str; 2] = ["claude", "codex"];
+const ACCOUNTED_AGENTS: [&str; 3] = ["claude", "codex", "grok"];
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
 pub struct LocalUsageTotals {
@@ -32,7 +32,9 @@ pub struct LocalUsageTotals {
 
 impl LocalUsageTotals {
     pub fn generated_tokens(&self) -> u64 {
-        self.input_tokens.saturating_add(self.output_tokens)
+        self.input_tokens
+            .saturating_add(self.cache_creation_tokens)
+            .saturating_add(self.output_tokens)
     }
 
     fn checked_add(&self, other: &Self) -> Result<Self, String> {
@@ -776,15 +778,23 @@ mod tests {
 
     #[test]
     fn excludes_non_chart_agents() {
-        let with_grok = String::from_utf8(UNIFIED.to_vec()).unwrap().replacen(
+        let with_opencode = String::from_utf8(UNIFIED.to_vec()).unwrap().replacen(
             "\"agents\": [\"claude\", \"codex\"]",
-            "\"agents\": [\"claude\", \"codex\", \"grok\"]",
+            "\"agents\": [\"claude\", \"codex\", \"opencode\"]",
             1,
         );
-        let report = normalize_report(with_grok.as_bytes(), "UTC", &[]).unwrap();
+        let report = normalize_report(with_opencode.as_bytes(), "UTC", &[]).unwrap();
         assert_eq!(report.provenance.detected_agents, ["claude", "codex"]);
-        assert_eq!(report.provenance.excluded_agents, ["grok"]);
+        assert_eq!(report.provenance.excluded_agents, ["opencode"]);
         assert_eq!(report.totals.total_tokens, 37);
+    }
+
+    #[test]
+    fn accounts_for_grok_but_not_devin() {
+        assert!(is_accounted_agent("claude"));
+        assert!(is_accounted_agent("codex"));
+        assert!(is_accounted_agent("grok"));
+        assert!(!is_accounted_agent("devin"));
     }
 
     #[test]

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-utils/schema.json",
   "identifier": "com.codevetter.desktop",
   "productName": "CodeVetter",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "build": {
     "beforeDevCommand": "npm run dev",
     "beforeBuildCommand": "npm run prepare:mcp-sidecar:release && npm run prepare:cli-sidecar:release && npm run prepare:ccusage-sidecar && npm run prepare:agent-island:release && npm run build",

--- a/apps/desktop/src/lib/local-usage.test.ts
+++ b/apps/desktop/src/lib/local-usage.test.ts
@@ -4,12 +4,18 @@ import test from 'node:test';
 import type { LocalUsageReport, LocalUsageTotals } from './tauri-ipc';
 import { ccusageAgentDays, ccusageAgentRows, ccusageModels, usageStats } from './local-usage';
 
-const totals = (input: number, cache: number, output: number, cost: number): LocalUsageTotals => ({
+const totals = (
+  input: number,
+  cache: number,
+  output: number,
+  cost: number,
+  cacheCreation = 0
+): LocalUsageTotals => ({
   input_tokens: input,
-  cache_creation_tokens: 0,
+  cache_creation_tokens: cacheCreation,
   cache_read_tokens: cache,
   output_tokens: output,
-  total_tokens: input + cache + output,
+  total_tokens: input + cacheCreation + cache + output,
   cost_usd: cost,
 });
 
@@ -23,8 +29,8 @@ const report: LocalUsageReport = {
     generated_at: '2026-08-16T12:00:00Z',
     timezone: 'UTC',
     window: 'all',
-    detected_agents: ['claude', 'codex'],
-    excluded_agents: ['grok'],
+    detected_agents: ['claude', 'codex', 'grok'],
+    excluded_agents: ['opencode'],
     codex_roots: [],
     source_fingerprint: 'sha256:test',
     pricing_complete: true,
@@ -34,10 +40,11 @@ const report: LocalUsageReport = {
   daily: [
     {
       period: '2026-08-16',
-      totals: totals(13, 6, 3, 4),
+      totals: totals(15, 9, 4, 5, 3),
       agents: [
-        { agent: 'claude', totals: totals(5, 2, 1, 1), models: [] },
+        { agent: 'claude', totals: totals(5, 2, 1, 1, 3), models: [] },
         { agent: 'codex', totals: totals(8, 4, 2, 3), models: [] },
+        { agent: 'grok', totals: totals(2, 3, 1, 1), models: [] },
       ],
       models: [],
     },
@@ -53,29 +60,37 @@ const report: LocalUsageReport = {
       totals: totals(8, 4, 2, 3),
       models: [{ model: 'gpt-test', totals: totals(8, 4, 2, 3), fallback: false, priced: true }],
     },
+    {
+      session_id: 'grok-1',
+      agent: 'grok',
+      last_activity: '2026-08-16T11:00:00Z',
+      reasoning_output_tokens: 0,
+      totals: totals(2, 3, 1, 1),
+      models: [{ model: 'grok-test', totals: totals(2, 3, 1, 1), fallback: false, priced: true }],
+    },
   ],
-  totals: totals(13, 6, 3, 4),
+  totals: totals(15, 9, 4, 5, 3),
 };
 
-test('ccusage selectors expose only mapped Claude and Codex rows', () => {
+test('ccusage selectors expose mapped Claude, Codex, and Grok rows', () => {
   assert.deepEqual(
     ccusageAgentDays(report).map((row) => row.agent_type),
-    ['claude-code', 'codex']
+    ['claude-code', 'codex', 'grok']
   );
   assert.deepEqual(
     ccusageAgentRows(report).map((row) => row.agent_type),
-    ['codex']
+    ['codex', 'grok']
   );
 });
 
 test('usage summary keeps generated and cache tokens separate', () => {
   const stats = usageStats(ccusageAgentDays(report), new Date('2026-08-16T12:00:00'));
-  assert.equal(stats.today_generated, 16);
-  assert.equal(stats.today, 22);
-  assert.equal(stats.today_cost, 4);
+  assert.equal(stats.today_generated, 22);
+  assert.equal(stats.today, 31);
+  assert.equal(stats.today_cost, 5);
 });
 
 test('model selector uses one report snapshot and honors agent filters', () => {
   assert.equal(ccusageModels(report)[0]?.model, 'gpt-test');
-  assert.deepEqual(ccusageModels(report, undefined, undefined, new Set(['codex'])), []);
+  assert.deepEqual(ccusageModels(report, undefined, undefined, new Set(['codex', 'grok'])), []);
 });

--- a/apps/desktop/src/lib/local-usage.ts
+++ b/apps/desktop/src/lib/local-usage.ts
@@ -9,7 +9,7 @@ import type {
 
 const agentName = (agent: string) => (agent === 'claude' ? 'claude-code' : agent);
 const generated = (totals: LocalUsageReport['totals']) =>
-  totals.input_tokens + totals.output_tokens;
+  totals.input_tokens + totals.cache_creation_tokens + totals.output_tokens;
 
 function localDay(value: Date): string {
   return `${value.getFullYear()}-${String(value.getMonth() + 1).padStart(2, '0')}-${String(value.getDate()).padStart(2, '0')}`;
@@ -145,12 +145,13 @@ export function ccusageAgentRows(report: LocalUsageReport): AgentUsageRow[] {
       cost: 0,
     };
     row.sessions += 1;
-    row.real_input_tokens += session.totals.input_tokens;
+    row.real_input_tokens += session.totals.input_tokens + session.totals.cache_creation_tokens;
     row.cache_read_tokens += session.totals.cache_read_tokens;
     row.output_tokens += session.totals.output_tokens;
     row.cost += session.totals.cost_usd;
     if (session.last_activity && session.last_activity.slice(0, 10) >= week) {
-      row.week_real_input_tokens += session.totals.input_tokens;
+      row.week_real_input_tokens +=
+        session.totals.input_tokens + session.totals.cache_creation_tokens;
       row.week_output_tokens += session.totals.output_tokens;
     }
     rows.set(agent, row);

--- a/apps/desktop/src/pages/Home.tsx
+++ b/apps/desktop/src/pages/Home.tsx
@@ -305,6 +305,12 @@ function formatLiveErrorHint(liveError: string | null): string | null {
   return `Live usage unavailable: ${liveError}`;
 }
 
+function scopeLiveErrorHint(provider: string, hint: string | null): string | null {
+  return provider === 'anthropic' && hint
+    ? `Local usage remains available via ccusage. ${hint}`
+    : hint;
+}
+
 function resolveAccountPlan(
   provider: string,
   liveUsage: LiveUsageResult | null,
@@ -753,6 +759,7 @@ function AccountUsageRow({
   isSharedUsage: boolean;
 }) {
   const liveErrorHint = formatLiveErrorHint(liveError);
+  const scopedLiveErrorHint = scopeLiveErrorHint(account.provider, liveErrorHint);
   const weekSessions = usage?.week_sessions ?? 0;
   const weekTokens = (usage?.week_input_tokens ?? 0) + (usage?.week_output_tokens ?? 0);
   const profileBreakdown = usage?.profile_breakdown ?? [];
@@ -829,7 +836,7 @@ function AccountUsageRow({
             weekSessions={weekSessions}
             usage={usage}
             hasLive={hasLive}
-            liveErrorHint={liveErrorHint}
+            liveErrorHint={scopedLiveErrorHint}
             profileBreakdown={profileBreakdown}
           />
         ) : (
@@ -860,7 +867,8 @@ const AGENT_PALETTE: Record<
 > = {
   'claude-code': { bar: '#d6a947', label: 'Claude', source: 'ccusage' },
   codex: { bar: '#31c6b7', label: 'Codex', source: 'ccusage' },
-  devin: { bar: '#fb923c', label: 'Devin', source: 'Devin sessions.db metrics' },
+  grok: { bar: '#38bdf8', label: 'Grok', source: 'ccusage' },
+  devin: { bar: '#fb923c', label: 'Devin', source: 'separate Devin sessions.db accounting' },
 };
 
 const agentPaletteFor = (agent: string) => AGENT_PALETTE[agent] ?? { bar: '#64748b', label: agent };
@@ -1428,15 +1436,11 @@ function TokenUsageChart({
 // including Grok and Cursor — appears. We show TWO bars because the agents log
 // tokens on incompatible bases:
 //   • "Total burn (cache-incl)" = real_input + cache_read + output. Mirrors
-//     ccusage; Claude/Codex dominate because ~96-98% of their tokens are cache
+//     ccusage; Claude/Codex/Grok often dominate because most tokens are cache
 //     reads (re-sent context counted every turn).
-//   • "Fresh tokens (cache-free)" = real_input + output. Cache reads aren't
-//     comparable across agents (Grok/Cursor logs don't expose them), so this is
-//     the fair cross-agent split — Grok and Cursor become visible.
-// Cursor's local cc_sessions value is a chars÷4 estimate that misses all IDE
-// usage, so when the live-API ledger has a cursor row we use it as the source
-// of truth instead (see CursorAgentTokens below). Grok stays a per-turn-context
-// estimate (no output/cache logged). AGENT_PALETTE is shared from above.
+//   • "Fresh tokens (cache-free)" = real_input + output. This separates newly
+//     processed tokens from re-sent cached context across the local sources.
+// AGENT_PALETTE is shared from above.
 
 type AgentSegment = { agent: string; tokens: number; estimated: boolean };
 
@@ -1507,7 +1511,7 @@ function useAgentUsageRows(active: boolean, report: LocalUsageReport) {
           setRows([...ccusageAgentRows(report), ...legacyRows]);
         }
       } catch {
-        if (!cancelled) setRows((prev) => prev ?? []);
+        if (!cancelled) setRows(ccusageAgentRows(report));
       }
     };
     void fetchRows();
@@ -2063,7 +2067,7 @@ function LocalUsagePanel({
     const { start, end } = modelFocusDayRange(focusDate, granularity);
     const devinRows = hiddenAgents.has('devin')
       ? Promise.resolve([] as ModelUsage[])
-      : getDevinUsageByModel(undefined, start, end);
+      : getDevinUsageByModel(undefined, start, end).catch(() => []);
     void devinRows
       .then((rows) => {
         if (!cancelled) {
@@ -2073,9 +2077,6 @@ function LocalUsagePanel({
             )
           );
         }
-      })
-      .catch(() => {
-        if (!cancelled) setFocusModelData([]);
       })
       .finally(() => {
         if (!cancelled) setFocusModelLoading(false);
@@ -2089,7 +2090,7 @@ function LocalUsagePanel({
     <div className="cv-frame overflow-hidden">
       <div className="cv-terminal-bar h-10 px-4">
         <BarChart3 size={14} className="text-[var(--cv-accent)]" />
-        <span className="cv-label">Local usage · ccusage + Devin</span>
+        <span className="cv-label">Local usage · ccusage · Devin separate</span>
       </div>
 
       <div className="flex flex-col gap-2 border-b border-[var(--cv-line)] px-4 py-2.5 sm:flex-row sm:items-center sm:justify-between">
@@ -2835,7 +2836,7 @@ function CcusageSummarySection({
         <div className="min-w-0">
           <div className="cv-label text-zinc-500">ccusage local accounting</div>
           <h1 className="mt-1 truncate text-lg font-semibold tracking-[-0.015em] text-zinc-100">
-            Claude + Codex + Devin usage
+            Claude + Codex + Grok, plus Devin
           </h1>
         </div>
         <div className="flex flex-wrap items-center gap-2">
@@ -2843,9 +2844,9 @@ function CcusageSummarySection({
             <Badge
               variant="outline"
               className="h-6 border-emerald-500/25 bg-emerald-500/[0.06] px-2 text-[11px] font-medium text-emerald-300/80"
-              title={`Claude and Codex from ccusage ${report.provenance.version}; Devin from CodeVetter's local tracker; generated ${formatShortDateTime(report.provenance.generated_at)}`}
+              title={`Claude, Codex, and Grok from ccusage ${report.provenance.version}; Devin from CodeVetter's separate local tracker; generated ${formatShortDateTime(report.provenance.generated_at)}`}
             >
-              ccusage {report.provenance.version} · Devin local
+              ccusage {report.provenance.version} · Devin separate
             </Badge>
           )}
           {report?.stale && (
@@ -2872,7 +2873,7 @@ function CcusageSummarySection({
           <div
             key={stat.label}
             className="flex min-h-20 items-center justify-between bg-[var(--cv-surface)] px-4 py-4"
-            title={`${formatMoney(stat.cost)} ccusage plus Devin local accounting · ${formatTokens(stat.gen)} generated tokens`}
+            title={`${formatMoney(stat.cost)} ccusage plus separate Devin accounting · ${formatTokens(stat.gen)} generated tokens`}
           >
             <span className="cv-label mr-2 truncate">{stat.label}</span>
             <span className="shrink-0 text-right">
@@ -2953,7 +2954,7 @@ export default function Home() {
       );
 
       const [localUsageResult, accountsResult, cachedUsagesResult] = await Promise.all([
-        Promise.all([getLocalUsageReport(), getDevinUsageByDay(366)]).then(
+        Promise.all([getLocalUsageReport(), getDevinUsageByDay(366).catch(() => [])]).then(
           (v) => ({ status: 'fulfilled' as const, value: v }),
           (e) => ({ status: 'rejected' as const, reason: e })
         ),
@@ -3041,7 +3042,9 @@ export default function Home() {
       if (!localUsageReport || localUsageReport.status === 'unavailable') return;
       const ranges = await Promise.all(
         MODEL_RANGES.map(async (range) => {
-          const devin = exclude.includes('devin') ? [] : await getDevinUsageByModel(range.days);
+          const devin = exclude.includes('devin')
+            ? []
+            : await getDevinUsageByModel(range.days).catch(() => []);
           return [
             range.key,
             [

--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -40,15 +40,17 @@ repairs run as idempotent migrations guarded by feature flags. The groups:
 
 ## Persistence invariants
 
-- **Claude/Codex Usage accounting is externalized.** The bundled, pinned
+- **Claude/Codex/Grok Usage accounting is externalized.** The bundled, pinned
   `ccusage` sidecar reads agent transcripts locally and supplies the Usage
-  chart's Claude/Codex period, model, session, token-class, and cost data. The
+  chart's Claude/Codex/Grok period, model, session, token-class, and cost data. The
   desktop caches only a short-lived normalized snapshot; SQLite is not a second
   canonical usage ledger.
 - **Devin remains explicitly separate.** Upstream `ccusage` cannot access
   Devin's cloud-side usage, so the chart retains only CodeVetter's existing
-  Devin rows from SQLite. Provider remaining-usage and quota telemetry is a
-  separate metric family and is unchanged.
+  Devin rows from SQLite, queried independently so a Devin failure cannot hide
+  ccusage data. Provider remaining-usage and quota telemetry is a
+  separate metric family. Claude live quota resolves configured profile files
+  and Keychain candidates by freshest credential expiry.
 - **Legacy usage tables are retained, not maintained as production truth.**
   Historical Codex observation/coverage/projection tables remain in existing
   databases for non-destructive compatibility, but startup repair and ledger

--- a/docs/product/surfaces.md
+++ b/docs/product/surfaces.md
@@ -37,7 +37,7 @@ Source: `navItems` in `apps/desktop/src/components/sidebar.tsx`.
 
 | Tab | Route | Page (via `persistent-routes.tsx`) | What it does |
 |---|---|---|---|
-| Usage | `/` | `apps/desktop/src/pages/Home.tsx` | Local spend and token trends from bundled `ccusage` for Claude/Codex plus CodeVetter's Devin tracker; provider remaining-usage and quota telemetry stays separate and unchanged. |
+| Usage | `/` | `apps/desktop/src/pages/Home.tsx` | Local spend and token trends from bundled `ccusage` for Claude/Codex/Grok plus CodeVetter's separately queried Devin tracker; provider remaining-usage and quota telemetry stays separate and unchanged. |
 | Repo Unpack | `/unpack` | `apps/desktop/src/pages/RepoPage.tsx` | Whole-repo evidence-backed system brief. Tab `match`es `/unpack` and `/intel`. Scanner in `src-tauri/src/commands/unpack*.rs`; persisted to `repo_unpacked_reports`. See [architecture/repo-unpacked.md](../architecture/repo-unpacked.md). |
 | Review | `/review` | `apps/desktop/src/pages/QuickReview.tsx` | First change-checking stage: select an exact change, inspect source-qualified findings and coverage gaps, attach evidence, and export a local Agent PR X-Ray. Findings remain leads until executable evidence supports the decision. |
 | Testing | `/trex` | `apps/desktop/src/pages/TRex.tsx` | Runtime-evidence stage: resolve a human-described flow, exact PR/change, or bounded codebase portfolio into runnable tests; confirm the plan; then capture receipts. Direct preview, changed-capability verification, scenarios, and PR watchers remain available. See [trex-change-preview.md](./trex-change-preview.md). |


### PR DESCRIPTION
## What changed

- Resolve Claude live-usage credentials across configured profile files and macOS Keychain candidates by freshest expiry.
- Include Claude, Codex, and Grok in the pinned ccusage report while keeping Devin separately queried.
- Prevent Devin failures from hiding healthy ccusage data.
- Count cache-creation input in fresh/generated totals.
- Clarify local accounting versus credential-dependent live quota telemetry.
- Bump the desktop release version to v1.9.1.

## Root cause

CodeVetter unconditionally preferred the default Claude credentials file even when it was stale and a newer logged-in Keychain/profile credential existed. The ccusage migration also filtered out Grok, coupled Devin failures to the unified dashboard load, and omitted cache-creation tokens from fresh totals.

## Validation

- pnpm lint
- TypeScript check
- frontend unit tests and production build
- ccusage sidecar qualification
- cargo fmt and full cargo test: 944 passed, 23 ignored
- docs, complexity, change-size, and diff checks