### PR TITLE
feat(structural-graph): field-weighted IDF ranking, and a headless driver

### DIFF
--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -18,6 +18,12 @@ name = "codevetter"
 path = "src/bin/codevetter.rs"
 required-features = ["browser-agent"]
 
+# Headless driver for the shipped structural-graph engine. External benchmarks
+# measure the product through this instead of reimplementing extraction.
+[[bin]]
+name = "codevetter-graph"
+path = "src/bin/codevetter-graph.rs"
+
 [dependencies]
 tauri = { version = "2", features = ["devtools", "tray-icon", "image-png"] }
 tauri-plugin-dialog = "2"

--- a/apps/desktop/src-tauri/src/bin/codevetter-graph.rs
+++ b/apps/desktop/src-tauri/src/bin/codevetter-graph.rs
@@ -1,0 +1,153 @@
+//! Headless driver for CodeVetter's shipped structural-graph implementation.
+//!
+//! External benchmarks must measure the product, not a reimplementation. The
+//! Tauri command layer (`commands::structural_graph::api`) needs an `AppHandle`
+//! and a SQLite `DbState`, so this binary goes one level down and calls the same
+//! extraction engine, interchange serializer, and query planner the desktop app
+//! calls. Nothing here parses source, ranks nodes, or bounds a response on its
+//! own: every decision — including every refusal — comes from product code.
+//!
+//! usage:
+//!   codevetter-graph build <repo_path> <revision> <out_snapshot_path>
+//!   codevetter-graph query <snapshot_path> <query_string> <node_limit>
+
+use codevetter_desktop::commands::structural_graph::extract::BundledTreeSitterEngine;
+use codevetter_desktop::commands::structural_graph::interchange::{
+    export_json, import_codevetter_json,
+};
+use codevetter_desktop::commands::structural_graph::query::{search_page, GraphQueryFilter};
+use codevetter_desktop::commands::structural_graph::types::{
+    StructuralGraphBuildInput, StructuralGraphCancellation, StructuralGraphEngine,
+    StructuralGraphProgress,
+};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const USAGE: &str = concat!(
+    "usage:\n",
+    "  codevetter-graph build <repo_path> <revision> <out_snapshot_path>\n",
+    "  codevetter-graph query <snapshot_path> <query_string> <node_limit>"
+);
+
+fn main() {
+    if let Err(error) = run(std::env::args().skip(1).collect()) {
+        eprintln!("codevetter-graph: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run(arguments: Vec<String>) -> Result<(), String> {
+    match arguments.split_first() {
+        Some((command, rest)) if command == "build" => match rest {
+            [repo_path, revision, out_path] => build(repo_path, revision, out_path),
+            _ => Err(format!("build takes 3 arguments\n{USAGE}")),
+        },
+        Some((command, rest)) if command == "query" => match rest {
+            [snapshot_path, query_text, node_limit] => query(snapshot_path, query_text, node_limit),
+            _ => Err(format!("query takes 3 arguments\n{USAGE}")),
+        },
+        Some((command, _)) if command == "--help" || command == "-h" => {
+            println!("{USAGE}");
+            Ok(())
+        }
+        _ => Err(USAGE.to_string()),
+    }
+}
+
+/// Builds a full structural graph for the checkout at `repo_path` and writes the
+/// product's own JSON interchange document to `out_path`.
+///
+/// `revision` is the identity stamped into `snapshot.repo_head`. Extraction
+/// itself always reads the working tree at `repo_path` (that is what
+/// `BundledTreeSitterEngine` does), so a caller that passes a revision the
+/// checkout is not actually at would mislabel the snapshot. That mismatch is
+/// reported on stderr rather than silently accepted.
+fn build(repo_path: &str, revision: &str, out_path: &str) -> Result<(), String> {
+    let root = canonical_repo_path(repo_path)?;
+    if let Some(head) = git_head(&root) {
+        if head != revision && !head.starts_with(revision) {
+            eprintln!(
+                "codevetter-graph: warning: indexing working tree at {head} but stamping revision {revision}"
+            );
+        }
+    } else {
+        eprintln!("codevetter-graph: warning: {} has no readable git HEAD; stamping revision {revision} unverified", root.display());
+    }
+
+    let input = StructuralGraphBuildInput::full(root, Some(revision.to_string()));
+    let cancellation = StructuralGraphCancellation::default();
+    let progress = |_: StructuralGraphProgress| {};
+    let snapshot = BundledTreeSitterEngine
+        .build(&input, &cancellation, &progress)
+        .map_err(|error| format!("build failed: {error}"))?;
+
+    let document = export_json(&snapshot)?;
+    let bytes = document.len();
+    std::fs::write(out_path, &document)
+        .map_err(|error| format!("cannot write {out_path}: {error}"))?;
+
+    // Reported so a caller can attribute a later import refusal to scale rather
+    // than corruption. The limits themselves stay in the product's interchange
+    // module; this only measures.
+    eprintln!(
+        "codevetter-graph: snapshot={} files={} indexed={} nodes={} edges={} bytes={} truncated={}",
+        snapshot.id,
+        snapshot.files.len(),
+        snapshot.coverage.indexed_files,
+        snapshot.nodes.len(),
+        snapshot.edges.len(),
+        bytes,
+        snapshot.truncated,
+    );
+    Ok(())
+}
+
+/// Loads a snapshot through the product's own importer (which enforces the
+/// shipped size and node bounds) and prints `query::search_page` verbatim.
+fn query(snapshot_path: &str, query_text: &str, node_limit: &str) -> Result<(), String> {
+    let limit = node_limit
+        .parse::<usize>()
+        .map_err(|error| format!("node_limit must be a positive integer: {error}"))?;
+    let document = std::fs::read_to_string(snapshot_path)
+        .map_err(|error| format!("cannot read {snapshot_path}: {error}"))?;
+    let snapshot = import_codevetter_json(&document)?;
+    let result = search_page(
+        &snapshot,
+        query_text,
+        &GraphQueryFilter::default(),
+        Some(limit),
+        None,
+    )?;
+    let encoded = serde_json::to_string(&result)
+        .map_err(|error| format!("cannot encode search result: {error}"))?;
+    println!("{encoded}");
+    Ok(())
+}
+
+fn canonical_repo_path(repo_path: &str) -> Result<PathBuf, String> {
+    let trimmed = repo_path.trim();
+    if trimmed.is_empty() {
+        return Err("repository path is required".to_string());
+    }
+    let path = PathBuf::from(trimmed)
+        .canonicalize()
+        .map_err(|error| format!("cannot resolve repository path: {error}"))?;
+    if !path.is_dir() {
+        return Err("repository path is not a directory".to_string());
+    }
+    Ok(path)
+}
+
+fn git_head(repo_path: &Path) -> Option<String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repo_path)
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let head = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!head.is_empty()).then_some(head)
+}

