### PR TITLE
feat(retrieval): shared path vocabulary, reliability gates, and tiering

### DIFF
--- a/benchmarks/context-retrieval/plan.json
+++ b/benchmarks/context-retrieval/plan.json
@@ -1,0 +1,148 @@
+{
+  "schema_version": "codevetter.context-retrieval-plan.v1",
+  "purpose": "Frozen experiment definition. Written before any tiered result exists so that the ranking cannot be selected after the fact. The plan_hash below appears in every report; if this file changes, the hash changes, and git history shows whether it changed before or after the run.",
+  "registered_on": "2026-08-23",
+  "primary_metric": "mean_recall_at_N_tokens",
+  "primary_metric_rationale": "Recall alone let a query-blind churn ranker appear to beat shipping products, because it ignored what the answer cost to deliver. The metric must charge for the payload the consumer actually pays for.",
+  "budgets": [
+    1000,
+    4000,
+    16000
+  ],
+  "budgets_rationale": "Three budgets, reported always together and never collapsed. On the small tier the leader changes at every one of them, so a single headline number would be a choice about budget disguised as a finding about quality.",
+  "no_overall_winner": true,
+  "no_overall_winner_rationale": "No cross-tier or cross-budget aggregate is computed or published. Different providers win different tiers, which is the result, not a problem to be averaged away.",
+  "tiers": [
+    {
+      "id": "small",
+      "max_code_files": 250,
+      "protocol": "per-case-index"
+    },
+    {
+      "id": "medium",
+      "max_code_files": 1000,
+      "protocol": "per-case-index"
+    },
+    {
+      "id": "large",
+      "max_code_files": null,
+      "protocol": "fixed-index"
+    }
+  ],
+  "tier_assignment": "Mechanical, by counting tracked files matching the code-extension set at the pinned revision. Repositories are measured and then assigned; they are never selected to fill a tier.",
+  "protocol_by_tier": {
+    "per-case-index": "Each case gets a fresh worktree at its base revision and every provider re-indexes it. Highest fidelity, does not survive scale.",
+    "fixed-index": "Index once at a pinned revision R; draw cases only from fixes that landed strictly after R, verified with git merge-base --is-ancestor. The index therefore never contains the fix. Cost: incremental-reindex behaviour cannot be credited in this tier, which is recorded rather than hidden."
+  },
+  "repositories": {
+    "assignment_method": "Mechanical: countCodeFiles() at the pinned head, then classify(). Repositories were cloned as a candidate pool and measured; none was selected to fill a tier.",
+    "measured_on": "2026-08-23",
+    "small": [
+      {
+        "id": "express",
+        "code_files": 141,
+        "language": "javascript",
+        "pinned_head": "a3714473feb3"
+      },
+      {
+        "id": "gin",
+        "code_files": 99,
+        "language": "go",
+        "pinned_head": "dcaa4296d111"
+      },
+      {
+        "id": "got",
+        "code_files": 85,
+        "language": "javascript",
+        "pinned_head": "e3924aa1e53a"
+      },
+      {
+        "id": "flask",
+        "code_files": 83,
+        "language": "python",
+        "pinned_head": "d318b6834711"
+      }
+    ],
+    "medium": [
+      {
+        "id": "hugo",
+        "code_files": 932,
+        "language": "go",
+        "pinned_head": "7b5199fdeff7"
+      },
+      {
+        "id": "fastify",
+        "code_files": 300,
+        "language": "javascript",
+        "pinned_head": "83e69762aff0"
+      }
+    ],
+    "large": [
+      {
+        "id": "django",
+        "code_files": 3040,
+        "language": "python",
+        "pinned_head": "03988c5a5ba2"
+      },
+      {
+        "id": "nest",
+        "code_files": 1828,
+        "language": "typescript",
+        "pinned_head": "55425779a1e2"
+      },
+      {
+        "id": "fastapi",
+        "code_files": 1142,
+        "language": "python",
+        "pinned_head": "c3f316b7e814"
+      }
+    ],
+    "known_imbalance": "No large Go repository yet, so a large-tier result specific to Go would be unsupported. Python and TypeScript are both represented at large (django, fastapi, nest), and every tier now spans at least two languages, so tier effects are no longer confounded with a single language.",
+    "note": "nest measured 1,828 files only after its clone completed; an earlier measurement read 0 and would have mis-tiered it as small. Sizes are taken from a completed checkout for exactly this reason."
+  },
+  "cases_per_repository": {
+    "per-case-index": 76,
+    "fixed-index": 30
+  },
+  "controls": [
+    "random-files",
+    "random-code-files",
+    "churn-ranked"
+  ],
+  "controls_rationale": "churn-ranked never reads the query. If it scores near the leaders the metric is broken, and nothing else in the harness detects that. Two random draws are required, not one: random-files samples every tracked file, which is the honest null because ground truth is not restricted to source code, and random-code-files samples source files only, which is strictly harder to beat. Widening the pool to all tracked files weakened the floor by 1.18x on gin and 2.36x on flask, and a weaker floor flatters every provider and makes the controls-lose gate easier to pass, so the conservative draw is mandatory alongside it. A report missing any control is refused.",
+  "providers": "Every candidate in candidates.json that installs and exposes a non-LLM ranked-result surface. LLM-mediated surfaces are recorded separately because they measure a model plus an index, not retrieval.",
+  "outcome_taxonomy": [
+    "answered",
+    "did-not-install",
+    "did-not-index",
+    "refused-own-capacity-limit",
+    "indexed-but-returned-nothing",
+    "unavailable-at-query-time"
+  ],
+  "outcome_rationale": "More candidates in this category fail to start than score badly. Collapsing did-not-install into a low score is the largest single distortion available here.",
+  "reliability_gates": [
+    "controls present in every run, else the report is refused",
+    "a control scoring above half the leader fails the run",
+    "corpus rebuild must hash-match its pinned artifact",
+    "zero, all-unavailable and near-perfect scores are flagged for raw-payload inspection before publication",
+    "a deterministic sample of mid-range cases is nominated for hand-verification each run",
+    "coverage (tiers and repository count) travels with every published row"
+  ],
+  "known_limitations": [
+    "Ground truth is the files a fix touched, a proxy for the files someone had to find.",
+    "Queries are commit subjects, written with the fix already in hand, so they are friendlier than real prompts.",
+    "One-shot single query; real agents iterate, which penalises precise-narrow providers and flatters broad ones.",
+    "Adapter integration effort is not uniform across providers and effort correlates with score; per-provider effort is disclosed in candidates.json.",
+    "Latency figures reflect harness process-spawning choices as much as provider speed."
+  ],
+  "path_extraction": "A provider's answer is read out of its output by shape, not by file type: a token is a candidate if it carries a path separator or an extension, or is one of a closed set of conventional extensionless root filenames, and it counts only if it resolves to a regular file in the worktree at the case's base revision. No list of admissible extensions exists anywhere in the harness, because every such list was narrower than the ground truth it was scored against.",
+  "amendments": [
+    {
+      "date": "2026-08-23",
+      "what": "Added random-code-files as a required control; replaced per-adapter extension allowlists with one shape-based path rule; added refused-own-capacity-limit to the outcome taxonomy.",
+      "why": "Four harness defects were found after the first tiered runs and before any corrected number was published. Path extraction used four different extension allowlists, one per adapter, none of which covered the file types 22.8% of cases were scored against; a `return` inside a `finally` block discarded every fixed-index result, so the large tier recorded nothing; and one provider spec was declared twice in the same object literal and ran under settings other than the documented ones.",
+      "effect_on_results": "Every provider number produced before this date is void and is retained only as a record of the methodology. The small tier was re-measured from scratch under the amended plan.",
+      "direction_of_bias": "Two of the three changes make the benchmark harder to pass, not easier: the extra control raises the floor a provider must clear, and the outcome addition moves capacity refusals out of the answered pool. The shape-based path rule raises measured recall for any provider whose answers were config or script files, which flatters providers relative to the void numbers \u2014 recorded here so the direction is not discovered later."
+    }
+  ]
+}

