### PR TITLE
chore(deps): group react updates and pin jscpd

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,22 @@ updates:
         patterns:
           - ccusage
           - '@ccusage/*'
+      # react and react-dom assert at runtime that they resolve to the exact
+      # same version, so they have to move in one PR. Bumping react alone
+      # leaves react-dom behind in the lockfile and every desktop test dies
+      # on "Incompatible React versions" before its first assertion.
+      react-runtime:
+        patterns:
+          - react
+          - react-dom
+          - '@types/react'
+          - '@types/react-dom'
+    ignore:
+      # jscpd is exact-pinned on purpose. quality:duplication compares its
+      # measured duplication against a fixed --threshold, so a patch bump that
+      # simply detects more clones fails the gate without any code changing.
+      # Upgrade it deliberately, alongside whatever threshold move it implies.
+      - dependency-name: jscpd
     labels:
       - dependencies
       - ccusage


### PR DESCRIPTION
Two dependabot rules, both prompted by PRs that could not merge this week.

## react — group it

#156 bumped `react` to `^19.2.8` and `@types/react` to `^19.2.18`, but left `react-dom` at `^19.1.0`. That range already admits 19.2.8, so dependabot saw nothing to update — while the lockfile still pinned `react-dom@19.2.5`. `react-dom` asserts at import time that both packages resolve to the exact same version, so the whole desktop suite died before its first assertion:

```
Error: Incompatible React versions: The "react" and "react-dom" packages must have the exact same version. Instead got:
  - react:      19.2.8
  - react-dom:  19.2.5
```

`@dependabot recreate` reproduced the identical split, so this is structural rather than a one-off. A `react-runtime` group puts `react`, `react-dom`, and both `@types` packages in one PR that either upgrades coherently or fails honestly.

## jscpd — ignore it

#155 bumped jscpd 5.0.14 → 5.0.16. The newer release measured **0.87% duplicated tokens** against the fixed `--threshold 0.81` in `quality:duplication`, so the gate failed (74 clones reported) without a single line of source changing.

`jscpd` was already exact-pinned (`"jscpd": "5.0.14"`, no caret) precisely because its output feeds a numeric gate — a measurement tool that drifts under you turns a quality gate into noise. This makes that intent explicit. Upgrading it stays a deliberate act, done alongside whatever threshold move or de-duplication it implies.

## Closing

#155 and #156 are being closed in favor of these rules.