--- a/apps/desktop/src-tauri/src/commands/structural_graph/contracts.rs
+++ b/apps/desktop/src-tauri/src/commands/structural_graph/contracts.rs
@@ -151,6 +151,9 @@ fn extract_sql(line_number: usize, line: &str, lower: &str, output: &mut Contrac
             }
         }
     }
+    if !reads_as_sql(lower) {
+        return;
+    }
     for (marker, edge_kind) in [
         ("from", "reads_from"),
         ("join", "reads_from"),
@@ -778,6 +781,34 @@ fn sql_object_after(line: &str, object_kind: &str) -> Option<String> {
             )
         })
         .map(|value| clean_sql_identifier(value))
+}
+
+/// Whether a line is plausibly SQL rather than prose that happens to contain the
+/// word "from".
+///
+/// The reference markers below are bare English words, and this extractor runs
+/// over every line of every metadata text file — Markdown, JSON, YAML. Without
+/// this guard, "extracted from Fleet Workspace" in a JSON `notes` string
+/// produced a `db_object_reference` node labelled `Fleet`, and "from the
+/// ios-landings factory" produced one labelled `the`. On one real config file
+/// eight of its nine nodes were this kind of noise. Requiring an unambiguous
+/// multi-word SQL marker keeps embedded queries like
+/// `db.query("SELECT * FROM users")` while dropping prose.
+fn reads_as_sql(lower: &str) -> bool {
+    const STATEMENTS: &[&str] = &[
+        "select ",
+        "insert into",
+        "delete from",
+        "create table",
+        "create view",
+        "create index",
+        "create or replace",
+        "alter table",
+        "truncate table",
+        "merge into",
+    ];
+    STATEMENTS.iter().any(|marker| lower.contains(marker))
+        || (lower.contains("update ") && lower.contains(" set "))
 }
 
 fn sql_references_after(line: &str, marker: &str) -> Vec<String> {

--- a/apps/desktop/src-tauri/src/commands/structural_graph/extract/files.rs
+++ b/apps/desktop/src-tauri/src/commands/structural_graph/extract/files.rs
@@ -293,6 +293,16 @@ fn is_metadata_text_path(path: &Path) -> bool {
             | "gql"
     ) || matches!(
         name.as_str(),
-        "dockerfile" | "makefile" | "justfile" | "procfile"
+        // Dotfiles have no extension, so they have to be named. These are
+        // key/value configuration in every practical repository; `.gitignore`
+        // and `.gitattributes` are deliberately absent because they are pattern
+        // lists, not entries.
+        "dockerfile"
+            | "makefile"
+            | "justfile"
+            | "procfile"
+            | ".gitmodules"
+            | ".editorconfig"
+            | ".npmrc"
     )
 }

--- a/apps/desktop/src-tauri/src/commands/structural_graph/extract/metadata.rs
+++ b/apps/desktop/src-tauri/src/commands/structural_graph/extract/metadata.rs
@@ -27,6 +27,7 @@ pub(super) fn extract_metadata_signals(
     }
 
     let lines = source.lines().collect::<Vec<_>>();
+    let mut config_entries = 0usize;
     for (index, line) in lines.iter().enumerate() {
         let trimmed = line.trim();
         let lower = trimmed.to_ascii_lowercase();
@@ -157,6 +158,28 @@ pub(super) fn extract_metadata_signals(
                 nodes,
                 edges,
             );
+        }
+
+        if is_structured_config_path(&lower_path) && !is_lockfile_path(&lower_path) {
+            for label in config_entry_labels(trimmed) {
+                if config_entries >= MAX_CONFIG_ENTRIES_PER_FILE {
+                    break;
+                }
+                config_entries += 1;
+                push_metadata_signal(
+                    path,
+                    source,
+                    file_id,
+                    language,
+                    line_number,
+                    "config_entry",
+                    &label,
+                    "declares",
+                    "configuration entry",
+                    nodes,
+                    edges,
+                );
+            }
         }
 
         if lower_path.ends_with(".md") || lower_path.ends_with(".mdx") {
@@ -357,6 +380,171 @@ pub(super) fn attach_metadata_to_syntax_owners(
             ));
         }
     }