--- a/scripts/context-retrieval/gates.mjs
+++ b/scripts/context-retrieval/gates.mjs
@@ -1,0 +1,197 @@
+#!/usr/bin/env node
+
+// Reliability gates.
+//
+// Each of these was a convention followed by hand in the first version of this
+// benchmark, and conventions rot. Every one corresponds to a specific bug that
+// actually shipped a wrong number, so they are checks rather than advice.
+
+// The single highest-value check. A control that never reads the query appeared to
+// beat shipping products at 37.3% recall, and nothing except the control itself
+// revealed that the metric was broken. A report without controls is unfalsifiable.
+// random-code-files is required alongside random-files because widening the random pool
+// to every tracked file — necessary, since ground truth is not restricted to code —
+// made the floor weaker and made this gate easier to pass. The conservative draw keeps
+// the gate honest.
+export const REQUIRED_CONTROLS = ['random-files', 'random-code-files', 'churn-ranked'];
+
+export function checkControlsPresent(providerIds) {
+  const missing = REQUIRED_CONTROLS.filter((id) => !providerIds.includes(id));
+  return {
+    ok: missing.length === 0,
+    missing,
+    reason: missing.length
+      ? `controls absent: ${missing.join(', ')}. A query-blind control is the only thing that detects a broken metric.`
+      : null,
+  };
+}
+
+// A query-blind arm scoring near the leaders means the metric is measuring something
+// other than retrieval. Checked numerically so it cannot be rationalised away.
+export function checkControlsLose({ providers, budget = 'mean_recall_at_4000_tokens' }) {
+  const score = (id) => providers.find((p) => p.provider_id === id)?.summary?.all?.[budget] ?? 0;
+  const best = Math.max(
+    ...providers
+      .filter((p) => !REQUIRED_CONTROLS.includes(p.provider_id))
+      .map((p) => p.summary?.all?.[budget] ?? 0),
+    0
+  );
+  const worstControl = Math.max(...REQUIRED_CONTROLS.map(score), 0);
+  // A control within half the leader's score is not a plausible retrieval result.
+  const ok = best > 0 && worstControl < best * 0.5;
+  return {
+    ok,
+    best,
+    control: worstControl,
+    reason: ok
+      ? null
+      : `a query-blind control scored ${(worstControl * 100).toFixed(1)}% against a leader's ${(best * 100).toFixed(1)}%. Suspect the metric, not the tools.`,
+  };
+}
+
+// Outcomes must stay separated. Over half the candidate registry failed to install
+// rather than failing to retrieve, and collapsing those into one number is the
+// largest single distortion available to a benchmark in this category.
+export const OUTCOMES = [
+  'answered',
+  'did-not-install',
+  'did-not-index',
+  // A provider that builds an index and then refuses to load it because the index
+  // breaches its own configured ceiling. Distinct from did-not-index on purpose:
+  // the extraction succeeded and the product declined the result, which is the most
+  // important thing this benchmark can report about a tool's usable scale.
+  'refused-own-capacity-limit',
+  'indexed-but-returned-nothing',
+  'unavailable-at-query-time',
+];
+
+export function classifyOutcome(response) {
+  if (!response) return 'unavailable-at-query-time';
+  const reason = response.unavailable_reason;
+  if (!reason) return response.files?.length ? 'answered' : 'indexed-but-returned-nothing';
+  if (/install|not found|command not found|ENOENT/i.test(reason)) return 'did-not-install';
+  // Checked before the generic index test, since these reasons also contain "import".
+  if (/exceeds?[- ].*limit|import[- ]limit|too (large|big)|safety limit/i.test(reason))
+    return 'refused-own-capacity-limit';
+  if (/index/i.test(reason)) return 'did-not-index';
+  if (/no output|no-paths|no matches/i.test(reason)) return 'indexed-but-returned-nothing';
+  return 'unavailable-at-query-time';
+}
+
+// Six arms had multi-repository numbers and six had one repository, printed in the
+// same table with nothing to distinguish them. Coverage travels with the row or the
+// row is misleading by construction.
+export function coverageOf(entry) {
+  const repos = [...new Set(entry.repos ?? [])].sort();
+  const tiers = [...new Set(entry.tiers ?? [])].sort();
+  return {
+    repos,
+    tiers,
+    label: `${tiers.join('+') || 'untiered'} · ${repos.length} repo${repos.length === 1 ? '' : 's'}`,
+    // A single repository in a single tier is a hint, not a finding.
+    strength: repos.length === 1 ? 'single-repo' : repos.length < 4 ? 'narrow' : 'broad',
+  };
+}
+
+// A ranking is only defensible if the arms in it were measured on comparable
+// evidence. The small tier at one point ranked a single-repository 75.1% above a
+// four-repository 50.4% as though they were the same kind of claim. They are not:
+// one is a hint, the other is a finding. This does not reorder anything — it states
+// the minimum coverage present, so a ranking drawn from mixed evidence has to say so.
+export function checkRankingComparable(rows, { minRepos = 2, minCaseShare = 0.9 } = {}) {
+  const scored = rows.filter((row) => !REQUIRED_CONTROLS.includes(row.provider_id));
+  const thin = scored.filter((row) => (row.coverage?.repos?.length ?? 0) < minRepos);
+  const counts = [...new Set(scored.map((row) => row.coverage?.repos?.length ?? 0))].sort();
+  // Repo count alone is not enough. An arm abandoned partway through a repository
+  // still lists that repository in its coverage while having been scored on a
+  // fraction of its cases — one arm here holds 160 of 242 cases yet looks fully
+  // covered. Ranking it against arms that answered all 242 is the same error as
+  // mixing single-repo and multi-repo evidence, one level down.
+  const maxCases = Math.max(...scored.map((row) => row.cases ?? 0), 0);
+  const partial = maxCases
+    ? scored.filter((row) => (row.cases ?? 0) < maxCases * minCaseShare)
+    : [];
+  const problems = [];
+  if (thin.length) {
+    problems.push(
+      `${thin.length} arm(s) measured on fewer than ${minRepos} repositories (${thin
+        .map((row) => row.provider_id)
+        .join(', ')})`
+    );
+  }
+  for (const row of partial) {
+    problems.push(
+      `${row.provider_id} scored on ${row.cases}/${maxCases} cases (${Math.round(((row.cases ?? 0) / maxCases) * 100)}% of the corpus)`
+    );
+  }
+  return {
+    ok: problems.length === 0,
+    min_repos_present: counts[0] ?? 0,
+    thin_arms: thin.map((row) => row.provider_id),
+    partial_arms: partial.map((row) => row.provider_id),
+    reason: problems.length
+      ? `${problems.join('; ')}. A ranking mixing evidence of different strengths is not defensible; mark or exclude these rows.`
+      : null,
+  };
+}
+
+// Extreme values are claims about the instrument. Four arms scored 0.0% here for
+// four unrelated harness bugs and zero tool defects; all four were caught only
+// because zero is implausible. This surfaces them as requiring a raw-payload check
+// rather than trusting them.
+export function flagExtremes(providers, { budget = 'mean_recall_at_4000_tokens' } = {}) {
+  const flagged = [];
+  for (const p of providers) {
+    const value = p.summary?.all?.[budget] ?? 0;
+    const cases = p.summary?.all?.cases ?? 0;
+    const unavailable = p.summary?.all?.unavailable ?? 0;
+    if (REQUIRED_CONTROLS.includes(p.provider_id)) continue;
+    if (value === 0) {
+      flagged.push({
+        provider_id: p.provider_id,
+        why: 'scored exactly zero — read the raw payload before believing it',
+      });
+    } else if (cases > 0 && unavailable === cases) {
+      flagged.push({
+        provider_id: p.provider_id,
+        why: 'unavailable on every case — usually setup, not the tool',
+      });
+    } else if (value >= 0.95) {
+      flagged.push({
+        provider_id: p.provider_id,
+        why: 'near-perfect recall — check for answer leakage into the index',
+      });
+    }
+  }
+  return flagged;
+}
+
+// The plausible middle is where bias hides, and it is exactly what got no scrutiny
+// in the first version. Deterministic sampling so the same run always nominates the
+// same cases for hand-verification and the sample cannot be reshuffled until it
+// looks acceptable.
+export function nominateForAudit({ providers, perProvider = 2 }) {
+  const nominations = [];
+  for (const p of providers) {
+    const cases = (p.cases ?? []).filter(
+      (c) => (c.measures?.recall_at_10 ?? 0) > 0 && (c.measures?.recall_at_10 ?? 0) < 1
+    );
+    if (cases.length === 0) continue;
+    // Fixed stride from a fixed offset: reproducible, and spread across the run.
+    const stride = Math.max(1, Math.floor(cases.length / perProvider));
+    for (
+      let i = 0;
+      i < cases.length && nominations.length < perProvider * providers.length;
+      i += stride
+    ) {
+      nominations.push({
+        provider_id: p.provider_id,
+        query: cases[i].case?.query,
+        revision: cases[i].case?.base_revision,
+        returned: cases[i].response?.files?.slice(0, 5),
+        expected: cases[i].case?.changed_files,
+      });
+    }
+  }
+  return nominations;
+}

--- a/scripts/context-retrieval/gates.test.mjs
+++ b/scripts/context-retrieval/gates.test.mjs
@@ -1,0 +1,139 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  REQUIRED_CONTROLS,
+  checkControlsLose,
+  checkControlsPresent,
+  classifyOutcome,
+  coverageOf,
+  flagExtremes,
+  nominateForAudit,
+} from './gates.mjs';
+
+const arm = (id, r4, extra = {}) => ({
+  provider_id: id,
+  summary: { all: { mean_recall_at_4000_tokens: r4, cases: 10, unavailable: 0, ...extra } },
+});
+
+test('a report without controls is refused', () => {
+  assert.equal(checkControlsPresent(['codesearch']).ok, false);
+  assert.deepEqual(checkControlsPresent(['codesearch']).missing, REQUIRED_CONTROLS);
+  // Asserting against REQUIRED_CONTROLS rather than a literal list, because the literal
+  // is what went stale when the conservative random draw was added as a third control.
+  assert.equal(checkControlsPresent(['codesearch', ...REQUIRED_CONTROLS]).ok, true);
+  // The weak random draw alone is not enough: widening its pool to every tracked file
+  // made it easier to beat, which is why the code-only draw is also mandatory.
+  assert.equal(checkControlsPresent(['codesearch', 'random-files', 'churn-ranked']).ok, false);
+});
+
+test('a control scoring near the leader fails the run', () => {
+  // The exact shape of the real bug: a query-blind churn ranker at 37.3% while the
+  // best real provider sat at 59.2%.
+  const bad = checkControlsLose({
+    providers: [arm('codesearch', 0.592), arm('churn-ranked', 0.373), arm('random-files', 0.026)],
+  });
+  assert.equal(bad.ok, false);
+  assert.match(bad.reason, /Suspect the metric/);
+
+  const good = checkControlsLose({
+    providers: [arm('codesearch', 0.592), arm('churn-ranked', 0.018), arm('random-files', 0.026)],
+  });
+  assert.equal(good.ok, true);
+});
+
+test('install failure is never conflated with poor retrieval', () => {
+  assert.equal(
+    classifyOutcome({ unavailable_reason: 'spawn: command not found' }),
+    'did-not-install'
+  );
+  assert.equal(classifyOutcome({ unavailable_reason: 'index step failed' }), 'did-not-index');
+  assert.equal(
+    classifyOutcome({ unavailable_reason: 'no output' }),
+    'indexed-but-returned-nothing'
+  );
+  assert.equal(classifyOutcome({ files: [] }), 'indexed-but-returned-nothing');
+  assert.equal(classifyOutcome({ files: ['a.go'] }), 'answered');
+});
+
+test('a capacity refusal is distinguished from an index failure', () => {
+  // The extraction succeeded and the product declined to load its own output. That is
+  // the most important thing this benchmark can say about a tool's usable scale, and
+  // collapsing it into did-not-index would lose it. Real reasons observed:
+  assert.equal(
+    classifyOutcome({
+      unavailable_reason: 'snapshot-exceeds-import-limit: 128820371 bytes > 33554432',
+    }),
+    'refused-own-capacity-limit'
+  );
+  assert.equal(
+    classifyOutcome({
+      unavailable_reason: 'CodeVetter import exceeds the 32 MiB local safety limit',
+    }),
+    'refused-own-capacity-limit'
+  );
+  // Still separated from a genuine index failure.
+  assert.equal(classifyOutcome({ unavailable_reason: 'index step failed' }), 'did-not-index');
+});
+
+test('coverage marks a single-repo row as a hint rather than a finding', () => {
+  assert.equal(coverageOf({ repos: ['gin'], tiers: ['small'] }).strength, 'single-repo');
+  assert.equal(
+    coverageOf({ repos: ['gin', 'flask', 'express', 'got'], tiers: ['small'] }).strength,
+    'broad'
+  );
+});
+
+test('a ranking mixing single-repo and multi-repo arms is flagged as indefensible', async () => {
+  const { checkRankingComparable } = await import('./gates.mjs');
+  const row = (id, repos) => ({ provider_id: id, coverage: { repos } });
+  // The exact shape of the problem: a one-repo leader ranked above a four-repo arm.
+  const mixed = checkRankingComparable([
+    row('semble', ['gin']),
+    row('codesearch', ['gin', 'express', 'flask', 'got']),
+    row('random-files', ['gin']),
+  ]);
+  assert.equal(mixed.ok, false);
+  assert.deepEqual(mixed.thin_arms, ['semble']);
+  assert.match(mixed.reason, /not defensible/);
+  // Controls are exempt: they exist to bound the metric, not to be ranked.
+  assert.ok(!mixed.thin_arms.includes('random-files'));
+
+  const sound = checkRankingComparable([
+    row('semble', ['gin', 'express']),
+    row('codesearch', ['gin', 'express', 'flask', 'got']),
+  ]);
+  assert.equal(sound.ok, true);
+  assert.equal(sound.min_repos_present, 2);
+});
+
+test('zeros and perfect scores are flagged for raw-payload inspection', () => {
+  const flags = flagExtremes([
+    arm('broken', 0),
+    arm('suspicious', 0.98),
+    arm('normal', 0.4),
+    arm('churn-ranked', 0),
+  ]);
+  const ids = flags.map((f) => f.provider_id);
+  assert.deepEqual(ids.sort(), ['broken', 'suspicious']);
+  // Controls are expected to score near zero, so they are never flagged.
+  assert.ok(!ids.includes('churn-ranked'));
+});
+
+test('audit nominations are deterministic and drawn from the plausible middle', () => {
+  const providers = [
+    {
+      provider_id: 'x',
+      cases: Array.from({ length: 6 }, (_, i) => ({
+        case: { query: `q${i}`, base_revision: `r${i}`, changed_files: ['a.go'] },
+        response: { files: ['a.go'] },
+        measures: { recall_at_10: i === 0 ? 0 : i === 5 ? 1 : 0.5 },
+      })),
+    },
+  ];
+  const first = nominateForAudit({ providers, perProvider: 2 });
+  const second = nominateForAudit({ providers, perProvider: 2 });
+  assert.deepEqual(first, second);
+  // Neither the 0.0 nor the 1.0 case is eligible: those are the ones already checked.
+  assert.ok(first.every((n) => n.query !== 'q0' && n.query !== 'q5'));
+});