+}
+
+/// A structured-configuration file contributed nothing searchable before this:
+/// its only node was the file itself, labelled with its own path. A query about
+/// what a config file *says* — a project id, a deploy target, a feature flag —
+/// therefore could not retrieve the file at any budget, which read as a ranking
+/// failure and was really a coverage gap. Each key/value entry now becomes one
+/// node anchored at its line.
+const MAX_CONFIG_ENTRIES_PER_FILE: usize = 400;
+
+fn is_structured_config_path(lower_path: &str) -> bool {
+    let name = lower_path.rsplit('/').next().unwrap_or(lower_path);
+    [".json", ".jsonc", ".yaml", ".yml", ".toml", ".ini"]
+        .iter()
+        .any(|extension| lower_path.ends_with(extension))
+        || matches!(name, ".gitmodules" | ".editorconfig" | ".npmrc")
+}
+
+/// A lockfile is a resolver's output, not authored configuration: thousands of
+/// dependency entries nobody asks a structural question about. One `pnpm-lock`
+/// alone contributed 213 entries on a measured repository.
+fn is_lockfile_path(lower_path: &str) -> bool {
+    let name = lower_path.rsplit('/').next().unwrap_or(lower_path);
+    matches!(
+        name,
+        "package-lock.json"
+            | "pnpm-lock.yaml"
+            | "yarn.lock"
+            | "npm-shrinkwrap.json"
+            | "cargo.lock"
+            | "poetry.lock"
+            | "composer.lock"
+            | "gemfile.lock"
+            | "bun.lock"
+            | "bun.lockb"
+    )
+}
+
+/// Every key/value entry on one line, as `key: value` (or a bare `key` when the
+/// value is structural or uninteresting).
+///
+/// A line can carry several entries — `{ "id": "x", "deployKind": "worker" }` —
+/// so the line is split on commas first. Fragments that are not a single
+/// key/value entry yield nothing, which is how prose, punctuation-only lines and
+/// continuation values are left alone.
+fn config_entry_labels(trimmed: &str) -> Vec<String> {
+    trimmed
+        .split(',')
+        .filter_map(config_entry_label)
+        .collect()
+}
+
+/// `"deployKind": "worker"` -> `deployKind: worker`; `tier: parked` -> the same
+/// shape; `name = "x"` -> `name: x`; an object or array opener yields the bare
+/// key.
+fn config_entry_label(fragment: &str) -> Option<String> {
+    // Tested before the brackets are stripped, since `[section]` is the bracket.
+    if let Some(section) = ini_section_label(fragment.trim()) {
+        return Some(section);
+    }
+    let line = fragment.trim().trim_start_matches(['{', '[', '-']).trim();
+    let (key, rest) = split_config_key(line)?;
+    let value = rest
+        .trim()
+        .trim_start_matches(':')
+        .trim()
+        .trim_end_matches([',', '}', ']'])
+        .trim()
+        .trim_matches(['"', '\'', '`'])
+        .trim();
+    // Structural punctuation only announces that the value continues elsewhere.
+    let structural = value.is_empty()
+        || value.len() > 120
+        || value.contains(['{', '}', '[', ']'])
+        || matches!(value, "|" | ">");
+    let value = if structural || !value_is_distinctive(value) {
+        ""
+    } else {
+        value
+    };
+    Some(if value.is_empty() {
+        key.to_string()
+    } else {
+        format!("{key}: {value}")
+    })
+}
+
+/// `[submodule "engines/reel-maker"]` -> `submodule: engines/reel-maker`;
+/// `[tool.ruff]` -> `tool.ruff`.
+///
+/// A section header names what the entries under it configure, and it is often
+/// the only place the noun a question uses appears at all — a `.gitmodules` file
+/// says "submodule" nowhere else.
+fn ini_section_label(line: &str) -> Option<String> {
+    let inner = line.strip_prefix('[')?.strip_suffix(']')?.trim();
+    if inner.is_empty() || inner.len() > 160 {
+        return None;
+    }
+    let (name, rest) = match inner.split_once(char::is_whitespace) {
+        Some((name, rest)) => (name.trim(), rest.trim().trim_matches(['"', '\'', '`']).trim()),
+        None => (inner, ""),
+    };
+    if name.is_empty() {
+        return None;
+    }
+    Some(if rest.is_empty() {
+        name.to_string()
+    } else {
+        format!("{name}: {rest}")
+    })
+}
+
+/// Whether a config value is the kind of thing a question is ever asked about.
+///
+/// Names are: `"cfProject": "tinygpt"`, `"deployKind": "worker"`. Flags,
+/// counts, versions, dates and hashes are not — and folding them into a
+/// key-only node collapses the hundreds of `"deployed": true` lines in a large
+/// registry onto one deduplicated node instead of one node per line. Without
+/// this, config entries cost roughly a fifth of a snapshot on a
+/// configuration-heavy repository and pushed it back over the import ceiling.
+fn value_is_distinctive(value: &str) -> bool {
+    if matches!(
+        value.to_ascii_lowercase().as_str(),
+        "true" | "false" | "null" | "nil" | "none" | "yes" | "no" | "on" | "off"
+    ) {
+        return false;
+    }
+    let mut letters = 0usize;
+    let mut digits = 0usize;
+    for character in value.chars() {
+        if character.is_ascii_digit() {
+            digits += 1;
+        } else if character.is_alphabetic() {
+            letters += 1;
+        }
+    }
+    // Versions (`1.2.3`), dates (`2026-08-22`), counts and hex digests are all
+    // digit-dominated; a name is not.
+    letters > digits && letters >= 2
+}
+
+/// Splits a leading quoted or bare key from its separator and remainder.
+fn split_config_key(line: &str) -> Option<(&str, &str)> {
+    let (key, rest) = match line.strip_prefix('"') {
+        Some(quoted) => {
+            let end = quoted.find('"')?;
+            (&quoted[..end], &quoted[end + 1..])
+        }
+        None => {
+            let end = line.find([':', '='])?;
+            (line[..end].trim(), &line[end..])
+        }
+    };
+    let rest = rest.trim_start();
+    if !rest.starts_with(':') && !rest.starts_with('=') {
+        return None;
+    }
+    let key = key.trim();
+    let plausible = !key.is_empty()
+        && key.len() <= 80
+        && key
+            .chars()
+            .all(|character| character.is_alphanumeric() || matches!(character, '_' | '-' | '.' | '$' | '/'))
+        && key.chars().any(char::is_alphanumeric);
+    plausible.then_some((key, rest.get(1..).unwrap_or_default()))
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/apps/desktop/src-tauri/src/commands/structural_graph/extract/tests.rs
+++ b/apps/desktop/src-tauri/src/commands/structural_graph/extract/tests.rs
@@ -661,6 +661,96 @@ fn incremental_graph_facts_are_identical_to_a_clean_rebuild() {
     fs::remove_dir_all(root).expect("remove fixture repo");
 }
 
+#[test]
+fn structured_config_files_contribute_searchable_entries_not_just_their_own_path() {
+    let source = r#"{
+  "_meta": { "purpose": "single source of truth for fleet projects" },
+  "projects": [
+    { "id": "tinygpt", "cfProject": "tinygpt", "deployKind": "worker", "deployed": true },
+    { "id": "reel-pipeline", "cfProject": "reel-pipeline", "deployKind": "pages", "deployed": true }
+  ],
+  "schemaVersion": 3
+}
+"#;
+    let contribution = extract_blob("ops/config/projects.json", source.as_bytes(), 1 << 20);
+    let entries = contribution
+        .nodes
+        .iter()
+        .filter(|node| node.kind == "config_entry")
+        .map(|node| node.label.as_str())
+        .collect::<Vec<_>>();
+    // The values a question actually names are retrievable.
+    for expected in [
+        "id: tinygpt",
+        "id: reel-pipeline",
+        "deployKind: worker",
+        "deployKind: pages",
+    ] {
+        assert!(entries.contains(&expected), "missing {expected:?} in {entries:?}");
+    }
+    // Flags and counts collapse onto one deduplicated key rather than one node
+    // per line, and every entry is anchored in the file.
+    assert_eq!(entries.iter().filter(|label| **label == "deployed").count(), 1);
+    assert!(!entries.iter().any(|label| label.starts_with("schemaVersion:")));
+    assert!(contribution
+        .nodes
+        .iter()
+        .filter(|node| node.kind == "config_entry")
+        .all(|node| node.path.as_deref() == Some("ops/config/projects.json")
+            && node.sources.iter().all(|source| source.start_line.is_some())));
+}
+
+#[test]
+fn ini_style_dotfile_config_is_indexed_by_section_and_entry() {
+    let source = "[submodule \"engines/reel-maker\"]\n\tpath = engines/reel-maker\n\turl = https://github.com/example/reel-maker.git\n";
+    let contribution = extract_blob(".gitmodules", source.as_bytes(), 1 << 20);
+    let entries = contribution
+        .nodes
+        .iter()
+        .filter(|node| node.kind == "config_entry")
+        .map(|node| node.label.as_str())
+        .collect::<Vec<_>>();
+    assert!(
+        entries.contains(&"submodule: engines/reel-maker"),
+        "section header not indexed: {entries:?}"
+    );
+    assert!(entries.contains(&"path: engines/reel-maker"), "{entries:?}");
+}
+
+#[test]
+fn prose_that_merely_contains_sql_words_does_not_become_a_database_reference() {
+    let prose = r#"{
+  "notes": "Canonical source was extracted from Fleet Workspace; the landing is served from the ios-landings factory.",
+  "detail": "Rolled into main after review."
+}
+"#;
+    let contribution = extract_blob("ops/config/notes.json", prose.as_bytes(), 1 << 20);
+    let references = contribution
+        .nodes
+        .iter()
+        .filter(|node| node.kind == "db_object_reference")
+        .map(|node| node.label.as_str())
+        .collect::<Vec<_>>();
+    assert!(
+        references.is_empty(),
+        "prose produced database references: {references:?}"
+    );
+
+    // A real statement, embedded in code, still resolves.
+    let query = "const rows = await db.query(\"SELECT id FROM accounts JOIN sessions ON sessions.account_id = accounts.id\");";
+    let indexed = extract_blob("src/db.ts", query.as_bytes(), 1 << 20);
+    let referenced = indexed
+        .nodes
+        .iter()
+        .filter(|node| node.kind == "db_object_reference")
+        .map(|node| node.label.as_str())
+        .collect::<Vec<_>>();
+    assert!(
+        referenced.contains(&"accounts") && referenced.contains(&"sessions"),
+        "embedded SQL lost its table references: {referenced:?}"
+    );
+}
+
 fn run_git(root: &Path, arguments: &[&str]) {
     let status = Command::new("git")
         .arg("-C")

--- a/apps/desktop/src-tauri/src/commands/structural_graph/interchange.rs
+++ b/apps/desktop/src-tauri/src/commands/structural_graph/interchange.rs
@@ -250,6 +250,16 @@ pub fn import_node_link_json(
     })
 }
 