--- a/scripts/context-retrieval/paths.mjs
+++ b/scripts/context-retrieval/paths.mjs
@@ -1,0 +1,88 @@
+// One shared definition of "what counts as a file path", imported by every adapter.
+//
+// It exists because there were four. generic-cli, mcp-client, controls and
+// agent-default each carried their own extension allowlist, and no two agreed:
+//
+//   generic-cli    ts tsx js jsx mjs cjs py go rs java rb php swift kt astro
+//   mcp-client     ts tsx js jsx mjs cjs rs py go java astro sql json
+//   controls       ts tsx mjs js rs astro py go swift sql json toml yaml yml
+//   agent-default  ts tsx mjs js rs astro py go swift sql json
+//
+// Two separate defects followed. The first is a ceiling: ground truth is "the files
+// the fix touched", which across the corpus includes package.json, go.mod, go.sum,
+// CHANGES.rst, globals.css, deploy-health.sh, .gitignore, pnpm-workspace.yaml,
+// people.csv, index.html, Dockerfile, LICENSE, public/_headers and .husky/pre-push.
+// 174 of 764 cases (22.8%) had at least one ground-truth file the generic-cli
+// vocabulary could not express, so those cases were unscoreable however good the
+// answer — and the rate ranged from 1.2% of fastify cases to 53.7% of
+// today-little-log's, which biases repository-to-repository comparison too.
+//
+// The second is worse, because it is differential rather than uniform: an arm on
+// mcp-client could name a .json file and an arm on generic-cli could not, so the arms
+// were not being asked the same question. Comparison-based gates cannot catch that —
+// checkControlsLose compares a tool against a control that had its own third
+// vocabulary — which is the same blind spot that hid the ranking inversion.
+//
+// The rule here is deliberately not a list of file types. A candidate is path-SHAPED
+// if it carries a separator or an extension; whether it is a real file is then settled
+// by the filesystem at the case's base revision, which is the actual definition and
+// needs no vocabulary.
+
+// Conventional extensionless filenames. This is the one residual allowlist, and unlike
+// a list of extensions it is genuinely closed: extensionless files appear at a
+// repository root by convention and the conventions are few. Shape cannot carry these,
+// because a tool writing "results complete" must not be credited with two files.
+export const KNOWN_ROOT_FILES = new Set([
+  'Dockerfile',
+  'Makefile',
+  'LICENSE',
+  'LICENCE',
+  'README',
+  'CHANGELOG',
+  'NOTICE',
+  'CODEOWNERS',
+  'Procfile',
+  'Gemfile',
+  'Rakefile',
+  'Justfile',
+  'Vagrantfile',
+  'Brewfile',
+]);
+
+// Candidate path tokens in free text. The leading `(?:\.{0,2}\/)?` admits "./x", "../x"
+// and absolute "/x": the earlier generic-cli pattern opened its capture with [\w.-],
+// which cannot match "/", so a tool printing absolute paths matched nothing at all. ck
+// delivered four correct .go files that way and was recorded at 0% recall.
+export const PATH_TOKEN = /(?:^|[\s"'`(\[<{:,=])((?:\.{0,2}\/)?[\w.\-+@]+(?:\/[\w.\-+@]+)*)/g;
+
+// Trailing sentence punctuation clings to paths in prose ("see src/app.ts.").
+export const TRAILING_PUNCT = /[.,;:!?)\]}>'"`]+$/;
+
+export function pathShaped(token) {
+  if (!token || token.length > 300 || token.startsWith('-')) return false;
+  if (token.includes('/')) return true;
+  if (/\.[A-Za-z0-9]{1,10}$/.test(token)) return true;
+  return KNOWN_ROOT_FILES.has(token);
+}
+
+// Raw candidates from text, punctuation trimmed, order and duplicates preserved so
+// callers can rank by first mention.
+export function pathTokensIn(text) {
+  const found = [];
+  for (const match of String(text).matchAll(PATH_TOKEN)) {
+    const token = match[1].replace(TRAILING_PUNCT, '');
+    if (pathShaped(token)) found.push(token);
+  }
+  return found;
+}
+
+// The universe a control may draw from, and the universe ground truth is drawn from:
+// every file tracked at the revision. Restricting it to source code — as three of the
+// four allowlists did — makes the control answer an easier question than the tools,
+// which is exactly the asymmetry the controls exist to rule out. Widening it does make
+// the random control weaker, and that direction flatters every real provider, so it is
+// recorded here rather than left as a silent default: the pool has to match the ground
+// truth, and corpus ground truth contains .rst, .css, .sh, .mod and even .webp files.
+export function isCandidateFile(path) {
+  return Boolean(path) && !path.endsWith('/');
+}

--- a/scripts/context-retrieval/preregister.mjs
+++ b/scripts/context-retrieval/preregister.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+
+// Pre-registration.
+//
+// The budget you choose determines the winner: on one repository codesearch wins at
+// 1k, semble at 4k and gitnexus at 16k. Choosing the budget after seeing results is
+// therefore choosing the winner, and it is indistinguishable in the final artifact
+// from having chosen it honestly beforehand.
+//
+// So the plan is written first, hashed, and committed. The hash goes into every
+// report. If the plan changes after results exist, the hash changes, and git history
+// shows when relative to the run. That does not prevent gaming; it makes gaming
+// leave a trace, which is the most any format can do.
+
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+// Fields that define the experiment. Anything here is frozen before the first run.
+const PLAN_FIELDS = [
+  'budgets',
+  'primary_metric',
+  'tiers',
+  'repositories',
+  'providers',
+  'controls',
+  'cases_per_repository',
+  'protocol_by_tier',
+];
+
+export function planHash(plan) {
+  // Canonical form: only the declared fields, keys sorted, so incidental edits like
+  // comments or field order do not change the hash but a metric change does.
+  const canonical = {};
+  for (const field of PLAN_FIELDS.slice().sort()) {
+    if (plan[field] !== undefined) canonical[field] = sortDeep(plan[field]);
+  }
+  return createHash('sha256').update(JSON.stringify(canonical)).digest('hex').slice(0, 16);
+}
+
+function sortDeep(value) {
+  if (Array.isArray(value)) return value.map(sortDeep);
+  if (value && typeof value === 'object') {
+    const out = {};
+    for (const key of Object.keys(value).sort()) out[key] = sortDeep(value[key]);
+    return out;
+  }
+  return value;
+}
+
+export function validatePlan(plan) {
+  const problems = [];
+  for (const field of PLAN_FIELDS) {
+    if (plan[field] === undefined) problems.push(`missing required field: ${field}`);
+  }
+  if (Array.isArray(plan.budgets) && plan.budgets.length < 2) {
+    // A single budget is the same failure as picking one afterwards: it hides that
+    // the ranking is budget-dependent.
+    problems.push('at least two budgets are required so budget-dependence stays visible');
+  }
+  if (Array.isArray(plan.controls) && plan.controls.length === 0) {
+    problems.push('at least one query-blind control is required');
+  }
+  return { ok: problems.length === 0, problems };
+}
+
+// A report may only claim to follow a plan if the plan it was run against still
+// hashes the same. Verified at report time, not trusted.
+export function verifyAgainstPlan({ plan, declaredHash }) {
+  const actual = planHash(plan);
+  return {
+    ok: actual === declaredHash,
+    actual,
+    declared: declaredHash,
+    reason:
+      actual === declaredHash
+        ? null
+        : `plan hash mismatch: report claims ${declaredHash}, plan hashes to ${actual}. The experiment definition changed after the run.`,
+  };
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const path = process.argv[2];
+  if (!path) throw new Error('usage: preregister.mjs <plan.json>');
+  const plan = JSON.parse(readFileSync(path, 'utf8'));
+  const validation = validatePlan(plan);
+  process.stdout.write(
+    `${JSON.stringify({ plan_hash: planHash(plan), ...validation }, null, 2)}\n`
+  );
+  if (!validation.ok) process.exitCode = 1;
+}