+/// Serializes a snapshot as the CodeVetter interchange document.
+///
+/// Encoded compactly on purpose. `import_codevetter_json` enforces
+/// `MAX_IMPORT_BYTES` against the raw document length, and on real repositories
+/// roughly a third of a pretty-printed graph is indentation whitespace
+/// (measured: gin 17.8 MiB -> 11.4 MiB, fastify 29.5 MiB -> 19.7 MiB). Spending
+/// a third of the import budget on padding shrank the repository size the
+/// product could round-trip for no reader's benefit: `export_markdown` is the
+/// human-readable rendering, and `export_public_package` stays indented because
+/// it is a small sanitized artifact people read directly.
 pub fn export_json(snapshot: &StructuralGraphSnapshot) -> Result<String, String> {
     #[derive(Serialize)]
     struct Export<'a> {
@@ -258,7 +268,7 @@ pub fn export_json(snapshot: &StructuralGraphSnapshot) -> Result<String, String>
         exported_at: String,
         snapshot: &'a StructuralGraphSnapshot,
     }
-    serde_json::to_string_pretty(&Export {
+    serde_json::to_string(&Export {
         format: "codevetter-structural-graph",
         schema_version: STRUCTURAL_GRAPH_SCHEMA_VERSION,
         exported_at: Utc::now().to_rfc3339(),
@@ -775,6 +785,27 @@ mod tests {
         assert!(markdown.contains("`src/api.py`:1"));
         let round_trip = import_codevetter_json(&json).expect("round trip");
         assert_eq!(round_trip, preview.snapshot);
+    }
+
+    #[test]
+    fn codevetter_json_export_spends_no_import_budget_on_indentation() {
+        let preview = import_node_link_json("/repo", FIXTURE).expect("import");
+        let json = export_json(&preview.snapshot).expect("json export");
+        // Whitespace inside string values is legitimate; newline-plus-indent is
+        // the pretty printer's padding, and it is what used to consume roughly a
+        // third of MAX_IMPORT_BYTES on real repositories.
+        assert!(!json.contains("\n  "), "export must not be indented");
+        let pretty = serde_json::to_string_pretty(&serde_json::from_str::<serde_json::Value>(&json).expect("valid json")).expect("pretty");
+        assert!(
+            json.len() < pretty.len(),
+            "compact export ({} bytes) must be smaller than the indented form ({} bytes)",
+            json.len(),
+            pretty.len()
+        );
+        assert_eq!(
+            import_codevetter_json(&json).expect("compact round trip"),
+            preview.snapshot
+        );
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/commands/structural_graph/query/index.rs
+++ b/apps/desktop/src-tauri/src/commands/structural_graph/query/index.rs
@@ -1,5 +1,31 @@
 use super::*;
 
+/// Highest score any hit can carry. Scores are `u32` on a fixed scale so paging
+/// and cursors stay byte-stable across processes, and **higher means more
+/// relevant** — the ordinary convention for a field called `score`.
+pub(super) const MAX_SCORE: u32 = 999_999;
+/// Tier floors. A tier is chosen by *how* the node matched; the lexical
+/// relevance of the same node is then added on top, so nodes inside one tier are
+/// still ordered against each other instead of tying at a single value.
+const TIER_ID: u32 = 900_000;
+const TIER_QUALIFIED: u32 = 800_000;
+const TIER_PATH: u32 = 700_000;
+const TIER_LABEL: u32 = 600_000;
+const TIER_QUALIFIED_CONTAINS: u32 = 500_000;
+const TIER_PATH_CONTAINS: u32 = 400_000;
+const TIER_LABEL_CONTAINS: u32 = 300_000;
+const TIER_LEXICAL: u32 = 0;
+const TIER_SPAN: f64 = 99_999.0;
+
+/// Field weights for lexical matching. A term found in a node's own name says
+/// far more about the node than the same term found in its surrounding detail
+/// text, and the old flat "matched or not" score could not express that.
+const WEIGHT_LABEL: f64 = 1.0;
+const WEIGHT_QUALIFIED: f64 = 0.75;
+const WEIGHT_PATH: f64 = 0.6;
+const WEIGHT_KIND: f64 = 0.25;
+const WEIGHT_DETAIL: f64 = 0.4;
+
 pub(super) fn normalize(value: &str) -> String {
     value.trim().replace('\\', "/").to_lowercase()
 }
@@ -14,76 +40,279 @@ pub(super) fn edge_matches_filter(edge: &StructuralGraphEdge, filter: &GraphQuer
         && (filter.trust.is_empty() || filter.trust.contains(&edge.trust))
 }
 
+/// Which whole-value comparison, if any, the node satisfied against the raw
+/// query string. Returns the tier floor plus the `matched_by` label.
 pub(super) fn rank_node(node: &StructuralGraphNode, needle: &str) -> Option<(u32, String)> {
     let id = normalize(&node.id);
     let qualified = node.qualified_name.as_deref().map(normalize);
     let path = node.path.as_deref().map(normalize);
     let label = normalize(&node.label);
     if id == needle {
-        Some((0, "id".to_string()))
+        Some((TIER_ID, "id".to_string()))
     } else if qualified.as_deref() == Some(needle) {
-        Some((1, "qualified_name".to_string()))
+        Some((TIER_QUALIFIED, "qualified_name".to_string()))
     } else if path.as_deref() == Some(needle) {
-        Some((2, "path".to_string()))
+        Some((TIER_PATH, "path".to_string()))
     } else if label == needle {
-        Some((3, "label".to_string()))
+        Some((TIER_LABEL, "label".to_string()))
     } else if qualified
         .as_deref()
         .is_some_and(|value| value.contains(needle))
     {
-        Some((10, "qualified_name_contains".to_string()))
+        Some((
+            TIER_QUALIFIED_CONTAINS,
+            "qualified_name_contains".to_string(),
+        ))
     } else if path.as_deref().is_some_and(|value| value.contains(needle)) {
-        Some((11, "path_contains".to_string()))
+        Some((TIER_PATH_CONTAINS, "path_contains".to_string()))
     } else if label.contains(needle) {
-        Some((12, "label_contains".to_string()))
+        Some((TIER_LABEL_CONTAINS, "label_contains".to_string()))
     } else {
         None
     }
 }
 
-pub(super) fn lexical_tokens(query: &str) -> Vec<String> {
-    const STOP_WORDS: &[&str] = &[
-        "a", "an", "and", "are", "does", "for", "from", "how", "in", "is", "of", "on", "or", "the",
-        "to", "what", "when", "where", "which", "why", "with",
-    ];
-    let mut tokens = query
-        .split(|character: char| {
-            !(character.is_alphanumeric()
-                || matches!(character, '_' | '-' | '.' | '/' | ':' | '\\'))
-        })
-        .map(str::trim)
-        .filter(|token| token.len() >= 2 && !STOP_WORDS.contains(token))
-        .map(str::to_string)
-        .collect::<Vec<_>>();
-    tokens.sort();
-    tokens.dedup();
-    tokens
+const STOP_WORDS: &[&str] = &[
+    "a", "an", "and", "are", "does", "for", "from", "how", "in", "is", "of", "on", "or", "the",
+    "to", "what", "when", "where", "which", "why", "with",
+];
+
+fn is_token_char(character: char) -> bool {
+    character.is_alphanumeric() || matches!(character, '_' | '-' | '.' | '/' | ':' | '\\')
 }
 
+/// Splits one raw token into every key a query might plausibly arrive as.
+///
+/// The whole token is kept, plus each path/qualifier segment, plus each
+/// camelCase, snake_case and letter/digit word inside those segments. Case is
+/// read from the *raw* token, so this has to run before lowercasing: once
+/// `FullPath` becomes `fullpath` the word boundary is gone. Candidate generation
+/// used to key on whole tokens only while the ranker scored by substring, so a
+/// node whose only match was inside a token — `path` inside `FullPath`, or
+/// `context` inside `context.go` — could be scored but never retrieved. That
+/// mismatch, not the requested limit, was what capped recall.
+fn token_keys(raw: &str) -> Vec<String> {
+    let mut keys = Vec::new();
+    let mut push = |value: String| {
+        if value.len() >= 2 && !STOP_WORDS.contains(&value.as_str()) && !keys.contains(&value) {
+            keys.push(value);
+        }
+    };
+    let whole = raw.to_lowercase();
+    push(whole.clone());
+    let segments = raw
+        .split(['_', '-', '.', '/', ':', '\\'])
+        .filter(|segment| !segment.is_empty())
+        .collect::<Vec<_>>();
+    for segment in &segments {
+        if segments.len() > 1 {
+            push(segment.to_lowercase());
+        }
+        for word in case_words(segment) {
+            push(word);
+        }
+    }
+    keys
+}
+
+/// `parseURLQuery` -> `parse`, `url`, `query`; `sha256Sum` -> `sha`, `256`, `sum`.
+fn case_words(segment: &str) -> Vec<String> {
+    let characters = segment.chars().collect::<Vec<_>>();
+    let mut words = Vec::new();
+    let mut current = String::new();
+    for (position, character) in characters.iter().copied().enumerate() {
+        let previous = position.checked_sub(1).map(|index| characters[index]);
+        let next = characters.get(position + 1).copied();
+        let boundary = match previous {
+            None => false,
+            Some(previous) => {
+                (character.is_uppercase() && previous.is_lowercase())
+                    || (character.is_numeric() != previous.is_numeric())
+                    || (character.is_uppercase()
+                        && previous.is_uppercase()
+                        && next.is_some_and(char::is_lowercase))
+            }
+        };
+        if boundary && !current.is_empty() {
+            words.push(std::mem::take(&mut current));
+        }
+        current.push(character);
+    }
+    if !current.is_empty() {
+        words.push(current);
+    }
+    if words.len() < 2 {
+        return Vec::new();
+    }
+    words
+        .into_iter()
+        .map(|word| word.to_lowercase())
+        .filter(|word| word.len() >= 2)
+        .collect()
+}
+
+fn index_keys(text: &str) -> Vec<String> {
+    let mut keys = Vec::new();
+    for raw in text.split(|character: char| !is_token_char(character)) {
+        let raw = raw.trim();
+        if raw.is_empty() {
+            continue;
+        }
+        for key in token_keys(raw) {
+            keys.push(key);
+        }
+    }
+    keys.sort();
+    keys.dedup();
+    keys
+}
+
+/// One search term plus the weight it carries. Terms nothing in the graph
+/// contains are dropped: a pull-request number or a verb like `add` that no node
+/// mentions would otherwise sit in the denominator and flatten the difference
+/// between the terms that do discriminate.
+#[derive(Debug)]
+pub(super) struct LexicalTerm {
+    text: String,
+    weight: f64,
+}
+
+#[derive(Debug, Default)]
+pub(super) struct LexicalQuery {
+    terms: Vec<LexicalTerm>,
+    total_weight: f64,
+}
+
+impl LexicalQuery {
+    pub(super) fn is_empty(&self) -> bool {
+        self.terms.is_empty()
+    }
+}
+
+/// Expands the raw query into weighted terms using the snapshot's own term
+/// frequencies, so a term that half the graph mentions cannot outvote one only a
+/// handful of nodes mention.
+pub(super) fn lexical_query(query: &str, index: &StructuralGraphQueryIndex) -> LexicalQuery {
+    let node_count = index.node_count.max(1) as f64;
+    let mut terms = Vec::<LexicalTerm>::new();
+    for raw in query.split(|character: char| !is_token_char(character)) {
+        let raw = raw.trim();
+        if raw.is_empty() {
+            continue;
+        }
+        for text in token_keys(raw) {
+            if terms.iter().any(|term| term.text == text) {
+                continue;
+            }
+            let frequency = index.tokens.get(&text).map_or(0, Vec::len);
+            if frequency == 0 {
+                continue;
+            }
+            let weight = (1.0 + node_count / (1.0 + frequency as f64)).ln();
+            terms.push(LexicalTerm { text, weight });
+        }
+    }
+    terms.sort_by(|left, right| {
+        right
+            .weight
+            .total_cmp(&left.weight)
+            .then_with(|| left.text.cmp(&right.text))
+    });
+    let total_weight = terms.iter().map(|term| term.weight).sum();
+    LexicalQuery {
+        terms,
+        total_weight,
+    }
+}
+
+/// How well `field` satisfies `term`: whole value, whole word, word prefix, or
+/// bare substring. Distinguishing these is what lets many weakly-matching nodes
+/// be ordered instead of tying.
+fn field_hit(field: &str, term: &str) -> f64 {
+    if field.is_empty() {
+        return 0.0;
+    }
+    if field == term {
+        return 1.0;
+    }
+    let mut best = 0.0f64;
+    let bytes = field.as_bytes();
+    let mut from = 0usize;
+    while let Some(offset) = field[from..].find(term) {
+        let start = from + offset;
+        let end = start + term.len();
+        let boundary_before = start == 0 || !bytes[start - 1].is_ascii_alphanumeric();
+        let boundary_after = end == field.len() || !bytes[end].is_ascii_alphanumeric();
+        let quality = match (boundary_before, boundary_after) {
+            (true, true) => 0.9,
+            (true, false) => 0.65,
+            _ => 0.4,
+        };
+        best = best.max(quality);
+        if best >= 0.9 {
+            break;
+        }
+        from = start + term.len().max(1);
+        if from >= field.len() {
+            break;
+        }
+    }
+    best
+}
+
+/// Lexical relevance in `[0, 1]`: the weighted share of query terms this node
+/// satisfies, each term scored in the best-weighted field that contains it.
+pub(super) fn lexical_relevance(node: &StructuralGraphNode, query: &LexicalQuery) -> f64 {
+    if query.total_weight <= 0.0 {
+        return 0.0;
+    }
+    let label = normalize(&node.label);
+    let qualified = node.qualified_name.as_deref().map(normalize);
+    let path = node.path.as_deref().map(normalize);
+    let kind = normalize(&node.kind);
+    let detail = node.detail.as_deref().map(normalize);
+    let mut earned = 0.0f64;
+    for term in &query.terms {
+        let mut best = WEIGHT_LABEL * field_hit(&label, &term.text);
+        for (weight, field) in [
+            (WEIGHT_QUALIFIED, qualified.as_deref()),
+            (WEIGHT_PATH, path.as_deref()),
+            (WEIGHT_DETAIL, detail.as_deref()),
+        ] {
+            if let Some(field) = field {
+                best = best.max(weight * field_hit(field, &term.text));
+            }
+        }
+        best = best.max(WEIGHT_KIND * field_hit(&kind, &term.text));
+        earned += term.weight * best;
+    }
+    (earned / query.total_weight).clamp(0.0, 1.0)
+}
+
+/// Folds a tier floor and a lexical relevance into the single `u32` a hit
+/// reports. Higher is more relevant.
+pub(super) fn tiered_score(tier: u32, relevance: f64) -> u32 {
+    tier.saturating_add((relevance.clamp(0.0, 1.0) * TIER_SPAN).round() as u32)
+        .min(MAX_SCORE)
+}
+
+/// Score for a node that matched nothing as a whole value but does match query
+/// terms. `None` when no term is present at all, so non-matching nodes stay out
+/// of the result rather than arriving with a zero score.
 pub(super) fn rank_question_tokens(
     node: &StructuralGraphNode,
-    tokens: &[String],
+    query: &LexicalQuery,
 ) -> Option<(u32, String)> {
-    if tokens.is_empty() {
+    if query.is_empty() {
         return None;
     }
-    let haystack = normalize(&format!(
-        "{} {} {} {} {}",
-        node.label,
-        node.qualified_name.as_deref().unwrap_or_default(),
-        node.path.as_deref().unwrap_or_default(),
-        node.kind,
-        node.detail.as_deref().unwrap_or_default()
-    ));
-    let matched = tokens
-        .iter()
-        .filter(|token| haystack.contains(token.as_str()))
-        .count();
-    if matched == 0 {
-        return None;
-    }
-    let missing = tokens.len() - matched;
-    Some((20 + missing as u32 * 5, "lexical_question".to_string()))
+    let relevance = lexical_relevance(node, query);
+    (relevance > 0.0).then(|| {
+        (
+            tiered_score(TIER_LEXICAL, relevance),
+            "lexical_question".to_string(),
+        )
+    })
 }
 
 pub(super) fn node_map(snapshot: &StructuralGraphSnapshot) -> HashMap<&str, &StructuralGraphNode> {
@@ -101,7 +330,10 @@ pub(super) fn query_index(snapshot: &StructuralGraphSnapshot) -> Arc<StructuralG
             return Arc::clone(index);
         }
     }
-    let mut index = StructuralGraphQueryIndex::default();
+    let mut index = StructuralGraphQueryIndex {
+        node_count: snapshot.nodes.len(),
+        ..StructuralGraphQueryIndex::default()
+    };
     for (ordinal, node) in snapshot.nodes.iter().enumerate() {
         for value in [
             Some(node.id.as_str()),
@@ -118,15 +350,15 @@ pub(super) fn query_index(snapshot: &StructuralGraphSnapshot) -> Arc<StructuralG
                 .or_default()
                 .push(ordinal);
         }
-        let searchable = normalize(&format!(
+        let searchable = format!(
             "{} {} {} {} {}",
             node.label,
             node.qualified_name.as_deref().unwrap_or_default(),
             node.path.as_deref().unwrap_or_default(),
             node.kind,
             node.detail.as_deref().unwrap_or_default()
-        ));
-        for token in lexical_tokens(&searchable) {
+        );
+        for token in index_keys(&searchable) {
             index.tokens.entry(token).or_default().push(ordinal);
         }
     }
@@ -144,11 +376,77 @@ pub(super) fn query_index(snapshot: &StructuralGraphSnapshot) -> Arc<StructuralG
     index
 }
 
+/// Candidate ordinals for a query: every node carrying any query term, plus any
+/// whole-value match on the raw needle.
+///
+/// Deliberately unfiltered. An earlier version of this skipped terms whose
+/// posting list covered more than a quarter of the graph, to avoid scoring
+/// everything for a query that merely mentioned `.go`. That was wrong in a way
+/// worth recording: seeding is a union, so skipping a term is only harmless when
+/// no other term seeds anything. On a repository where `reel` appeared in a
+/// quarter of all nodes, the query `reel paths` seeded from `paths` alone and
+/// retrieved 6 nodes where `reel` on its own retrieved over 500 — adding a term
+/// shrank the result. Any ceiling here recreates the exact defect this module
+/// exists to avoid: a retriever narrower than the ranker. Discrimination belongs
+/// in the score, where a term the whole graph shares already earns almost no
+/// weight.
+pub(super) fn candidate_ordinals(
+    index: &StructuralGraphQueryIndex,
+    needle: &str,
+    query: &LexicalQuery,
+) -> Vec<usize> {
+    let mut candidates = HashSet::new();
+    if let Some(exact) = index.exact.get(needle) {
+        candidates.extend(exact.iter().copied());
+    }
+    for term in &query.terms {
+        if let Some(postings) = index.tokens.get(&term.text) {
+            candidates.extend(postings.iter().copied());
+        }
+    }
+    let mut candidates = candidates.into_iter().collect::<Vec<_>>();
+    candidates.sort_unstable();
+    candidates
+}
+
 pub(super) fn trust_cost(trust: GraphTrust) -> f64 {
     match trust {
         GraphTrust::Extracted => 1.0,
         GraphTrust::Inferred => 1.6,
         GraphTrust::Ambiguous => 3.5,
         GraphTrust::Legacy => 4.0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn token_keys_expand_paths_and_camel_case_without_losing_the_whole_token() {
+        assert_eq!(token_keys("context.go"), vec!["context.go", "context", "go"]);
+        assert_eq!(token_keys("FullPath"), vec!["fullpath", "full", "path"]);
+        assert_eq!(
+            token_keys("src/parseURLQuery"),
+            vec![
+                "src/parseurlquery",
+                "src",
+                "parseurlquery",
+                "parse",
+                "url",
+                "query"
+            ]
+        );
+        // A single lowercase word expands to itself and nothing else.
+        assert_eq!(token_keys("copy"), vec!["copy"]);
+    }
+
+    #[test]
+    fn field_hit_separates_whole_word_prefix_and_substring_matches() {
+        assert_eq!(field_hit("path", "path"), 1.0);
+        assert_eq!(field_hit("full path here", "path"), 0.9);
+        assert_eq!(field_hit("pathfinder", "path"), 0.65);
+        assert_eq!(field_hit("fullpath", "path"), 0.4);
+        assert_eq!(field_hit("unrelated", "path"), 0.0);
     }
 }

--- a/apps/desktop/src-tauri/src/commands/structural_graph/query/limits.rs
+++ b/apps/desktop/src-tauri/src/commands/structural_graph/query/limits.rs
@@ -59,6 +59,21 @@ pub(super) fn enforce_projection_bytes(
     });
 }
 
+/// Drops the source preview from hits past the first default page.
+///
+/// A search result is a ranked list of locations; every hit keeps its path and
+/// line range, so the answer to "where is this" is unchanged. What a preview
+/// buys is not having to open the file, and that only pays off for hits someone
+/// actually reads. A caller asking for several hundred nodes used to be billed
+/// for several hundred code excerpts to get a ranked list — on a 400-node search
+/// that is tens of kilobytes of text nobody looks at. Callers who ask for a
+/// default page or less are unaffected.
+pub(super) fn trim_search_previews(result: &mut GraphSearchResult) {
+    for hit in result.hits.iter_mut().skip(DEFAULT_LIMIT) {
+        strip_node_excerpts(&mut hit.node);
+    }
+}
+
 pub(super) fn enforce_search_bytes(result: &mut GraphSearchResult, offset: usize, total: usize) {
     if serialized_bytes(result) <= MAX_RESPONSE_BYTES {
         return;

--- a/apps/desktop/src-tauri/src/commands/structural_graph/query/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/structural_graph/query/mod.rs
@@ -20,7 +20,12 @@ const MAX_QUERY_INDEXES: usize = 16;
 #[derive(Debug, Default)]
 struct StructuralGraphQueryIndex {
     exact: HashMap<String, Vec<usize>>,
+    /// Term -> node ordinals. Keys include whole tokens *and* their path
+    /// segments and camelCase words, so retrieval reaches everything the ranker
+    /// is able to score.
     tokens: HashMap<String, Vec<usize>>,
+    /// Denominator for inverse document frequency.
+    node_count: usize,
 }
 
 static QUERY_INDEXES: OnceLock<Mutex<HashMap<String, Arc<StructuralGraphQueryIndex>>>> =
@@ -48,6 +53,12 @@ pub struct GraphQueryFilter {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GraphSearchHit {
     pub node: StructuralGraphNode,
+    /// Relevance on a fixed `0..=999_999` scale where **higher is more
+    /// relevant**, matching what every other search API means by `score`.
+    /// `hits` is already returned best-first; this is the magnitude behind that
+    /// order. It used to be an ascending match-rank (`0` = best), which read as
+    /// a relevance score and silently inverted any consumer that sorted by it
+    /// descending.
     pub score: u32,
     pub matched_by: String,
 }
@@ -192,12 +203,13 @@ mod search;
 mod traversal;
 
 use index::{
-    edge_matches_filter, lexical_tokens, node_map, node_matches_filter, normalize, query_index,
-    rank_node, rank_question_tokens, trust_cost,
+    candidate_ordinals, edge_matches_filter, lexical_query, lexical_relevance, node_map,
+    node_matches_filter, normalize, query_index, rank_node, rank_question_tokens, tiered_score,
+    trust_cost,
 };
 use limits::{
     bounded_limit, enforce_impact_bytes, enforce_path_bytes, enforce_projection_bytes,
-    enforce_search_bytes, parse_cursor,
+    enforce_search_bytes, parse_cursor, trim_search_previews,
 };
 use path_visit::PathVisit;
 use projection::query_context;

--- a/apps/desktop/src-tauri/src/commands/structural_graph/query/search.rs
+++ b/apps/desktop/src-tauri/src/commands/structural_graph/query/search.rs
@@ -26,37 +26,39 @@ pub fn search_page(
         });
     }
 
-    let tokens = lexical_tokens(&needle);
     let index = query_index(snapshot);
-    let mut candidate_indices = HashSet::new();
-    if let Some(exact) = index.exact.get(&needle) {
-        candidate_indices.extend(exact.iter().copied());
-    }
-    for token in &tokens {
-        if let Some(postings) = index.tokens.get(token) {
-            candidate_indices.extend(postings.iter().copied());
+    // Terms come from the raw query, not the lowercased needle: camelCase word
+    // boundaries are gone once the text is normalized.
+    let lexical = lexical_query(query, &index);
+    let candidates = {
+        let ordinals = candidate_ordinals(&index, &needle, &lexical);
+        if ordinals.is_empty() {
+            (0..snapshot.nodes.len()).collect::<Vec<_>>()
+        } else {
+            ordinals
         }
-    }
-    let candidates = if candidate_indices.is_empty() {
-        (0..snapshot.nodes.len()).collect::<Vec<_>>()
-    } else {
-        let mut candidates = candidate_indices.into_iter().collect::<Vec<_>>();
-        candidates.sort_unstable();
-        candidates
     };
     let mut hits = candidates
         .into_iter()
         .filter_map(|index| snapshot.nodes.get(index))
         .filter(|node| node_matches_filter(node, filter))
         .filter_map(|node| {
-            rank_node(node, &needle)
-                .or_else(|| rank_question_tokens(node, &tokens))
-                .map(|(score, matched_by)| (node, score, matched_by))
+            // A whole-value match picks the tier; the lexical relevance of the
+            // same node then orders it inside that tier.
+            match rank_node(node, &needle) {
+                Some((tier, matched_by)) => Some((
+                    node,
+                    tiered_score(tier, lexical_relevance(node, &lexical)),
+                    matched_by,
+                )),
+                None => rank_question_tokens(node, &lexical)
+                    .map(|(score, matched_by)| (node, score, matched_by)),
+            }
         })
         .collect::<Vec<_>>();
     hits.sort_by(|(left_node, left_score, _), (right_node, right_score, _)| {
-        left_score
-            .cmp(right_score)
+        right_score
+            .cmp(left_score)
             .then_with(|| left_node.label.cmp(&right_node.label))
             .then_with(|| left_node.id.cmp(&right_node.id))
     });
@@ -86,6 +88,7 @@ pub fn search_page(
         next_cursor: (next_offset < total).then(|| next_offset.to_string()),
         context: query_context(snapshot),
     };
+    trim_search_previews(&mut result);
     enforce_search_bytes(&mut result, offset, total);
     Ok(result)
 }
@@ -105,11 +108,15 @@ pub fn resolve_node<'a>(
         .get(&needle)
         .cloned()
         .unwrap_or_else(|| (0..snapshot.nodes.len()).collect());
-    for exact_score in 0..=3 {
+    // Only the four whole-value tiers resolve a reference; a substring match is
+    // too weak to name a node.
+    for tier in ["id", "qualified_name", "path", "label"] {
         let matches = candidates
             .iter()
             .filter_map(|index| snapshot.nodes.get(*index))
-            .filter(|node| rank_node(node, &needle).is_some_and(|(score, _)| score == exact_score))
+            .filter(|node| {
+                rank_node(node, &needle).is_some_and(|(_, matched_by)| matched_by == tier)
+            })
             .collect::<Vec<_>>();
         match matches.len() {
             0 => continue,

--- a/apps/desktop/src-tauri/src/commands/structural_graph/query/tests.rs
+++ b/apps/desktop/src-tauri/src/commands/structural_graph/query/tests.rs
@@ -81,6 +81,117 @@ fn search_prefers_exact_stable_identifier() {
 }
 
 #[test]
+fn search_returns_hits_ordered_by_descending_relevance_score() {
+    let result = search(
+        &snapshot(),
+        "start src/a.rs",
+        &GraphQueryFilter::default(),
+        Some(10),
+    );
+    assert!(result.hits.len() >= 2);
+    assert!(
+        result
+            .hits
+            .windows(2)
+            .all(|pair| pair[0].score >= pair[1].score),
+        "hits must be best-first with score decreasing: {:?}",
+        result.hits.iter().map(|hit| hit.score).collect::<Vec<_>>()
+    );
+    // Scores separate near-matches instead of collapsing them onto one tier
+    // value, which is what made large repositories rank almost arbitrarily.
+    let distinct = result
+        .hits
+        .iter()
+        .map(|hit| hit.score)
+        .collect::<HashSet<_>>();
+    assert!(distinct.len() > 1, "identical scores for unequal matches");
+}
+
+#[test]
+fn search_retrieves_nodes_whose_only_match_is_inside_a_camel_case_or_path_token() {
+    let mut graph = snapshot();
+    // The query index is cached per snapshot id, so a mutated fixture needs its
+    // own identity or it would be answered from another test's index.
+    graph.id = "snapshot:camel".to_string();
+    graph.nodes.push(StructuralGraphNode {
+        id: "node:fullpath".to_string(),
+        kind: "function".to_string(),
+        label: "FullPath".to_string(),
+        qualified_name: Some("src/context.go::FullPath".to_string()),
+        path: Some("src/context.go".to_string()),
+        detail: None,
+        language: Some("go".to_string()),
+        community_id: None,
+        trust: GraphTrust::Extracted,
+        origin: GraphOrigin::Syntax,
+        sources: Vec::new(),
+    });
+    // "path" is only a suffix of the label and "context" only a stem of the file
+    // name, so keying candidates on whole tokens never reached this node.
+    for query in ["path", "context", "full path in context"] {
+        let result = search(&graph, query, &GraphQueryFilter::default(), Some(10));
+        assert!(
+            result.hits.iter().any(|hit| hit.node.id == "node:fullpath"),
+            "query {query:?} did not retrieve the camel-case/path match"
+        );
+    }
+}
+
+#[test]
+fn adding_a_query_term_never_shrinks_the_retrieved_set() {
+    let mut graph = snapshot();
+    graph.id = "snapshot:monotonic".to_string();
+    // "shared" is on most nodes, "paths" on exactly one: the shape that made a
+    // frequency-based candidate ceiling drop the common term's nodes entirely.
+    for index in 0..40 {
+        graph.nodes.push(node(
+            &format!("node:shared:{index}"),
+            &format!("shared{index}"),
+            &format!("src/shared{index}.rs"),
+        ));
+    }
+    graph.nodes.push(node("node:paths", "paths", "src/paths.rs"));
+    let ids = |query: &str| {
+        search(&graph, query, &GraphQueryFilter::default(), Some(500))
+            .hits
+            .into_iter()
+            .map(|hit| hit.node.id)
+            .collect::<HashSet<_>>()
+    };
+    let shared = ids("shared");
+    let both = ids("shared paths");
+    assert!(
+        shared.is_subset(&both),
+        "adding a term dropped {} nodes",
+        shared.difference(&both).count()
+    );
+}
+
+#[test]
+fn search_weights_rare_terms_above_terms_the_whole_graph_shares() {
+    let mut graph = snapshot();
+    graph.id = "snapshot:idf".to_string();
+    for index in 0..40 {
+        graph.nodes.push(node(
+            &format!("node:common:{index}"),
+            &format!("handler{index}"),
+            &format!("src/handler{index}.rs"),
+        ));
+    }
+    graph.nodes.push(node("node:rare", "reticulate", "src/rare.rs"));
+    let result = search(
+        &graph,
+        "reticulate handler",
+        &GraphQueryFilter::default(),
+        Some(5),
+    );
+    assert_eq!(
+        result.hits[0].node.id, "node:rare",
+        "the rare term must outweigh the term forty nodes share"
+    );
+}
+
+#[test]
 fn search_seeds_natural_language_questions_without_stop_words() {
     let result = search(
         &snapshot(),

--- a/apps/desktop/src/lib/tauri-ipc.ts
+++ b/apps/desktop/src/lib/tauri-ipc.ts
@@ -2066,6 +2066,7 @@ export interface StructuralGraphStatus {
 export interface StructuralGraphSearchResult {
   hits: Array<{
     node: StructuralGraphNode;
+    /** Relevance on a 0..=999_999 scale; higher is more relevant. `hits` is already best-first. */
     score: number;
     matched_by: string;
   }>;


### PR DESCRIPTION
First of a dependency-ordered stack replacing #169, which was 131 files against a 40-file gate.

## What changes

Query scoring used raw term presence: a path match counted the same as a symbol match, and a common token the same as a rare one. Replaced with sub-token indexing and field-weighted IDF. Preview trimming keeps the payload proportionate to what the caller asked for.

## The part to review carefully

**Relevance flips direction.** It is now higher-is-better on `0..=999_999`; previously it was ascending match-rank where *lower* meant better. Anything consuming these hits must sort descending.

This is worth stating loudly because an external consumer got it backwards and spent an entire measurement session reading each query's five *worst* results — a ~9.5 point understatement that looked like a finding. `tauri-ipc.ts` now documents the direction at the call site.

## Verification

70 `structural_graph` tests pass, including new coverage in `query/tests.rs` and `extract/tests.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)