--- a/scripts/context-retrieval/tiers.mjs
+++ b/scripts/context-retrieval/tiers.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+
+// Repository size tiers, and the protocol each tier is measured under.
+//
+// Why this exists: every repository in the first version of this benchmark held
+// between 83 and 141 code files. Those results were published as "the field" when
+// they were in fact one narrow tier, and the single most consequential finding about
+// any provider — that one of them cannot index a 1,461-file repository at all —
+// was invisible because nothing that large was ever measured.
+//
+// Tiers are assigned by MEASURING a repository, never by choosing a repository to
+// fill a tier. That ordering matters: picking the repo after knowing the boundary is
+// how a benchmark ends up with tiers that flatter a particular tool's sweet spot.
+
+import { execFileSync } from 'node:child_process';
+
+// Extensions counted as code. Deliberately the same set the corpus builder uses, so
+// "files in the repo" and "files a provider could be asked about" cannot drift.
+// Deliberately NOT the shared vocabulary in ./paths.mjs, which asks "could a tool have
+// meant this path". This asks "how much code is in this repository", to place it in a
+// size tier — a lockfile and a changelog are not code by that measure even though both
+// are legitimate retrieval targets. Keep the two separate.
+const CODE_EXTENSIONS = /\.(ts|tsx|js|jsx|mjs|cjs|py|go|rs|java|rb|php|swift|kt|astro)$/;
+
+// Boundaries sit at observed failure points, not round numbers. A graph provider
+// failed on a 1,461-file repository against its own 32 MB / 100k-node import
+// ceiling, so the medium ceiling is set below that: a repository of that size must
+// land in `large` and be measured under the large-tier protocol, or the benchmark
+// cannot observe the scale limit that matters most.
+//
+// This boundary was originally 1,500, which put the 1,461-file case in `medium` and
+// would have hidden exactly that. The tier test now asserts the relationship rather
+// than the number, so the constant cannot drift back.
+export const TIERS = [
+  { id: 'small', max_code_files: 250, protocol: 'per-case-index' },
+  { id: 'medium', max_code_files: 1000, protocol: 'per-case-index' },
+  { id: 'large', max_code_files: Number.POSITIVE_INFINITY, protocol: 'fixed-index' },
+];
+
+export function countCodeFiles(repo) {
+  const listed = execFileSync('git', ['-C', repo, 'ls-files'], {
+    encoding: 'utf8',
+    maxBuffer: 256 * 1024 * 1024,
+  });
+  let count = 0;
+  for (const line of listed.split('\n')) {
+    if (CODE_EXTENSIONS.test(line)) count += 1;
+  }
+  return count;
+}
+
+// Tier must be measured at the revisions the cases are actually scored at, not at
+// HEAD. site-health reads 69 code files at HEAD and 537 at its median case revision,
+// because a monorepo was extracted out of it partway through its history — so it was
+// labelled `small` while most of its cases were scored against a `medium` tree. A
+// provider was then judged to have a capacity defect on the strength of the wrong
+// number. Nine of ten repositories measured are stable; this exists for the tenth.
+export function tierFromRevisions(repo, revisions, { sample = 20 } = {}) {
+  const counts = [];
+  for (const revision of revisions.slice(0, sample)) {
+    try {
+      const listed = execFileSync('git', ['-C', repo, 'ls-tree', '-r', '--name-only', revision], {
+        encoding: 'utf8',
+        maxBuffer: 256 * 1024 * 1024,
+      });
+      let count = 0;
+      for (const line of listed.split('\n')) if (CODE_EXTENSIONS.test(line)) count += 1;
+      counts.push(count);
+    } catch {
+      // A revision that cannot be listed contributes nothing rather than a zero.
+    }
+  }
+  if (counts.length === 0) return { ok: false, reason: 'no revision could be listed' };
+  const sorted = [...counts].sort((a, b) => a - b);
+  const median = sorted[Math.floor(sorted.length / 2)];
+  const tiers = [...new Set(counts.map((n) => classify(n).id))];
+  return {
+    ok: true,
+    tier: classify(median).id,
+    median_code_files: median,
+    min_code_files: sorted[0],
+    max_code_files: sorted.at(-1),
+    // A corpus spanning tiers cannot be attributed to any one of them. Reported so
+    // the row is excluded or split rather than silently averaged.
+    spans_tiers: tiers.length > 1 ? tiers : null,
+  };
+}
+
+export function classify(codeFiles) {
+  return TIERS.find((tier) => codeFiles <= tier.max_code_files) ?? TIERS.at(-1);
+}
+
+// Two protocols, because per-case reindexing does not survive scale. On a 109-file
+// repository a graph build costs 3–43 s, so 76 cases across 19 arms is hours. On a
+// 3,000-file repository the same design is days, and nobody would rerun it — which
+// makes it useless as a published benchmark regardless of how correct it is.
+//
+// fixed-index keeps the property that actually matters. Index once at a pinned
+// revision R, then draw every case from fixes that landed strictly AFTER R. The
+// index therefore never contains the fix, which is the same guarantee per-case
+// indexing gives, at one index per repository instead of one per case.
+//
+// It is also closer to real use: an agent queries an index built earlier, not one
+// rebuilt for its question. The cost is that a provider cannot be credited for
+// incremental reindexing in this tier, which is recorded rather than hidden.
+export function protocolFor(tierId) {
+  const tier = TIERS.find((entry) => entry.id === tierId);
+  if (!tier) throw new Error(`unknown tier: ${tierId}`);
+  return tier.protocol;
+}
+
+// A case is only admissible under fixed-index if its fix is not already in the
+// index. Enforced rather than assumed: an off-by-one here would silently hand every
+// provider the answer and inflate the whole tier.
+export function admissibleUnderFixedIndex({ repo, indexRevision, caseRevision }) {
+  try {
+    // Exit 0 means indexRevision is an ancestor of caseRevision, i.e. the case is
+    // strictly newer than the index.
+    execFileSync('git', ['-C', repo, 'merge-base', '--is-ancestor', indexRevision, caseRevision], {
+      stdio: 'ignore',
+    });
+    return indexRevision !== caseRevision;
+  } catch {
+    return false;
+  }
+}

--- a/scripts/context-retrieval/tiers.test.mjs
+++ b/scripts/context-retrieval/tiers.test.mjs
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { TIERS, classify, protocolFor } from './tiers.mjs';
+
+test('tiers are assigned by measured size, and the boundaries are ordered', () => {
+  assert.equal(classify(99).id, 'small');
+  assert.equal(classify(141).id, 'small');
+  assert.equal(classify(250).id, 'small');
+  assert.equal(classify(251).id, 'medium');
+  assert.equal(classify(1000).id, 'medium');
+  assert.equal(classify(1001).id, 'large');
+  // The regime that matters: the 1,461-file repository that broke a graph provider's
+  // own import ceiling must be classified large, not medium.
+  assert.equal(classify(1461).id, 'large');
+  assert.equal(classify(30000).id, 'large');
+});
+
+test('the large boundary sits below the observed import ceiling', () => {
+  // A graph provider failed on a 1,461-file repository against its own 32 MB /
+  // 100k-node limits. If the large tier began above that, the benchmark could never
+  // observe the failure mode that matters most at scale.
+  const large = TIERS.find((t) => t.id === 'large');
+  const medium = TIERS.find((t) => t.id === 'medium');
+  assert.ok(medium.max_code_files <= 1461, 'large tier must include the 1,461-file regime');
+  assert.equal(large.max_code_files, Number.POSITIVE_INFINITY);
+});
+
+test('large repositories use fixed-index, smaller ones re-index per case', () => {
+  assert.equal(protocolFor('small'), 'per-case-index');
+  assert.equal(protocolFor('medium'), 'per-case-index');
+  assert.equal(protocolFor('large'), 'fixed-index');
+  assert.throws(() => protocolFor('enormous'), /unknown tier/);
+});
+
+test('tier is measured at case revisions, not at HEAD', async (t) => {
+  const { tierFromRevisions } = await import('./tiers.mjs');
+  const { existsSync, readFileSync } = await import('node:fs');
+  const repo = `${process.env.HOME}/Desktop/fleet/site-health`;
+  // Deliberately the corpus's own base revisions, not `rev-list HEAD`. The newest
+  // commits are all post-split and read small; the trap only appears in the
+  // revisions the cases are actually scored against. Sampling the wrong revisions
+  // is the exact mistake this test exists to catch, and the first version of this
+  // test made it.
+  const corpus =
+    '/private/tmp/claude-501/-Users-sarthak-Desktop-fleet-codevetter/89a25e80-80a8-452a-bfe6-a8c6ea4ae228/scratchpad/corpus-site-health.json';
+  if (!existsSync(repo) || !existsSync(corpus)) {
+    t.skip('site-health checkout or corpus unavailable');
+    return;
+  }
+  const revisions = JSON.parse(readFileSync(corpus, 'utf8')).cases.map((c) => c.base_revision);
+  const result = tierFromRevisions(repo, revisions);
+  assert.equal(result.ok, true);
+  // HEAD reads 69 code files (small); the case revisions run far larger, because a
+  // monorepo was extracted out of this repository partway through its history. A
+  // provider was wrongly accused of a capacity defect on the HEAD number.
+  assert.ok(
+    result.max_code_files > 250,
+    `history must exceed the small ceiling, saw ${result.max_code_files}`
+  );
+  assert.ok(Array.isArray(result.spans_tiers), 'a repo spanning tiers must say so');
+});
+
+test('every repository lands in exactly one tier', () => {
+  for (const files of [0, 1, 250, 251, 1000, 1001, 1461, 99999]) {
+    const matches = TIERS.filter((t) => files <= t.max_code_files);
+    assert.ok(matches.length >= 1);
+    assert.equal(classify(files).id, matches[0].id);
+  }
+});


### PR DESCRIPTION
Second of the stack replacing #169. Depends on nothing; everything else in the stack depends on this.

## Three files, three problems each solves

**`paths.mjs`** — one definition of "what counts as a file path". There were four, one per adapter, and no two agreed:

```
generic-cli    ts tsx js jsx mjs cjs py go rs java rb php swift kt astro
mcp-client     ts tsx js jsx mjs cjs rs py go java astro sql json
controls       ts tsx mjs js rs astro py go swift sql json toml yaml yml
agent-default  ts tsx mjs js rs astro py go swift sql json
```

Two defects followed. A **ceiling**: 174 of 764 corpus cases had at least one ground-truth file no allowlist could express, so they were unscoreable however good the answer — and the rate ran from 1.2% of one corpus to 53.7% of another, which biases repo-to-repo comparison too. And a **comparability** defect, which is worse because it is differential: an MCP arm could name a `.json` file where a CLI arm could not.

The replacement is not a longer list. A candidate is path-*shaped* — it carries a separator or an extension — and the filesystem at the case's base revision decides whether it is real. One residual allowlist survives for conventional extensionless root files (`Dockerfile`, `LICENSE`), because shape alone cannot separate those from prose.

**`gates.mjs`** — refuses reports that cannot be trusted. Note `REQUIRED_CONTROLS` has **three** entries. `random-files` samples every tracked file (the honest null, since ground truth is not restricted to code); `random-code-files` samples source only and is strictly harder to beat. Widening the pool was correct but weakened the floor by 1.18×–2.36× depending on the repository, and a weaker floor flatters every provider, so the conservative draw is mandatory.

**`tiers.mjs`** — size by measurement, never by selection. Sizes come from a repository's *case revisions*, not HEAD: one repository measures 69 code files at HEAD with a median case revision of 537, which is a different tier entirely.

## Verification

13 tests. `node scripts/context-retrieval/preregister.mjs benchmarks/context-retrieval/plan.json` → `4937d61d19d81518`, `ok: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)