### PR TITLE
feat(retrieval): provider adapters over one shared extraction path

### DIFF
--- a/scripts/context-retrieval/adapters/agent-default.mjs
+++ b/scripts/context-retrieval/adapters/agent-default.mjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+
+// What a coding agent already does for free, before any provider is installed.
+//
+// `keyword-search` alone understates the default: agents also guess filenames from
+// the task ("auth" -> look for auth.ts) and combine that with content search. This
+// adapter models the realistic default as reciprocal-rank fusion of two free
+// signals — content grep and filename match — which is the bar a paid or installed
+// provider actually has to clear.
+
+import { execFileSync } from 'node:child_process';
+
+import { retrieveByKeyword } from './keyword-search.mjs';
+
+import { isCandidateFile } from '../paths.mjs';
+import { elapsed } from './shared.mjs';
+
+// Standard RRF constant; damps the influence of any single ranking's tail.
+const RRF_K = 60;
+
+const MAX_FILE_BYTES = 512 * 1024;
+
+export function retrieveByFilename({ repo, revision, query, queryTokens = [], limit = 20 }) {
+  const started = process.hrtime.bigint();
+  const tokens = new Set(queryTokens);
+  const scored = listFiles(repo, revision)
+    .map((path) => ({ path, overlap: countOverlap(path, tokens) }))
+    .filter((entry) => entry.overlap > 0)
+    // More matched terms first; shallower paths break ties, as a human would guess.
+    .sort(
+      (left, right) =>
+        right.overlap - left.overlap ||
+        left.path.split('/').length - right.path.split('/').length ||
+        left.path.localeCompare(right.path)
+    )
+    .slice(0, limit);
+  const sizes = fileSizes(
+    repo,
+    revision,
+    scored.map((entry) => entry.path)
+  );
+  return {
+    provider_id: 'filename-match',
+    query,
+    indexed_revision: revision,
+    files: scored.map((entry) => entry.path),
+    ranking: scored.map((entry, index) => ({ ...entry, rank: index + 1 })),
+    tokens_delivered: Math.ceil(
+      scored.reduce((total, entry) => total + (sizes.get(entry.path) ?? 0), 0) / 4
+    ),
+    payload_kind: 'whole-files',
+    latency_ms: elapsed(started),
+  };
+}
+
+export function retrieveAgentDefault({ repo, revision, query, queryTokens = [], limit = 20 }) {
+  const started = process.hrtime.bigint();
+  const grep = retrieveByKeyword({ repo, revision, query, queryTokens, limit: limit * 2 });
+  const names = retrieveByFilename({ repo, revision, query, queryTokens, limit: limit * 2 });
+
+  const fused = new Map();
+  for (const ranking of [grep.files, names.files]) {
+    for (const [index, path] of ranking.entries()) {
+      const entry = fused.get(path) ?? { path, score: 0, sources: [] };
+      entry.score += 1 / (RRF_K + index + 1);
+      fused.set(path, entry);
+    }
+  }
+  for (const path of grep.files) fused.get(path).sources.push('content');
+  for (const path of names.files) fused.get(path).sources.push('filename');
+
+  const ordered = [...fused.values()]
+    .sort((left, right) => right.score - left.score || left.path.localeCompare(right.path))
+    .slice(0, limit);
+  const sizes = fileSizes(
+    repo,
+    revision,
+    ordered.map((entry) => entry.path)
+  );
+  return {
+    provider_id: 'agent-default',
+    query,
+    indexed_revision: revision,
+    files: ordered.map((entry) => entry.path),
+    ranking: ordered.map((entry, index) => ({ ...entry, rank: index + 1 })),
+    tokens_delivered: Math.ceil(
+      ordered.reduce((total, entry) => total + (sizes.get(entry.path) ?? 0), 0) / 4
+    ),
+    payload_kind: 'whole-files',
+    latency_ms: elapsed(started),
+    fusion: { rrf_k: RRF_K, content_hits: grep.files.length, filename_hits: names.files.length },
+  };
+}
+
+function countOverlap(path, tokens) {
+  const parts = path
+    .replace(/\.[a-z0-9]+$/i, '')
+    .split(/[^A-Za-z0-9]+/)
+    .flatMap((part) => part.replace(/([a-z0-9])([A-Z])/g, '$1 $2').split(' '))
+    .map((part) => part.toLowerCase())
+    .filter(Boolean);
+  return new Set(parts.filter((part) => tokens.has(part))).size;
+}
+
+function listFiles(repo, revision) {
+  try {
+    return execFileSync('git', ['-C', repo, 'ls-tree', '-r', '--name-only', revision], {
+      encoding: 'utf8',
+      maxBuffer: 32 * 1024 * 1024,
+    })
+      .split('\n')
+      .filter((path) => path && isCandidateFile(path));
+  } catch {
+    return [];
+  }
+}
+
+function fileSizes(repo, revision, paths) {
+  const sizes = new Map();
+  if (paths.length === 0) return sizes;
+  try {
+    const output = execFileSync('git', ['-C', repo, 'cat-file', '--batch-check'], {
+      encoding: 'utf8',
+      maxBuffer: 16 * 1024 * 1024,
+      input: `${paths.map((path) => `${revision}:${path}`).join('\n')}\n`,
+    });
+    for (const [index, line] of output.split('\n').filter(Boolean).entries()) {
+      const parts = line.trim().split(/\s+/);
+      const size = parts.length >= 3 ? Number.parseInt(parts[2], 10) : 0;
+      // Same cap as the keyword baseline: no agent reads a huge data blob whole.
+      sizes.set(paths[index], Number.isFinite(size) && size <= MAX_FILE_BYTES ? size : 0);
+    }
+  } catch {
+    // Missing sizes contribute nothing rather than failing the run.
+  }
+  return sizes;
+}

--- a/scripts/context-retrieval/adapters/cli-indexed-mcp.mjs
+++ b/scripts/context-retrieval/adapters/cli-indexed-mcp.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+
+// Providers that index with a CLI and answer over MCP.
+//
+// Third tool in this registry with that shape (jcodemunch, cocoindex-code, and cgr),
+// so it is worth a shared adapter. The MCP `indexToolName` hook does not cover it:
+// these tools build their index from a shell command, and only the query side speaks
+// JSON-RPC.
+//
+// Every case gets its own worktree at the case's base revision, because these
+// indexers read the filesystem and would otherwise all index HEAD.
+
+import { mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { run } from './shared.mjs';
+
+export function createCliIndexedMcpAdapter({
+  providerId,
+  indexCommand,
+  buildIndexArgs,
+  serveCommand,
+  buildArguments,
+  toolName,
+  parsePaths,
+  env = {},
+  timeoutMs = 240_000,
+  worktreeRoot,
+  createMcpAdapter,
+}) {
+  mkdirSync(worktreeRoot, { recursive: true });
+  const [indexBin, ...indexRest] = indexCommand.split(' ');
+  const [serveBin, ...serveRest] = serveCommand.split(' ');
+
+  return async function retrieve({ repo, revision, query, limit = 20 }) {
+    const started = process.hrtime.bigint();
+    const repoId = repo.replace(/\/+$/, '').split('/').pop();
+    const worktree = join(worktreeRoot, `${providerId}-${repoId}-${revision.slice(0, 12)}`);
+    rmSync(worktree, { recursive: true, force: true });
+    const fail = (reason) => ({
+      provider_id: providerId,
+      query,
+      indexed_revision: revision,
+      files: [],
+      ranking: [],
+      tokens_delivered: 0,
+      payload_kind: 'mcp-tool-result',
+      latency_ms: Math.round((Number(process.hrtime.bigint() - started) / 1e6) * 1000) / 1000,
+      unavailable_reason: reason,
+    });
+    try {
+      run('git', ['-C', repo, 'worktree', 'add', '--detach', '--force', worktree, revision]);
+    } catch (error) {
+      return fail(`worktree: ${short(error)}`);
+    }
+    try {
+      for (const argv of normalize(buildIndexArgs({ worktree, revision }))) {
+        run(indexBin, [...indexRest, ...argv], { cwd: worktree, env: { ...process.env, ...env } });
+      }
+    } catch (error) {
+      return fail(`index: ${short(error)}`);
+    }
+    try {
+      const adapter = createMcpAdapter({
+        providerId,
+        command: serveBin,
+        args: serveRest,
+        env,
+        toolName,
+        buildArguments,
+        parsePaths,
+        timeoutMs,
+      });
+      return await adapter({ repo, revision, query, limit, workspace: worktree });
+    } finally {
+      rmSync(worktree, { recursive: true, force: true });
+      try {
+        run('git', ['-C', repo, 'worktree', 'prune']);
+      } catch {
+        // Best-effort bookkeeping.
+      }
+    }
+  };
+}
+
+function normalize(built) {
+  return Array.isArray(built[0]) ? built : [built];
+}
+
+function short(error) {
+  const text = error?.stderr || error?.message || String(error);
+  return String(text).split('\n')[0].slice(0, 160);
+}

--- a/scripts/context-retrieval/adapters/codesearch.mjs
+++ b/scripts/context-retrieval/adapters/codesearch.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+
+// codesearch (github.com/flupkede/codesearch): hybrid BM25 + local vector search
+// over tree-sitter AST chunks. Fully offline, models bundled, no API key.
+//
+// Same revision trap as the other indexers: it reads the filesystem, so each case
+// is indexed in a worktree materialized at its own base revision.
+
+import { existsSync, mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { elapsed, firstLine, materialiseWorktree, run } from './shared.mjs';
+
+export const PROVIDER_ID = 'codesearch';
+
+export function createCodesearchAdapter({ binary, worktreeRoot, indexRoot, rerank = false }) {
+  if (!existsSync(binary)) throw new Error(`codesearch binary not found: ${binary}`);
+  mkdirSync(worktreeRoot, { recursive: true });
+  mkdirSync(indexRoot, { recursive: true });
+
+  return function retrieveByCodesearch({ repo, revision, query, limit = 20 }) {
+    const started = process.hrtime.bigint();
+    const repoId = repo.replace(/\/+$/, '').split('/').pop();
+    const worktree = join(worktreeRoot, `${repoId}-${revision.slice(0, 12)}`);
+    // The index lives beside the worktree, so it must be rebuilt per revision.
+    const materialised = materialiseWorktree({ repo, revision, worktree });
+    if (!materialised.ok) {
+      return unavailable({ query, revision, started, reason: materialised.reason });
+    }
+
+    try {
+      run(binary, ['index', 'add', worktree], { cwd: worktree, env: indexEnv(indexRoot) });
+      const args = [
+        'search',
+        query,
+        '--path',
+        worktree,
+        '--json',
+        '--quiet',
+        '--max-results',
+        String(limit),
+      ];
+      if (rerank) args.push('--rerank');
+      const output = run(binary, args, { cwd: worktree, env: indexEnv(indexRoot) });
+      return parseResponse({ output, query, revision, started, worktree, limit });
+    } catch (error) {
+      return unavailable({
+        query,
+        revision,
+        started,
+        reason: `search-failed: ${firstLine(error)}`,
+      });
+    } finally {
+      rmSync(worktree, { recursive: true, force: true });
+      try {
+        run('git', ['-C', repo, 'worktree', 'prune']);
+      } catch {
+        // Best-effort bookkeeping.
+      }
+    }
+  };
+}
+
+function parseResponse({ output, query, revision, started, worktree, limit }) {
+  let document;
+  try {
+    document = JSON.parse(output.slice(output.indexOf('{') >= 0 ? output.indexOf('{') : 0));
+  } catch {
+    // Fall back to the object/array boundary the JSON actually starts at.
+    const start = Math.min(
+      ...['{', '['].map((token) =>
+        output.indexOf(token) === -1 ? Infinity : output.indexOf(token)
+      )
+    );
+    if (!Number.isFinite(start)) {
+      return unavailable({ query, revision, started, reason: 'unparseable-json' });
+    }
+    try {
+      document = JSON.parse(output.slice(start));
+    } catch {
+      return unavailable({ query, revision, started, reason: 'unparseable-json' });
+    }
+  }
+  const rows = Array.isArray(document)
+    ? document
+    : (document.results ?? document.matches ?? document.hits ?? []);
+  const ordered = [];
+  const seen = new Set();
+  let chunkBytes = 0;
+  for (const row of rows) {
+    const raw = row?.path ?? row?.file ?? row?.file_path ?? row?.relative_path;
+    if (typeof raw !== 'string') continue;
+    chunkBytes += Buffer.byteLength(row?.snippet ?? row?.content ?? '');
+    // Paths may be absolute inside the throwaway worktree; report repo-relative.
+    const path = raw.startsWith(worktree) ? raw.slice(worktree.length).replace(/^\/+/, '') : raw;
+    if (seen.has(path)) continue;
+    seen.add(path);
+    ordered.push({ path, rank: ordered.length + 1, score: row?.score ?? null });
+  }
+  return {
+    provider_id: PROVIDER_ID,
+    query,
+    indexed_revision: revision,
+    files: ordered.slice(0, limit).map((entry) => entry.path),
+    ranking: ordered.slice(0, limit),
+    tokens_delivered: Math.ceil(chunkBytes / 4),
+    payload_kind: 'chunks',
+    latency_ms: elapsed(started),
+    results_returned: rows.length,
+  };
+}
+
+function indexEnv(indexRoot) {
+  // Keep every index inside the scratch root so nothing lands in the user's repos.
+  return { ...process.env, CODESEARCH_DATA_DIR: indexRoot, CODESEARCH_HOME: indexRoot };
+}
+
+function unavailable({ query, revision, started, reason }) {
+  return {
+    provider_id: PROVIDER_ID,
+    query,
+    indexed_revision: revision,
+    files: [],
+    ranking: [],
+    tokens_delivered: 0,
+    payload_kind: 'chunks',
+    latency_ms: elapsed(started),
+    unavailable_reason: reason,
+  };
+}

--- a/scripts/context-retrieval/adapters/codevetter-graph.mjs
+++ b/scripts/context-retrieval/adapters/codevetter-graph.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+
+// CodeVetter structural context, via the repo's own experiment fixture tool.
+//
+// The fixture's `revision` argument is only a LABEL: indexing discovers files with
+// `git ls-files -co` against the working tree and reads them from disk. Passing a
+// historical SHA without checking it out would index HEAD and stamp it with the old
+// revision — wrong, and invisible to any identity check. So every case is indexed
+// in a detached worktree materialized at its own base revision.
+
+import { existsSync, mkdirSync, readFileSync, rmSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { elapsed, firstLine, materialiseWorktree, run } from './shared.mjs';
+
+export const PROVIDER_ID = 'codevetter-structural-context';
+
+// Hits are graph nodes, and many nodes share a file. Ask for well over the file
+// budget so deduplication can still fill it.
+const NODE_LIMIT = 400;
+
+export function createStructuralGraphAdapter({ tool, cacheDir, worktreeRoot }) {
+  if (!existsSync(tool)) throw new Error(`fixture tool not found: ${tool}`);
+  mkdirSync(cacheDir, { recursive: true });
+  mkdirSync(worktreeRoot, { recursive: true });
+
+  // The unavailable shape was spelled out three times inline, which is most of why this
+  // function was flagged at cognitive complexity 24 against a ceiling of 20.
+  const failed = (query, revision, started, reason) => ({
+    provider_id: PROVIDER_ID,
+    query,
+    indexed_revision: revision,
+    files: [],
+    ranking: [],
+    tokens_delivered: 0,
+    payload_kind: 'excerpts',
+    latency_ms: elapsed(started),
+    unavailable_reason: reason,
+  });
+
+  // Collapse hits to one row per file, keeping each file's strongest hit. Score is
+  // higher-is-better on a 0..=999_999 scale, so this takes the MAXIMUM — the engine
+  // previously returned an ascending match-rank where lower meant better, and reading
+  // that direction backwards measured each query's five worst results for a whole
+  // session. If the engine's direction ever changes again, this comparison changes with it.
+  function collapseToFiles(hits) {
+    const byFile = new Map();
+    let excerptBytes = 0;
+    for (const hit of hits) {
+      const path = hit?.node?.path;
+      if (typeof path !== 'string') continue;
+      for (const source of hit.node.sources ?? []) {
+        excerptBytes += Buffer.byteLength(source.excerpt ?? '');
+      }
+      const existing = byFile.get(path);
+      if (existing === undefined || hit.score > existing.score) {
+        byFile.set(path, { path, score: hit.score, matched_by: hit.matched_by });
+      }
+    }
+    return { byFile, excerptBytes };
+  }
+
+  return function retrieveByStructuralGraph({ repo, revision, query, limit = 20 }) {
+    const started = process.hrtime.bigint();
+    const snapshot = ensureSnapshot({ tool, cacheDir, worktreeRoot, repo, revision });
+    if (!snapshot.ok) return failed(query, revision, started, snapshot.reason);
+
+    let result;
+    try {
+      result = JSON.parse(
+        run(tool, ['query', snapshot.path, query, String(NODE_LIMIT)], {
+          maxBuffer: 256 * 1024 * 1024,
+        })
+      );
+    } catch (error) {
+      return failed(query, revision, started, `query-failed: ${firstLine(error)}`);
+    }
+
+    const { byFile, excerptBytes } = collapseToFiles(result.hits ?? []);
+    const ranked = [...byFile.values()]
+      .sort((left, right) => right.score - left.score || left.path.localeCompare(right.path))
+      .slice(0, limit);
+    return {
+      provider_id: PROVIDER_ID,
+      query,
+      indexed_revision: result.context?.snapshot_id ? revision : null,
+      files: ranked.map((entry) => entry.path),
+      ranking: ranked,
+      // The graph returns excerpts, not whole files. Reported separately from the
+      // baseline's whole-file cost so the two are never silently blended.
+      tokens_delivered: Math.ceil(excerptBytes / 4),
+      payload_kind: 'excerpts',
+      latency_ms: elapsed(started),
+      snapshot_id: result.context?.snapshot_id ?? null,
+      freshness: result.context?.freshness ?? null,
+      nodes_returned: (result.hits ?? []).length,
+      truncated: Boolean(result.truncated),
+    };
+  };
+}
+
+function ensureSnapshot({ tool, cacheDir, worktreeRoot, repo, revision }) {
+  const repoId = repo.replace(/\/+$/, '').split('/').pop();
+  const path = join(cacheDir, `${repoId}-${revision}.json`);
+  if (existsSync(path)) return { ok: true, path, cached: true };
+
+  const worktree = join(worktreeRoot, `${repoId}-${revision.slice(0, 12)}`);
+  const materialised = materialiseWorktree({ repo, revision, worktree });
+  if (!materialised.ok) return materialised;
+  try {
+    run(tool, ['build', worktree, revision, path], { maxBuffer: 64 * 1024 * 1024 });
+    // Refuse to score a snapshot the provider cannot read back.
+    const size = statSync(path).size;
+    const importLimit = 32 * 1024 * 1024;
+    if (size > importLimit) {
+      return {
+        ok: false,
+        reason: `snapshot-exceeds-import-limit: ${size} bytes > ${importLimit}`,
+      };
+    }
+    return { ok: true, path, cached: false };
+  } catch (error) {
+    return { ok: false, reason: `build-failed: ${firstLine(error)}` };
+  } finally {
+    rmSync(worktree, { recursive: true, force: true });
+    try {
+      run('git', ['-C', repo, 'worktree', 'prune']);
+    } catch {
+      // Pruning is best-effort bookkeeping.
+    }
+  }
+}
+
+export function readSnapshotIdentity(path) {
+  const document = JSON.parse(readFileSync(path, 'utf8'));
+  return { snapshot_id: document?.snapshot?.id, repo_head: document?.snapshot?.repo_head };
+}

--- a/scripts/context-retrieval/adapters/controls.mjs
+++ b/scripts/context-retrieval/adapters/controls.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+
+// Null controls. These do no retrieval at all, so they calibrate how much of a
+// provider's score comes from understanding the query versus from the shape of the
+// benchmark itself.
+//
+// - random-files : the floor from coverage alone. Returning k of a small repo's n
+//   files scores k/n by luck. Any provider near this is not retrieving.
+// - churn-ranked : the leakage probe. Ground truth is "files a commit changed", and
+//   files that changed often before tend to change again. A churn ranker uses ONLY
+//   history before the base revision and never reads the query. If it rivals the
+//   real providers, the benchmark is rewarding churn prediction, not retrieval.
+
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+
+import { isCandidateFile } from '../paths.mjs';
+import { elapsed } from './shared.mjs';
+
+// The pool a random draw samples from decides how strong the floor is, and it used to
+// be source code only. Widening it to every tracked file is correct — ground truth is
+// "the files the fix touched", which includes .rst, .css, .sh, .mod and .webp — but it
+// also makes the control WEAKER, by 1.18x on gin and 2.36x on flask, and weaker
+// unevenly. A weaker floor flatters every real provider and makes the controls-lose
+// gate easier to pass, so both draws are reported rather than picking the flattering
+// one: random-files is the honest null (no information at all) and random-code-files is
+// the conservative floor a provider ought to have to clear.
+const CODE_POOL = /\.(ts|tsx|js|jsx|mjs|cjs|py|go|rs|java|rb|php|swift|kt|astro)$/;
+
+function randomDraw({ providerId, repo, revision, query, limit, pool }) {
+  const started = process.hrtime.bigint();
+  const files = pool
+    ? listFiles(repo, revision).filter((path) => pool.test(path))
+    : listFiles(repo, revision);
+  // Seeded by case identity so the control is reproducible, not luck of the run.
+  const seed = createHash('sha256').update(`${revision}:${query}`).digest();
+  const ordered = files
+    .map((path, index) => ({
+      path,
+      key: createHash('sha256').update(seed).update(String(index)).digest('hex'),
+    }))
+    .sort((left, right) => left.key.localeCompare(right.key))
+    .slice(0, limit)
+    .map((entry) => entry.path);
+  return {
+    provider_id: providerId,
+    query,
+    indexed_revision: revision,
+    files: ordered,
+    ranking: ordered.map((path, index) => ({ path, rank: index + 1 })),
+    tokens_delivered: wholeFileTokens(repo, revision, ordered),
+    payload_kind: 'control-whole-files',
+    latency_ms: elapsed(started),
+    corpus_size: files.length,
+  };
+}
+
+export function retrieveRandomFiles({ repo, revision, query, limit = 20 }) {
+  return randomDraw({ providerId: 'random-files', repo, revision, query, limit });
+}
+
+// Same draw, restricted to source files. Strictly harder to beat than random-files,
+// because the wasted slots (lockfiles, images, generated output) are removed.
+export function retrieveRandomCodeFiles({ repo, revision, query, limit = 20 }) {
+  return randomDraw({
+    providerId: 'random-code-files',
+    repo,
+    revision,
+    query,
+    limit,
+    pool: CODE_POOL,
+  });
+}
+
+export function retrieveByChurn({ repo, revision, query, limit = 20 }) {
+  const started = process.hrtime.bigint();
+  // `git log <revision>` walks ancestors only, so no post-fix information leaks in.
+  let output;
+  try {
+    output = execFileSync(
+      'git',
+      ['-C', repo, 'log', revision, '--name-only', '--format=', '--no-merges', '--max-count=500'],
+      { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 }
+    );
+  } catch {
+    output = '';
+  }
+  const counts = new Map();
+  for (const line of output.split('\n')) {
+    const path = line.trim();
+    if (!path || !isCandidateFile(path)) continue;
+    counts.set(path, (counts.get(path) ?? 0) + 1);
+  }
+  const present = new Set(listFiles(repo, revision));
+  const ordered = [...counts.entries()]
+    .filter(([path]) => present.has(path))
+    .sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0]))
+    .slice(0, limit)
+    .map(([path, changes]) => ({ path, changes }));
+  return {
+    provider_id: 'churn-ranked',
+    query,
+    indexed_revision: revision,
+    files: ordered.map((entry) => entry.path),
+    ranking: ordered,
+    tokens_delivered: wholeFileTokens(
+      repo,
+      revision,
+      ordered.map((entry) => entry.path)
+    ),
+    payload_kind: 'control-whole-files',
+    latency_ms: elapsed(started),
+    // Recorded to make the point explicit: the query was never read.
+    query_used: false,
+  };
+}
+
+// Controls return paths, not payloads — but an agent handed a path still pays to
+// read the file. Charging them the whole-file cost, exactly as the keyword baseline
+// is charged, is what keeps the token-budget comparison honest; reporting zero would
+// hand every control an unlimited budget and a free win.
+function wholeFileTokens(repo, revision, paths) {
+  if (paths.length === 0) return 0;
+  try {
+    const output = execFileSync('git', ['-C', repo, 'cat-file', '--batch-check'], {
+      encoding: 'utf8',
+      maxBuffer: 16 * 1024 * 1024,
+      input: `${paths.map((path) => `${revision}:${path}`).join('\n')}\n`,
+    });
+    let bytes = 0;
+    for (const line of output.split('\n').filter(Boolean)) {
+      const parts = line.trim().split(/\s+/);
+      if (parts.length >= 3) {
+        const size = Number.parseInt(parts[2], 10);
+        if (Number.isFinite(size)) bytes += size;
+      }
+    }
+    return Math.ceil(bytes / 4);
+  } catch {
+    return 0;
+  }
+}
+
+function listFiles(repo, revision) {
+  try {
+    return execFileSync('git', ['-C', repo, 'ls-tree', '-r', '--name-only', revision], {
+      encoding: 'utf8',
+      maxBuffer: 64 * 1024 * 1024,
+    })
+      .split('\n')
+      .filter((path) => path && isCandidateFile(path));
+  } catch {
+    return [];
+  }
+}

--- a/scripts/context-retrieval/adapters/controls.test.mjs
+++ b/scripts/context-retrieval/adapters/controls.test.mjs
@@ -1,0 +1,89 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { test } from 'node:test';
+
+import { retrieveRandomCodeFiles, retrieveRandomFiles } from './controls.mjs';
+
+// A repository whose tracked files are deliberately a mix of code and everything else,
+// because the distinction between the two random draws is the thing under test.
+const CODE = ['src/app.ts', 'src/util.go', 'lib/handler.py'];
+const NON_CODE = ['package.json', 'go.sum', 'CHANGES.rst', 'docs/guide.md', 'assets/logo.webp'];
+
+function fixtureRepo() {
+  const dir = mkdtempSync(join(tmpdir(), 'cr-controls-'));
+  const git = (...args) => execFileSync('git', ['-C', dir, ...args], { encoding: 'utf8' });
+  git('init', '-q');
+  git('config', 'user.email', 'test@example.com');
+  git('config', 'user.name', 'test');
+  for (const path of [...CODE, ...NON_CODE]) {
+    mkdirSync(join(dir, dirname(path)), { recursive: true });
+    writeFileSync(join(dir, path), 'x\n');
+  }
+  git('add', '-A');
+  git('commit', '-qm', 'init');
+  return { dir, revision: git('rev-parse', 'HEAD').trim() };
+}
+
+test('the honest null draws from every tracked file, not just code', () => {
+  // Restricting the pool to source files was the old behaviour and it is wrong: ground
+  // truth is "the files the fix touched", and the corpus contains .rst, .css, .sh, .mod
+  // and .webp answers. A floor that cannot draw them is not a floor for those cases.
+  const { dir, revision } = fixtureRepo();
+  const result = retrieveRandomFiles({ repo: dir, revision, query: 'anything', limit: 50 });
+  assert.equal(result.corpus_size, CODE.length + NON_CODE.length);
+  assert.deepEqual([...result.files].sort(), [...CODE, ...NON_CODE].sort());
+});
+
+test('the conservative floor draws only source files', () => {
+  const { dir, revision } = fixtureRepo();
+  const result = retrieveRandomCodeFiles({ repo: dir, revision, query: 'anything', limit: 50 });
+  assert.equal(result.corpus_size, CODE.length);
+  assert.deepEqual([...result.files].sort(), [...CODE].sort());
+});
+
+test('the conservative floor is the harder one to beat', () => {
+  // This is why both are reported. Widening the pool makes the random control weaker,
+  // and a weaker floor flatters every real provider and makes the controls-lose gate
+  // easier to pass — so the run has to clear the strict draw too, not only the honest
+  // one. Same limit, fewer wasted slots.
+  const { dir, revision } = fixtureRepo();
+  const limit = 3;
+  const wide = retrieveRandomFiles({ repo: dir, revision, query: 'q', limit });
+  const strict = retrieveRandomCodeFiles({ repo: dir, revision, query: 'q', limit });
+  const codeIn = (files) => files.filter((path) => CODE.includes(path)).length;
+  assert.ok(
+    codeIn(strict.files) >= codeIn(wide.files),
+    `strict draw returned ${codeIn(strict.files)} code files, wide returned ${codeIn(wide.files)}`
+  );
+  assert.equal(codeIn(strict.files), limit);
+});
+
+test('both draws are reproducible from case identity alone', () => {
+  // A control that varies run to run cannot be cited as a floor.
+  const { dir, revision } = fixtureRepo();
+  for (const draw of [retrieveRandomFiles, retrieveRandomCodeFiles]) {
+    const a = draw({ repo: dir, revision, query: 'stable', limit: 3 });
+    const b = draw({ repo: dir, revision, query: 'stable', limit: 3 });
+    assert.deepEqual(a.files, b.files);
+  }
+  // A different query must reshuffle, or the "random" draw is a fixed answer key.
+  const first = retrieveRandomFiles({ repo: dir, revision, query: 'one', limit: 3 });
+  const second = retrieveRandomFiles({ repo: dir, revision, query: 'two', limit: 3 });
+  assert.notDeepEqual(first.files, second.files);
+});
+
+test('the ranking a control reports matches the files it returned', () => {
+  const { dir, revision } = fixtureRepo();
+  const result = retrieveRandomCodeFiles({ repo: dir, revision, query: 'q', limit: 3 });
+  assert.deepEqual(
+    result.ranking.map((entry) => entry.path),
+    result.files
+  );
+  assert.deepEqual(
+    result.ranking.map((entry) => entry.rank),
+    [1, 2, 3]
+  );
+});

--- a/scripts/context-retrieval/adapters/generic-cli-reuse.test.mjs
+++ b/scripts/context-retrieval/adapters/generic-cli-reuse.test.mjs
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+
+import { createGenericCliAdapter } from './generic-cli.mjs';
+
+// Builds a one-commit repository so the adapter has a real revision to materialise.
+function fixtureRepo() {
+  const dir = mkdtempSync(join(tmpdir(), 'cr-reuse-'));
+  const git = (...args) => execFileSync('git', ['-C', dir, ...args], { encoding: 'utf8' });
+  git('init', '-q');
+  git('config', 'user.email', 'test@example.com');
+  git('config', 'user.name', 'test');
+  writeFileSync(join(dir, 'handler.go'), 'package main\n');
+  writeFileSync(join(dir, 'package.json'), '{}\n');
+  git('add', '-A');
+  git('commit', '-qm', 'init');
+  return { dir, revision: git('rev-parse', 'HEAD').trim() };
+}
+
+test('fixed-index mode returns the result instead of discarding it', () => {
+  // This is the large tier's only protocol. The teardown skip was written as
+  // `if (reuseIndex) return;` inside a finally block, and a return there does not merely
+  // skip cleanup — it REPLACES the value the try block produced. Every fixed-index call
+  // resolved to undefined, so the large tier recorded nothing at all and that was read
+  // as retrieval tools failing to scale rather than as the harness dropping their work.
+  const { dir, revision } = fixtureRepo();
+  const worktreeRoot = mkdtempSync(join(tmpdir(), 'cr-wt-'));
+  const retrieve = createGenericCliAdapter({
+    providerId: 'echo-probe',
+    binary: '/bin/echo',
+    queryArgs: () => ['handler.go package.json'],
+    worktreeRoot,
+    reuseIndex: true,
+  });
+
+  const first = retrieve({ repo: dir, revision, query: 'handler', limit: 20 });
+  assert.ok(first, 'fixed-index call returned nothing');
+  assert.deepEqual(first.files, ['handler.go', 'package.json']);
+
+  // The second call must reuse the established worktree and still return a result.
+  const second = retrieve({ repo: dir, revision, query: 'handler', limit: 20 });
+  assert.ok(second, 'reused fixed-index call returned nothing');
+  assert.deepEqual(second.files, ['handler.go', 'package.json']);
+});
+
+test('per-case mode still returns a result and tears its worktree down', () => {
+  const { dir, revision } = fixtureRepo();
+  const worktreeRoot = mkdtempSync(join(tmpdir(), 'cr-wt-'));
+  const retrieve = createGenericCliAdapter({
+    providerId: 'echo-probe',
+    binary: '/bin/echo',
+    queryArgs: () => ['handler.go'],
+    worktreeRoot,
+  });
+  const result = retrieve({ repo: dir, revision, query: 'handler', limit: 20 });
+  assert.ok(result, 'per-case call returned nothing');
+  assert.deepEqual(result.files, ['handler.go']);
+});
+
+test('the provider runs inside the worktree and receives the configured env', () => {
+  // Regression guard. The provider invocations take cwd and env positionally, and
+  // folding them onto a shared three-argument runner silently dropped both: `worktree`
+  // became an options object and `env` was ignored outright, along with the call
+  // timeout. Nothing caught it, because the other tests here invoke /bin/echo, which
+  // produces the same output from any directory. This one asks the tool where it is.
+  const { dir, revision } = fixtureRepo();
+  const worktreeRoot = mkdtempSync(join(tmpdir(), 'cr-wt-'));
+  const retrieve = createGenericCliAdapter({
+    providerId: 'env-probe',
+    binary: '/bin/sh',
+    // Prints its own working directory and one path taken from the environment, so a
+    // dropped cwd or a dropped env shows up as a missing result rather than passing.
+    queryArgs: () => ['-c', 'basename "$PWD"; echo "$PROBE_PATH"'],
+    env: { PROBE_PATH: 'handler.go' },
+    worktreeRoot,
+  });
+
+  const result = retrieve({ repo: dir, revision, query: 'where am i', limit: 20 });
+  assert.ok(result, 'call returned nothing');
+  // handler.go resolves only if PROBE_PATH survived; the cwd basename is the worktree
+  // directory name, which is not a file, so it is correctly filtered out.
+  assert.deepEqual(result.files, ['handler.go']);
+});

--- a/scripts/context-retrieval/adapters/generic-cli.mjs
+++ b/scripts/context-retrieval/adapters/generic-cli.mjs
@@ -1,0 +1,288 @@
+#!/usr/bin/env node
+
+// Config-driven adapter for the common CLI shape: optionally build an index, run a
+// query, read file paths out of whatever the tool prints.
+//
+// Most tools in this category are variations on that shape, so one adapter plus a
+// config entry beats a bespoke integration each time. Same leverage as the MCP
+// client. Tools that genuinely differ (structural patterns, symbol lookup) declare
+// a `queryArgs` builder instead of a template.
+//
+// Every tool is indexed in a worktree materialized at the case's base revision,
+// because they all read the filesystem and would otherwise index HEAD.
+
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, rmSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { pathShaped, PATH_TOKEN, TRAILING_PUNCT } from '../paths.mjs';
+import { elapsed, firstLine, run } from './shared.mjs';
+
+// Several providers write a cache inside the tree they were pointed at
+// (token-savior drops .token-savior/, gitnexus drops .gitnexus/). A teardown that
+// races one of those writes fails with ENOTEMPTY and takes the whole arm down —
+// which is how two repositories were lost to a tool merely finishing its own write.
+// Retry briefly, then give up quietly: a leftover worktree costs disk, not results.
+function removeTree(path, attempts = 5) {
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    try {
+      rmSync(path, { recursive: true, force: true, maxRetries: 3, retryDelay: 120 });
+      return true;
+    } catch {
+      if (attempt === attempts - 1) return false;
+      // Synchronous spin: this runs inside a sync adapter, so there is nowhere to await.
+      const until = Date.now() + 150 * (attempt + 1);
+      while (Date.now() < until) {
+        // busy-wait
+      }
+    }
+  }
+  return false;
+}
+
+const MAX_FILE_BYTES = 512 * 1024;
+
+// Exported so the extraction can be tested directly. It was previously buried inside
+// the adapter closure, reachable only by running a real tool against a real worktree —
+// which is how three separate defects survived in it (a sort inversion, absolute paths
+// silently dropped, and an extension allowlist narrower than the ground truth).
+export function extractPaths({ text, worktree, ignorePattern, isFile = defaultIsFile }) {
+  const ordered = [];
+  const seen = new Set();
+  // Some tools report paths relative to the parent of the repo, so every path arrives
+  // prefixed with the repo directory's own name (gortex does this). Worktree names are
+  // `<provider>-<repo>-<rev12>`, which no real source directory shares, so stripping
+  // that exact leading segment is unambiguous.
+  const selfPrefix = `${worktree.split('/').pop()}/`;
+  const selfRe = new RegExp(`^${selfPrefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`);
+  // PATH_TOKEN keeps a leading slash, so absolute output survives the strips below. It
+  // did not always: the earlier pattern's capture group began with [\w.-], which cannot
+  // match "/", so "/private/.../context.go" arrived as "private/.../context.go", the
+  // worktree-prefix strip missed, and the path was dropped. ck delivered four correct
+  // .go files and was recorded at 0% recall for exactly that reason.
+  const absPrefix = `${worktree.replace(/^\//, '')}/`;
+  for (const match of text.matchAll(PATH_TOKEN)) {
+    const path = match[1]
+      .replace(TRAILING_PUNCT, '')
+      .replace(/^\.\//, '')
+      .replace(`${worktree}/`, '')
+      .replace(absPrefix, '')
+      .replace(selfRe, '');
+    if (!pathShaped(path) || seen.has(path)) continue;
+    if (ignorePattern?.test(path)) continue;
+    // The filesystem adjudicates: a candidate counts only if it resolves to a regular
+    // file at this revision. This check is what makes the extension-agnostic pattern
+    // safe — without it every directory a tool mentions ("src/", "tests/") would take a
+    // result slot and dilute the ranking.
+    if (!isFile(join(worktree, path))) continue;
+    seen.add(path);
+    ordered.push({ path, rank: ordered.length + 1 });
+  }
+  return ordered;
+}
+
+function defaultIsFile(absolute) {
+  try {
+    return statSync(absolute).isFile();
+  } catch {
+    return false;
+  }
+}
+
+export function createGenericCliAdapter({
+  providerId,
+  binary,
+  // Some tools index with a different executable than they query with (zoekt).
+  indexBinary,
+  indexArgs,
+  queryArgs,
+  worktreeRoot,
+  indexRoot,
+  env = {},
+  payloadKind = 'tool-output',
+  // Some tools emit their own paths (config, cache) which are not retrieval results.
+  ignorePattern,
+  // Tools backed by a shared database keep every repository they have ever indexed,
+  // so without this the Nth case searches a graph containing the previous N-1
+  // revisions of the same files. Their copies live outside this worktree and so get
+  // filtered out, but they still consume result slots and silently depress recall.
+  cleanupArgs,
+  // Fixed-index mode for the large tier. The worktree is materialised once at a
+  // pinned revision and kept, and the index step runs only on the first call.
+  // Per-case reindexing is 43 s per case for some providers, which on a 3,000-file
+  // repository makes a rerun cost days — and a benchmark nobody reruns is not a
+  // benchmark. Correctness is preserved upstream: cases admitted under this protocol
+  // are drawn only from fixes that landed after the pinned revision, so the index
+  // still never contains the answer.
+  reuseIndex = false,
+}) {
+  mkdirSync(worktreeRoot, { recursive: true });
+  if (indexRoot) mkdirSync(indexRoot, { recursive: true });
+
+  // Set once reuseIndex has built its worktree, so later cases skip both the
+  // worktree creation and the index step.
+  let established = null;
+
+  // Split into named steps rather than one long body. The composite was flagged at
+  // cognitive complexity 51 against a ceiling of 20, and it had already hidden three
+  // defects — a sort inversion, dropped absolute paths, and a `return` in a `finally`.
+  // A step you can read in one screen is a step whose bug you can see.
+
+  function addWorktree(repo, revision, worktree) {
+    run('git', ['-C', repo, 'worktree', 'add', '--detach', '--force', worktree, revision]);
+  }
+
+  function buildIndex(worktree, revision) {
+    if (!indexArgs) return true;
+    for (const argv of normalizeArgv(indexArgs({ worktree, indexRoot, revision }))) {
+      if (runInTree(indexBinary ?? binary, argv, worktree, env) === null) return false;
+    }
+    return true;
+  }
+
+  // A tool may need several invocations, one per query token; the outputs concatenate.
+  function collectOutput(worktree, query, queryTokens, limit) {
+    let combined = '';
+    for (const argv of normalizeArgv(
+      queryArgs({ worktree, indexRoot, query, queryTokens, limit })
+    )) {
+      const output = runInTree(binary, argv, worktree, env);
+      if (output !== null) combined += `${output}\n`;
+    }
+    return combined;
+  }
+
+  function payloadTokens(worktree, top, combined) {
+    if (payloadKind !== 'whole-files') return Math.ceil(Buffer.byteLength(combined) / 4);
+    return Math.ceil(top.reduce((sum, entry) => sum + fileBytes(worktree, entry.path), 0) / 4);
+  }
+
+  function teardown(repo, worktree) {
+    if (cleanupArgs) {
+      for (const argv of normalizeArgv(cleanupArgs({ worktree, indexRoot }))) {
+        runInTree(binary, argv, undefined, env);
+      }
+    }
+    removeTree(worktree);
+    try {
+      run('git', ['-C', repo, 'worktree', 'prune']);
+    } catch {
+      // Best-effort bookkeeping.
+    }
+  }
+
+  return function retrieveByCli({ repo, revision, query, queryTokens = [], limit = 20 }) {
+    const started = process.hrtime.bigint();
+    const repoId = repo.replace(/\/+$/, '').split('/').pop();
+    const worktree = join(worktreeRoot, `${providerId}-${repoId}-${revision.slice(0, 12)}`);
+    const base = { providerId, payloadKind, query, revision, started };
+    const reusing = reuseIndex && established === worktree;
+
+    if (!reusing) {
+      removeTree(worktree);
+      try {
+        addWorktree(repo, revision, worktree);
+      } catch (error) {
+        return unavailable({ ...base, reason: `worktree: ${firstLine(error)}` });
+      }
+    }
+
+    try {
+      if (!reusing && !buildIndex(worktree, revision)) {
+        return unavailable({ ...base, reason: 'index step failed' });
+      }
+      if (reuseIndex) established = worktree;
+
+      const combined = collectOutput(worktree, query, queryTokens, limit);
+      if (combined.trim().length === 0) {
+        return { ...shape(base), unavailable_reason: 'no output' };
+      }
+
+      const ordered = extractPaths({ text: combined, worktree, ignorePattern });
+      const top = ordered.slice(0, limit);
+      return {
+        ...shape(base),
+        files: top.map((entry) => entry.path),
+        ranking: top,
+        tokens_delivered: payloadTokens(worktree, top, combined),
+        results_parsed: ordered.length,
+      };
+    } catch (error) {
+      return unavailable({ ...base, reason: `query: ${firstLine(error)}` });
+    } finally {
+      // No `return` in here, ever. A bare `return` in a finally block does not just skip
+      // the cleanup — it REPLACES the value the try block was returning. This guard was
+      // written as `if (reuseIndex) return;` to skip teardown in fixed-index mode, and
+      // the effect was that every fixed-index call resolved to undefined: the entire
+      // large tier recorded no results, which was read as tools failing to scale rather
+      // than as the adapter discarding their answers.
+      if (!reuseIndex) teardown(repo, worktree);
+    }
+  };
+}
+
+function normalizeArgv(built) {
+  return Array.isArray(built[0]) ? built : [built];
+}
+
+function shape({ providerId, payloadKind, query, revision, started }) {
+  return {
+    provider_id: providerId,
+    query,
+    indexed_revision: revision,
+    files: [],
+    ranking: [],
+    tokens_delivered: 0,
+    payload_kind: payloadKind,
+    latency_ms: elapsed(started),
+  };
+}
+
+function unavailable({ providerId, payloadKind, query, revision, started, reason }) {
+  return {
+    ...shape({ providerId, payloadKind, query, revision, started }),
+    unavailable_reason: reason,
+  };
+}
+
+function fileBytes(worktree, path) {
+  try {
+    const size = Number.parseInt(
+      run('wc', ['-c', join(worktree, path)])
+        .trim()
+        .split(/\s+/)[0],
+      10
+    );
+    return Number.isFinite(size) && size <= MAX_FILE_BYTES ? size : 0;
+  } catch {
+    return 0;
+  }
+}
+
+// A provider that hangs must lose its case, not the run. One arm sat on a single
+// query for 30 minutes with no timeout set, which blocked every remaining case and
+// every remaining arm behind it — and an unbounded run is an unreproducible one.
+const CALL_TIMEOUT_MS = 300_000;
+
+// Deliberately NOT the shared `run`. Provider invocations need four things the shared
+// helper does not give them: a cwd (the worktree), extra env, a hard timeout, and
+// tolerance of exit 1, which for most search tools means "no matches" rather than
+// failure. Folding this into the shared helper once already dropped the cwd and env
+// silently — the call sites pass them positionally — and the adapter tests did not
+// catch it because /bin/echo ignores cwd. runInTree keeps the difference visible.
+function runInTree(command, args, cwd, env = {}) {
+  try {
+    return execFileSync(command, args, {
+      encoding: 'utf8',
+      maxBuffer: 64 * 1024 * 1024,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: CALL_TIMEOUT_MS,
+      killSignal: 'SIGKILL',
+      env: { ...process.env, ...env },
+      ...(cwd ? { cwd } : {}),
+    });
+  } catch (error) {
+    if (error?.status === 1 && typeof error.stdout === 'string') return error.stdout;
+    return null;
+  }
+}

--- a/scripts/context-retrieval/adapters/generic-cli.test.mjs
+++ b/scripts/context-retrieval/adapters/generic-cli.test.mjs
@@ -1,0 +1,138 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { extractPaths } from './generic-cli.mjs';
+
+const WORKTREE = '/private/tmp/wt/ck-gin-abcdef012345';
+// Stand in for the filesystem so these cases are about extraction, not about a fixture
+// repository. Anything listed here "exists as a regular file"; everything else does not.
+const files = (...paths) => {
+  const set = new Set(paths.map((p) => `${WORKTREE}/${p}`));
+  return (absolute) => set.has(absolute);
+};
+
+test('ground-truth file types outside the source-code vocabulary are extractable', () => {
+  // Every path here is a real ground-truth entry from the corpus. Under the previous
+  // extension allowlist (ts|tsx|js|jsx|mjs|cjs|py|go|rs|java|rb|php|swift|kt|astro)
+  // none of them could be matched, so 174 of 764 cases were unscoreable by construction
+  // and no tool could score them however good its answer was.
+  const nonCode = [
+    'package.json',
+    'go.mod',
+    'go.sum',
+    'CHANGES.rst',
+    'wrangler.toml',
+    'src/styles/globals.css',
+    'scripts/deploy-health.sh',
+    'pnpm-workspace.yaml',
+    'data/people.csv',
+    'index.html',
+    '.gitignore',
+    'Dockerfile',
+    'LICENSE',
+    'public/_headers',
+    '.husky/pre-push',
+  ];
+  const found = extractPaths({
+    text: nonCode.map((p) => `  ${p}`).join('\n'),
+    worktree: WORKTREE,
+    isFile: files(...nonCode),
+  });
+  assert.deepEqual(
+    found.map((entry) => entry.path),
+    nonCode
+  );
+});
+
+test('absolute paths survive extraction', () => {
+  // ck emits absolute paths. The old capture group began with [\w.-], which cannot match
+  // a leading slash, so a full 2,597-token payload of four correct files scored 0%.
+  const found = extractPaths({
+    text: `${WORKTREE}/context.go:12: func (c *Context) Bind\n${WORKTREE}/gin.go:88: engine`,
+    worktree: WORKTREE,
+    isFile: files('context.go', 'gin.go'),
+  });
+  assert.deepEqual(
+    found.map((entry) => entry.path),
+    ['context.go', 'gin.go']
+  );
+});
+
+test('directories never occupy a result slot', () => {
+  // The extension-agnostic pattern matches "src/handlers" as readily as a filename, so
+  // the isFile check is load-bearing: without it a tool that prints the directories it
+  // searched would have those slots counted against its ranking depth.
+  const isFile = (absolute) => absolute === `${WORKTREE}/src/handlers/auth.ts`;
+  const found = extractPaths({
+    text: 'searched src/handlers, src/lib, tests/ and found src/handlers/auth.ts',
+    worktree: WORKTREE,
+    isFile,
+  });
+  assert.deepEqual(
+    found.map((entry) => entry.path),
+    ['src/handlers/auth.ts']
+  );
+});
+
+test('rank reflects the order the tool emitted, not the order discovered on disk', () => {
+  const found = extractPaths({
+    text: 'third.ts\nfirst.ts\nsecond.ts',
+    worktree: WORKTREE,
+    isFile: files('first.ts', 'second.ts', 'third.ts'),
+  });
+  assert.deepEqual(found, [
+    { path: 'third.ts', rank: 1 },
+    { path: 'first.ts', rank: 2 },
+    { path: 'second.ts', rank: 3 },
+  ]);
+});
+
+test('trailing prose punctuation is not absorbed into the path', () => {
+  const found = extractPaths({
+    text: 'The handler lives in src/app.ts. See also (src/util.ts), or src/x.ts;',
+    worktree: WORKTREE,
+    isFile: files('src/app.ts', 'src/util.ts', 'src/x.ts'),
+  });
+  assert.deepEqual(
+    found.map((entry) => entry.path),
+    ['src/app.ts', 'src/util.ts', 'src/x.ts']
+  );
+});
+
+test('a bare extensionless word is not treated as a path', () => {
+  // "Dockerfile" at a root is a real ground-truth file, but a prose word like "results"
+  // is not. The separator-or-extension rule is what distinguishes them, so a tool whose
+  // output is chatty does not accumulate phantom hits on common English words.
+  const found = extractPaths({
+    text: 'results summary complete Dockerfile',
+    worktree: WORKTREE,
+    // Deliberately claim all three exist: the filter under test is shape, not existence.
+    isFile: files('results', 'summary', 'complete', 'Dockerfile'),
+  });
+  assert.deepEqual(
+    found.map((entry) => entry.path),
+    ['Dockerfile']
+  );
+});
+
+test('repo-name self-prefix is stripped', () => {
+  // gortex reports paths relative to the worktree's parent.
+  const found = extractPaths({
+    text: 'ck-gin-abcdef012345/routes.go',
+    worktree: WORKTREE,
+    isFile: files('routes.go'),
+  });
+  assert.deepEqual(
+    found.map((entry) => entry.path),
+    ['routes.go']
+  );
+});
+
+test('duplicate mentions collapse to one ranked entry', () => {
+  const found = extractPaths({
+    text: 'src/app.ts\nsrc/app.ts\n./src/app.ts',
+    worktree: WORKTREE,
+    isFile: files('src/app.ts'),
+  });
+  assert.equal(found.length, 1);
+});

--- a/scripts/context-retrieval/adapters/graphify.mjs
+++ b/scripts/context-retrieval/adapters/graphify.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+
+// Graphify, via its local CLI. Indexing uses `update --no-cluster`, which is pure
+// AST extraction with no LLM call and no network egress; clustering and community
+// labelling are deliberately skipped because they invoke a model.
+//
+// Like the CodeVetter fixture, graphify reads the filesystem, so every case is
+// indexed in a worktree materialized at its own base revision.
+
+import { copyFileSync, existsSync, mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { elapsed, firstLine, materialiseWorktree, run } from './shared.mjs';
+
+export const PROVIDER_ID = 'graphify';
+
+const DEFAULT_BUDGET = 2000;
+const NODE_LINE = /^NODE\s+(.*?)\s+\[src=([^\s\]]*)/;
+const REPORTED_TOKENS = /~(\d+)\s+tokens/;
+
+export function createGraphifyAdapter({
+  binary = 'graphify',
+  cacheDir,
+  worktreeRoot,
+  budget = DEFAULT_BUDGET,
+}) {
+  mkdirSync(cacheDir, { recursive: true });
+  mkdirSync(worktreeRoot, { recursive: true });
+
+  return function retrieveByGraphify({ repo, revision, query, limit = 20 }) {
+    const started = process.hrtime.bigint();
+    const graph = ensureGraph({ binary, cacheDir, worktreeRoot, repo, revision });
+    if (!graph.ok) return unavailable({ query, revision, started, reason: graph.reason });
+
+    let output;
+    try {
+      output = run(binary, ['query', query, '--graph', graph.path, '--budget', String(budget)]);
+    } catch (error) {
+      return unavailable({ query, revision, started, reason: `query-failed: ${firstLine(error)}` });
+    }
+
+    const ordered = [];
+    const seen = new Set();
+    for (const line of output.split('\n')) {
+      const match = NODE_LINE.exec(line.trim());
+      if (!match) continue;
+      const path = match[2];
+      // Nodes without a source path are synthetic references, not retrievable files.
+      if (!path || seen.has(path)) continue;
+      seen.add(path);
+      ordered.push({ path, rank: ordered.length + 1, label: match[1] });
+    }
+    const reported = REPORTED_TOKENS.exec(output);
+    return {
+      provider_id: PROVIDER_ID,
+      query,
+      indexed_revision: revision,
+      // Breadth-first traversal order is the provider's own ranking.
+      files: ordered.slice(0, limit).map((entry) => entry.path),
+      ranking: ordered.slice(0, limit),
+      tokens_delivered: reported
+        ? Number.parseInt(reported[1], 10)
+        : Math.ceil(Buffer.byteLength(output) / 4),
+      payload_kind: 'node-summaries',
+      latency_ms: elapsed(started),
+      nodes_returned: ordered.length,
+    };
+  };
+}
+
+function ensureGraph({ binary, cacheDir, worktreeRoot, repo, revision }) {
+  const repoId = repo.replace(/\/+$/, '').split('/').pop();
+  const cached = join(cacheDir, `${repoId}-${revision}.graph.json`);
+  if (existsSync(cached)) return { ok: true, path: cached, cached: true };
+
+  const worktree = join(worktreeRoot, `${repoId}-${revision.slice(0, 12)}`);
+  const materialised = materialiseWorktree({ repo, revision, worktree });
+  if (!materialised.ok) return materialised;
+  try {
+    run(binary, ['update', worktree, '--no-cluster'], {
+      cwd: worktree,
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    const produced = join(worktree, 'graphify-out', 'graph.json');
+    if (!existsSync(produced)) return { ok: false, reason: 'index-produced-no-graph' };
+    copyFileSync(produced, cached);
+    return { ok: true, path: cached, cached: false };
+  } catch (error) {
+    return { ok: false, reason: `index-failed: ${firstLine(error)}` };
+  } finally {
+    rmSync(worktree, { recursive: true, force: true });
+    try {
+      run('git', ['-C', repo, 'worktree', 'prune']);
+    } catch {
+      // Best-effort bookkeeping.
+    }
+  }
+}
+
+function unavailable({ query, revision, started, reason }) {
+  return {
+    provider_id: PROVIDER_ID,
+    query,
+    indexed_revision: revision,
+    files: [],
+    ranking: [],
+    tokens_delivered: 0,
+    payload_kind: 'node-summaries',
+    latency_ms: elapsed(started),
+    unavailable_reason: reason,
+  };
+}

--- a/scripts/context-retrieval/adapters/jcodemunch.mjs
+++ b/scripts/context-retrieval/adapters/jcodemunch.mjs
@@ -1,0 +1,207 @@
+#!/usr/bin/env node
+
+// jcodemunch — retrieval behind a deliberately compressed wire format.
+//
+// Two things make it unlike every other MCP arm. Its tool surface is six generic
+// verbs rather than named search tools, so retrieval is reached as one of 91
+// catalog actions through `order`. And its payload interns file paths into @1/@2
+// refs with a legend at the top:
+//
+//   #MUNCH/1 tool=search_symbols enc=ss1
+//
+//   @1=context_test.go
+//   @2=context.go
+//
+//   __tables=s:results:id|name|kind|file|line|score|signature|summary
+//   s,@2::Context#type,Context,type,@2,61,,"type Context struct {..."
+//
+// That interning is the product's whole point, so resolving it is measuring the
+// tool as shipped rather than working around it. A generic path regex reports 0%
+// recall here while the tool is in fact returning the right files.
+//
+// Ranking follows first appearance in the results table, not legend order: the
+// legend is emitted sorted, so trusting it would score a fixed alphabetical
+// permutation instead of the tool's own ordering.
+
+const LEGEND = /^@(\d+)=(.+)$/;
+const TABLE_HEADER = /^__tables=([a-z]+):results:(.+)$/;
+
+// Reads the legend and locates the results table in one pass. Split out because the
+// combined parser was flagged at cognitive complexity 22 against a ceiling of 20.
+function readHeader(lines) {
+  const legend = new Map();
+  let rowPrefix = null;
+  let fileColumn = -1;
+  for (const line of lines) {
+    const entry = LEGEND.exec(line.trim());
+    if (entry) {
+      legend.set(entry[1], entry[2].trim());
+      continue;
+    }
+    const header = TABLE_HEADER.exec(line.trim());
+    if (header) {
+      rowPrefix = header[1];
+      fileColumn = header[2].split('|').indexOf('file');
+    }
+  }
+  return { legend, rowPrefix, fileColumn };
+}
+
+// Reference order in the results table, which is the ranking. NOT legend order: the
+// legend is emitted in first-mention order across the whole payload, so ranking by it
+// scored a working retriever on an ordering it never claimed.
+function refsFromTable(lines, rowPrefix, fileColumn) {
+  const refs = [];
+  for (const line of lines) {
+    if (!line.startsWith(`${rowPrefix},`)) continue;
+    const cell = splitRow(line)[fileColumn];
+    const ref = /^@(\d+)$/.exec((cell ?? '').trim());
+    if (ref) refs.push(ref[1]);
+  }
+  return refs;
+}
+
+// Rows can be absent (search_text returns spans, not a symbol table). Fall back to
+// reference order in the body, still not legend order.
+function refsFromBody(lines) {
+  const body = lines.filter((line) => !LEGEND.test(line.trim())).join('\n');
+  return [...body.matchAll(/@(\d+)/g)].map((match) => match[1]);
+}
+
+export function parseMunchPaths({ text }) {
+  if (typeof text !== 'string' || !text.includes('#MUNCH/')) return [];
+  const lines = text.split('\n');
+  const { legend, rowPrefix, fileColumn } = readHeader(lines);
+  if (legend.size === 0) return [];
+
+  const tabled =
+    rowPrefix !== null && fileColumn >= 0 ? refsFromTable(lines, rowPrefix, fileColumn) : [];
+  const refs = tabled.length > 0 ? tabled : refsFromBody(lines);
+
+  const ordered = [];
+  const seen = new Set();
+  for (const id of refs) {
+    const path = legend.get(id);
+    if (!path || seen.has(path)) continue;
+    seen.add(path);
+    ordered.push(path);
+  }
+  return ordered;
+}
+
+// Signatures are embedded whole and contain commas, quotes and newlines, so the
+// row needs real CSV splitting rather than a split(',').
+function splitRow(line) {
+  const cells = [];
+  let cell = '';
+  let quoted = false;
+  for (let index = 0; index < line.length; index += 1) {
+    const char = line[index];
+    if (quoted) {
+      if (char === '"' && line[index + 1] === '"') {
+        cell += '"';
+        index += 1;
+      } else if (char === '"') {
+        quoted = false;
+      } else {
+        cell += char;
+      }
+    } else if (char === '"') {
+      quoted = true;
+    } else if (char === ',') {
+      cells.push(cell);
+      cell = '';
+    } else {
+      cell += char;
+    }
+  }
+  cells.push(cell);
+  return cells;
+}
+
+// jcodemunch indexes a directory and registers it under that directory's basename,
+// then queries by that name rather than by path. So the worktree name IS the repo
+// id, and it has to be deterministic per revision or cases collide. Indexing is a
+// CLI step, not an MCP tool, which is why this wraps the MCP adapter instead of
+// using its indexToolName hook.
+import { mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { run } from './shared.mjs';
+
+export function createJcodemunchAdapter({
+  command,
+  worktreeRoot,
+  timeoutMs = 240_000,
+  createMcpAdapter,
+}) {
+  mkdirSync(worktreeRoot, { recursive: true });
+  const [bin, ...rest] = command.split(' ');
+
+  return async function retrieveByJcodemunch({ repo, revision, query, limit = 20 }) {
+    const started = process.hrtime.bigint();
+    const repoId = repo.replace(/\/+$/, '').split('/').pop();
+    const name = `jcm-${repoId}-${revision.slice(0, 12)}`;
+    const worktree = join(worktreeRoot, name);
+    rmSync(worktree, { recursive: true, force: true });
+    const fail = (reason) => ({
+      provider_id: 'jcodemunch',
+      query,
+      indexed_revision: revision,
+      files: [],
+      ranking: [],
+      tokens_delivered: 0,
+      payload_kind: 'mcp-tool-result',
+      latency_ms: Math.round((Number(process.hrtime.bigint() - started) / 1e6) * 1000) / 1000,
+      unavailable_reason: reason,
+    });
+    try {
+      run('git', ['-C', repo, 'worktree', 'add', '--detach', '--force', worktree, revision]);
+    } catch (error) {
+      return fail(`worktree: ${short(error)}`);
+    }
+    try {
+      // --no-ai-summaries keeps this a retrieval measurement rather than a
+      // measurement of whatever model it would otherwise call per file.
+      run(bin, [...rest, 'index', worktree, '--no-ai-summaries', '--log-level', 'ERROR'], {
+        cwd: worktree,
+      });
+    } catch (error) {
+      return fail(`index: ${short(error)}`);
+    }
+    try {
+      const adapter = createMcpAdapter({
+        providerId: 'jcodemunch',
+        command: bin,
+        args: rest,
+        toolName: 'order',
+        // It reports `limit` in ignored_arguments and always returns 10, so the
+        // budget curve, not the limit, is what constrains it here.
+        buildArguments: ({ query: text }) => ({
+          action: 'search_symbols',
+          args: { repo: name, query: text, limit },
+        }),
+        parsePaths: parseMunchPaths,
+        timeoutMs,
+      });
+      return await adapter({ repo, revision, query, limit, workspace: worktree });
+    } finally {
+      // Leaving the worktree registered would grow its repo list by one per case.
+      try {
+        run(bin, [...rest, 'delete-index', name]);
+      } catch {
+        // delete-index is best-effort; its state dir is disposable either way.
+      }
+      rmSync(worktree, { recursive: true, force: true });
+      try {
+        run('git', ['-C', repo, 'worktree', 'prune']);
+      } catch {
+        // Best-effort bookkeeping.
+      }
+    }
+  };
+}
+
+function short(error) {
+  const text = error?.stderr || error?.message || String(error);
+  return String(text).split('\n')[0].slice(0, 160);
+}

--- a/scripts/context-retrieval/adapters/jcodemunch.test.mjs
+++ b/scripts/context-retrieval/adapters/jcodemunch.test.mjs
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { parseMunchPaths } from './jcodemunch.mjs';
+
+const SYMBOLS = [
+  '#MUNCH/1 tool=search_symbols enc=ss1',
+  '',
+  '@1=context_test.go',
+  '@2=context.go',
+  '',
+  'result_count=2 __tables=s:results:id|name|kind|file|line|score|signature|summary',
+  '',
+  's,@2::Context#type,Context,type,@2,61,,"type Context struct {',
+  '\tfullPath string, comma inside a quoted signature',
+  '}",Context is the most important part of gin.',
+  's,@1::TestX#function,TestX,function,@1,3,,func TestX(t *testing.T),',
+].join('\n');
+
+test('resolves interned refs to paths', () => {
+  assert.deepEqual(parseMunchPaths({ text: SYMBOLS }), ['context.go', 'context_test.go']);
+});
+
+test('ranks by result order, not the sorted legend', () => {
+  // The legend lists context_test.go first. Trusting it would score an alphabetical
+  // permutation of the answer instead of the ordering the tool actually returned.
+  const [first] = parseMunchPaths({ text: SYMBOLS });
+  assert.equal(first, 'context.go');
+});
+
+test('a quoted signature containing commas and newlines does not shift the file column', () => {
+  // Naive split(',') puts "61" in the file column and yields nothing.
+  assert.ok(parseMunchPaths({ text: SYMBOLS }).includes('context.go'));
+});
+
+test('falls back to reference order when there is no results table', () => {
+  const spans = [
+    '#MUNCH/1 tool=search_text enc=ss1',
+    '',
+    '@1=a.go',
+    '@2=b.go',
+    '',
+    'hit @2:14',
+    'hit @1:3',
+  ].join('\n');
+  assert.deepEqual(parseMunchPaths({ text: spans }), ['b.go', 'a.go']);
+});
+
+test('non-munch payloads are left to the default reader', () => {
+  assert.deepEqual(parseMunchPaths({ text: '{"files":["a.go"]}' }), []);
+  assert.deepEqual(parseMunchPaths({ text: undefined }), []);
+});

--- a/scripts/context-retrieval/adapters/keyword-search.mjs
+++ b/scripts/context-retrieval/adapters/keyword-search.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+
+// The honest baseline: what a competent agent already does with grep over the
+// repository at the pre-fix revision. Any context provider has to beat this,
+// not "no context at all".
+
+import { execFileSync } from 'node:child_process';
+
+export const RETRIEVAL_RESPONSE_SCHEMA_VERSION = 'codevetter.context-retrieval-response.v1';
+
+const MAX_FILE_BYTES = 512 * 1024;
+
+const CODE_PATHSPEC = [
+  '*.ts',
+  '*.tsx',
+  '*.mjs',
+  '*.js',
+  '*.rs',
+  '*.astro',
+  '*.py',
+  '*.go',
+  '*.swift',
+  '*.sql',
+  '*.json',
+];
+
+export function retrieveByKeyword({
+  repo,
+  revision,
+  query,
+  queryTokens,
+  limit = 20,
+  maxFileBytes = MAX_FILE_BYTES,
+}) {
+  const started = process.hrtime.bigint();
+  const tokens = [...queryTokens].sort();
+  const hits = new Map();
+  for (const token of tokens) {
+    for (const path of grepFiles(repo, revision, token)) {
+      const entry = hits.get(path) ?? { path, tokens: new Set() };
+      entry.tokens.add(token);
+      hits.set(path, entry);
+    }
+  }
+  // A competent agent does not read a 20MB data blob because one token matched.
+  // Without this the baseline's token cost is dominated by vendored data.
+  const sizes = fileSizes(repo, revision, [...hits.keys()]);
+  const oversized = [...hits.keys()].filter((path) => (sizes.get(path) ?? 0) > maxFileBytes);
+  for (const path of oversized) hits.delete(path);
+  const ranked = [...hits.values()]
+    .map((entry) => ({ path: entry.path, matched: entry.tokens.size }))
+    // Distinct query terms matched first; shorter paths break ties so that a
+    // module beats an incidental mention deep in a generated tree.
+    .sort(
+      (left, right) =>
+        right.matched - left.matched ||
+        left.path.split('/').length - right.path.split('/').length ||
+        left.path.localeCompare(right.path)
+    )
+    .slice(0, limit);
+  const elapsedMs = Number(process.hrtime.bigint() - started) / 1e6;
+  return {
+    schema_version: RETRIEVAL_RESPONSE_SCHEMA_VERSION,
+    provider_id: 'keyword-search',
+    provider_version: gitVersion(repo),
+    query,
+    indexed_revision: revision,
+    files: ranked.map((entry) => entry.path),
+    ranking: ranked,
+    tokens_delivered: Math.ceil(
+      ranked.reduce((total, entry) => total + (sizes.get(entry.path) ?? 0), 0) / 4
+    ),
+    latency_ms: Math.round(elapsedMs * 1000) / 1000,
+    candidates_considered: hits.size,
+    oversized_skipped: oversized.sort(),
+  };
+}
+
+function grepFiles(repo, revision, token) {
+  try {
+    const output = execFileSync(
+      'git',
+      [
+        '-C',
+        repo,
+        'grep',
+        '--name-only',
+        '--fixed-strings',
+        '--ignore-case',
+        '-e',
+        token,
+        revision,
+        '--',
+        ...CODE_PATHSPEC,
+      ],
+      { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 }
+    );
+    return output
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => line.slice(line.indexOf(':') + 1));
+  } catch (error) {
+    // git grep exits 1 when a pattern matches nothing; that is not a failure.
+    if (error?.status === 1) return [];
+    throw error;
+  }
+}
+
+// One `cat-file --batch-check` per query instead of one process per candidate.
+function fileSizes(repo, revision, paths) {
+  const sizes = new Map();
+  if (paths.length === 0) return sizes;
+  const output = execFileSync('git', ['-C', repo, 'cat-file', '--batch-check'], {
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+    input: `${paths.map((path) => `${revision}:${path}`).join('\n')}\n`,
+  });
+  for (const [index, line] of output.split('\n').filter(Boolean).entries()) {
+    const parts = line.trim().split(/\s+/);
+    const size = parts.length >= 3 ? Number.parseInt(parts[2], 10) : 0;
+    sizes.set(paths[index], Number.isFinite(size) ? size : 0);
+  }
+  return sizes;
+}
+
+function gitVersion(repo) {
+  return execFileSync('git', ['-C', repo, '--version'], { encoding: 'utf8' }).trim();
+}

--- a/scripts/context-retrieval/adapters/mcp-client.mjs
+++ b/scripts/context-retrieval/adapters/mcp-client.mjs
@@ -1,0 +1,246 @@
+#!/usr/bin/env node
+
+// Generic MCP stdio client. Most tools in this category ship as an MCP server with
+// no CLI, so one client turns each of them into a config entry instead of a bespoke
+// adapter.
+//
+// Speaks the minimum of the protocol needed to retrieve: initialize, the
+// initialized notification, tools/list, then tools/call.
+
+import { spawn } from 'node:child_process';
+
+import { pathTokensIn } from '../paths.mjs';
+import { elapsed, firstLine } from './shared.mjs';
+
+const PROTOCOL_VERSION = '2025-06-18';
+const DEFAULT_TIMEOUT_MS = 180_000;
+// Paths turn up under many key names across servers; check the common ones.
+const PATH_KEYS = ['path', 'file', 'file_path', 'filePath', 'relative_path', 'relativePath', 'uri'];
+
+export function createMcpAdapter({
+  providerId,
+  command,
+  args = [],
+  env = {},
+  toolName,
+  buildArguments,
+  indexToolName,
+  buildIndexArguments,
+  // Providers whose payload is deliberately not a list of paths supply their own
+  // reader. jcodemunch, for one, interns paths to @1/@2 and ships a legend, so a
+  // path regex scores it 0% recall while it is returning the right symbols.
+  parsePaths,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+}) {
+  return async function retrieveByMcp({ repo, revision, query, limit = 20, workspace }) {
+    const started = process.hrtime.bigint();
+    const root = workspace ?? repo;
+    let session;
+    try {
+      session = await openSession({ command, args, env, cwd: root, timeoutMs });
+    } catch (error) {
+      return unavailable({
+        providerId,
+        query,
+        revision,
+        started,
+        reason: `spawn: ${firstLine(error)}`,
+      });
+    }
+    try {
+      const tools = await session.request('tools/list', {});
+      const names = (tools?.tools ?? []).map((tool) => tool.name);
+      if (!names.includes(toolName)) {
+        return unavailable({
+          providerId,
+          query,
+          revision,
+          started,
+          reason: `tool "${toolName}" not offered; server exposes: ${names.join(', ') || 'none'}`,
+        });
+      }
+      if (indexToolName && names.includes(indexToolName)) {
+        await session.request('tools/call', {
+          name: indexToolName,
+          arguments: buildIndexArguments({ root, query, limit }),
+        });
+      }
+      const result = await session.request('tools/call', {
+        name: toolName,
+        arguments: buildArguments({ root, query, limit }),
+      });
+      return shapeResponse({
+        providerId,
+        query,
+        revision,
+        started,
+        result,
+        root,
+        limit,
+        names,
+        parsePaths,
+      });
+    } catch (error) {
+      return unavailable({ providerId, query, revision, started, reason: firstLine(error) });
+    } finally {
+      session.close();
+    }
+  };
+}
+
+function shapeResponse({ providerId, query, revision, started, result, root, limit, parsePaths }) {
+  const text = (result?.content ?? [])
+    .filter((block) => block?.type === 'text')
+    .map((block) => block.text)
+    .join('\n');
+  const structured = result?.structuredContent ?? tryJson(text);
+  const paths = [];
+  if (parsePaths) {
+    paths.push(...parsePaths({ text, structured }));
+  } else {
+    collectPaths(structured, paths);
+    if (paths.length === 0) collectPathsFromText(text, paths);
+  }
+
+  const ordered = [];
+  const seen = new Set();
+  for (const raw of paths) {
+    const path = raw
+      .replace(/^file:\/\//, '')
+      .replace(root, '')
+      .replace(/^\/+/, '');
+    if (!path || seen.has(path)) continue;
+    seen.add(path);
+    ordered.push({ path, rank: ordered.length + 1 });
+  }
+  return {
+    provider_id: providerId,
+    query,
+    indexed_revision: revision,
+    files: ordered.slice(0, limit).map((entry) => entry.path),
+    ranking: ordered.slice(0, limit),
+    tokens_delivered: Math.ceil(Buffer.byteLength(text) / 4),
+    payload_kind: 'mcp-tool-result',
+    latency_ms: elapsed(started),
+    ...(ordered.length === 0 ? { unavailable_reason: 'no-paths-in-result' } : {}),
+  };
+}
+
+function collectPaths(value, out, depth = 0) {
+  if (depth > 8 || value === null || value === undefined) return;
+  if (Array.isArray(value)) {
+    for (const item of value) collectPaths(item, out, depth + 1);
+    return;
+  }
+  if (typeof value !== 'object') return;
+  for (const key of PATH_KEYS) {
+    if (typeof value[key] === 'string') out.push(value[key]);
+  }
+  for (const nested of Object.values(value)) collectPaths(nested, out, depth + 1);
+}
+
+function collectPathsFromText(text, out) {
+  // Last resort: servers that only return prose still name files in it. Shared with
+  // every other adapter on purpose — this used to carry its own extension allowlist,
+  // one of four that disagreed, so an MCP arm could name a .json file while a CLI arm
+  // could not and the two were not being asked the same question. See ../paths.mjs.
+  for (const token of pathTokensIn(text)) out.push(token);
+}
+
+async function openSession({ command, args, env, cwd, timeoutMs }) {
+  const child = spawn(command, args, {
+    cwd,
+    env: { ...process.env, ...env },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  let buffer = '';
+  const pending = new Map();
+  let nextId = 1;
+  let stderr = '';
+
+  child.stdout.setEncoding('utf8');
+  child.stdout.on('data', (chunk) => {
+    buffer += chunk;
+    let newline = buffer.indexOf('\n');
+    while (newline !== -1) {
+      const line = buffer.slice(0, newline).trim();
+      buffer = buffer.slice(newline + 1);
+      newline = buffer.indexOf('\n');
+      if (!line) continue;
+      let message;
+      try {
+        message = JSON.parse(line);
+      } catch {
+        continue; // Servers sometimes log to stdout; ignore non-JSON lines.
+      }
+      const waiter = pending.get(message.id);
+      if (!waiter) continue;
+      pending.delete(message.id);
+      if (message.error) waiter.reject(new Error(message.error.message ?? 'mcp error'));
+      else waiter.resolve(message.result);
+    }
+  });
+  child.stderr.setEncoding('utf8');
+  child.stderr.on('data', (chunk) => {
+    stderr = `${stderr}${chunk}`.slice(-4000);
+  });
+  child.on('exit', () => {
+    for (const waiter of pending.values()) {
+      waiter.reject(new Error(`server exited: ${stderr.split('\n').filter(Boolean).pop() ?? ''}`));
+    }
+    pending.clear();
+  });
+
+  const send = (payload) => child.stdin.write(`${JSON.stringify(payload)}\n`);
+  const request = (method, params) =>
+    new Promise((resolve, reject) => {
+      const id = nextId++;
+      const timer = setTimeout(() => {
+        pending.delete(id);
+        reject(new Error(`timeout on ${method}`));
+      }, timeoutMs);
+      pending.set(id, {
+        resolve: (value) => {
+          clearTimeout(timer);
+          resolve(value);
+        },
+        reject: (error) => {
+          clearTimeout(timer);
+          reject(error);
+        },
+      });
+      send({ jsonrpc: '2.0', id, method, params });
+    });
+
+  await request('initialize', {
+    protocolVersion: PROTOCOL_VERSION,
+    capabilities: {},
+    clientInfo: { name: 'codevetter-retrieval-benchmark', version: '1' },
+  });
+  send({ jsonrpc: '2.0', method: 'notifications/initialized' });
+  return { request, close: () => child.kill('SIGKILL') };
+}
+
+function tryJson(text) {
+  const start = text.search(/[[{]/);
+  if (start === -1) return null;
+  try {
+    return JSON.parse(text.slice(start));
+  } catch {
+    return null;
+  }
+}
+
+function unavailable({ providerId, query, revision, started, reason }) {
+  return {
+    provider_id: providerId,
+    query,
+    indexed_revision: revision,
+    files: [],
+    ranking: [],
+    tokens_delivered: 0,
+    payload_kind: 'mcp-tool-result',
+    latency_ms: elapsed(started),
+    unavailable_reason: reason,
+  };
+}

--- a/scripts/context-retrieval/adapters/repomapper.mjs
+++ b/scripts/context-retrieval/adapters/repomapper.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+
+// RepoMapper (pdavis68/RepoMapper): a standalone implementation of Aider's repo-map
+// — tree-sitter tags plus personalized PageRank over the symbol graph.
+//
+// IMPORTANT: repo-map is not a natural-language retrieval interface, and scoring it
+// as one is a category error.
+//
+// `--mentioned-idents` applies a 10x boost where `tag.name in mentioned_idents` — an
+// exact match against extracted *identifier* names. Feeding it prose tokens from a
+// commit subject ("canonical", "auth", "fallback") almost never matches a camelCase
+// tag, so it produces no boost while still perturbing the map, and scores BELOW the
+// no-personalization run. Fed real identifiers instead (`getGmailAccessToken`,
+// `AuthEnv`) it ranks the correct file first.
+//
+// So `personalize: true` is only meaningful with an identifier list, which a
+// natural-language corpus cannot supply. In Aider those identifiers come from live
+// chat state. `repomap-global` is the configuration this benchmark can measure
+// honestly: a query-blind orientation map, expected to land near the controls.
+
+import { existsSync, mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { elapsed, firstLine, materialiseWorktree, run } from './shared.mjs';
+
+export const PROVIDER_ID = 'repomap';
+
+// The repr-printed map names each file as `path:\n(Rank value: N)`, and the tuple
+// repr escapes its newlines, so accept either form.
+// The separator is consumed explicitly: matching it as an optional prefix lets the
+// path class swallow the "n" out of an escaped "\n" and yields paths like "nsrc/…".
+const RANKED_FILE =
+  /(?:\\n|\n|^|["\s])([\w.-]+(?:\/[\w.-]+)*\.[A-Za-z]+):(?:\\n|\n)\(Rank value: ([\d.]+)\)/g;
+
+export function createRepomapperAdapter({
+  python,
+  script,
+  worktreeRoot,
+  personalize = true,
+  mapTokens = 4096,
+}) {
+  if (!existsSync(script)) throw new Error(`RepoMapper script not found: ${script}`);
+  mkdirSync(worktreeRoot, { recursive: true });
+
+  return function retrieveByRepomap({ repo, revision, query, queryTokens = [], limit = 20 }) {
+    const started = process.hrtime.bigint();
+    const repoId = repo.replace(/\/+$/, '').split('/').pop();
+    const worktree = join(worktreeRoot, `rm-${repoId}-${revision.slice(0, 12)}`);
+    const materialised = materialiseWorktree({ repo, revision, worktree });
+    if (!materialised.ok) {
+      return unavailable({ query, revision, started, reason: materialised.reason });
+    }
+    try {
+      const args = [script, worktree, '--root', worktree, '--map-tokens', String(mapTokens)];
+      if (personalize && queryTokens.length > 0) {
+        args.push('--mentioned-idents', ...queryTokens);
+      }
+      const output = run(python, args, { cwd: worktree, maxBuffer: 256 * 1024 * 1024 });
+      const ranked = [];
+      const seen = new Set();
+      for (const match of output.matchAll(RANKED_FILE)) {
+        const path = match[1];
+        if (seen.has(path)) continue;
+        seen.add(path);
+        ranked.push({ path, rank: ranked.length + 1, score: Number.parseFloat(match[2]) });
+      }
+      const scores = new Set(ranked.map((entry) => entry.score));
+      return {
+        provider_id: providerId(personalize),
+        query,
+        indexed_revision: revision,
+        files: ranked.slice(0, limit).map((entry) => entry.path),
+        ranking: ranked.slice(0, limit),
+        tokens_delivered: Math.ceil(Buffer.byteLength(output) / 4),
+        payload_kind: 'symbol-map',
+        latency_ms: elapsed(started),
+        files_ranked: ranked.length,
+        // Recorded so a degenerate all-ties ranking is visible in the evidence
+        // rather than being silently scored as if it were a ranking.
+        distinct_scores: scores.size,
+        rank_is_degenerate: scores.size <= 1,
+      };
+    } catch (error) {
+      return unavailable({
+        query,
+        revision,
+        started,
+        personalize,
+        reason: `map: ${firstLine(error)}`,
+      });
+    } finally {
+      rmSync(worktree, { recursive: true, force: true });
+      try {
+        run('git', ['-C', repo, 'worktree', 'prune']);
+      } catch {
+        // Best-effort bookkeeping.
+      }
+    }
+  };
+}
+
+function providerId(personalize) {
+  return personalize ? 'repomap-personalized' : 'repomap-global';
+}
+
+function unavailable({ query, revision, started, personalize, reason }) {
+  return {
+    provider_id: providerId(personalize),
+    query,
+    indexed_revision: revision,
+    files: [],
+    ranking: [],
+    tokens_delivered: 0,
+    payload_kind: 'symbol-map',
+    latency_ms: elapsed(started),
+    unavailable_reason: reason,
+  };
+}

--- a/scripts/context-retrieval/adapters/repomix.mjs
+++ b/scripts/context-retrieval/adapters/repomix.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+
+// Repomix as the upper reference bound, not a competitor. It is a packer, not a
+// retriever: it ships the whole repository, so it reaches perfect recall by
+// definition and its only interesting number is the token cost of doing so.
+//
+// Including it frames every other row. A provider is only worth anything if it
+// approaches this recall at a small fraction of this cost.
+
+import { existsSync, mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { elapsed, firstLine, materialiseWorktree, run } from './shared.mjs';
+
+export const PROVIDER_ID = 'repomix-pack-all';
+
+export function createRepomixAdapter({ binary = 'npx', worktreeRoot, compress = false }) {
+  mkdirSync(worktreeRoot, { recursive: true });
+
+  return function retrieveByRepomix({ repo, revision, query, limit = 20 }) {
+    const started = process.hrtime.bigint();
+    const repoId = repo.replace(/\/+$/, '').split('/').pop();
+    const worktree = join(worktreeRoot, `repomix-${repoId}-${revision.slice(0, 12)}`);
+    const materialised = materialiseWorktree({ repo, revision, worktree });
+    if (!materialised.ok) {
+      return unavailable({ query, revision, started, reason: materialised.reason });
+    }
+    try {
+      const output = join(worktree, 'repomix-output.xml');
+      const args = [
+        '--yes',
+        'repomix@1.18.0',
+        worktree,
+        '--output',
+        output,
+        '--style',
+        'xml',
+        '--no-file-summary',
+        '--no-directory-structure',
+      ];
+      if (compress) args.push('--compress');
+      const stdout = run(binary, args, { cwd: worktree });
+      // Repomix reports its own token total; prefer it over an estimate.
+      const reported = /Total Tokens?:\s*([\d,]+)/i.exec(stdout);
+      const tokens = reported
+        ? Number.parseInt(reported[1].replaceAll(',', ''), 10)
+        : Math.ceil(fileBytes(output) / 4);
+      // A packer "returns" every file it packed. Rank is arbitrary because there is no
+      // ranking; the honest report is the whole set with its true cost.
+      //
+      // The whole set, and NOT the first `limit` of it. Truncating to 20 took the first
+      // twenty paths in `git ls-files` order — .editorconfig, .github/... — which are
+      // never the answer, so both packer arms recorded 0.0% recall and a 1.0 zero-hit
+      // rate on all 108 cases while in fact delivering every required file in a 163k
+      // token payload. "Finds nothing" and "finds everything, unaffordably" are opposite
+      // findings and the truncation turned the second into the first. The token-budget
+      // metric is what should penalise a packer, and it does that without any help.
+      const packed = existsSync(output)
+        ? run('git', ['-C', worktree, 'ls-files']).split('\n').filter(Boolean)
+        : [];
+      return {
+        provider_id: compress ? `${PROVIDER_ID}-compressed` : PROVIDER_ID,
+        query,
+        indexed_revision: revision,
+        files: packed,
+        ranking: packed.map((path, index) => ({ path, rank: index + 1 })),
+        tokens_delivered: tokens,
+        payload_kind: 'whole-repository',
+        latency_ms: elapsed(started),
+        files_packed: packed.length,
+        unranked: true,
+      };
+    } catch (error) {
+      return unavailable({ query, revision, started, reason: `pack-failed: ${firstLine(error)}` });
+    } finally {
+      rmSync(worktree, { recursive: true, force: true });
+      try {
+        run('git', ['-C', repo, 'worktree', 'prune']);
+      } catch {
+        // Best-effort bookkeeping.
+      }
+    }
+  };
+}
+
+function fileBytes(path) {
+  try {
+    return Number.parseInt(run('wc', ['-c', path]).trim().split(/\s+/)[0], 10);
+  } catch {
+    return 0;
+  }
+}
+
+function unavailable({ query, revision, started, reason }) {
+  return {
+    provider_id: PROVIDER_ID,
+    query,
+    indexed_revision: revision,
+    files: [],
+    ranking: [],
+    tokens_delivered: 0,
+    payload_kind: 'whole-repository',
+    latency_ms: elapsed(started),
+    unavailable_reason: reason,
+  };
+}

--- a/scripts/context-retrieval/adapters/ripgrep.mjs
+++ b/scripts/context-retrieval/adapters/ripgrep.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+
+// ripgrep — the actual default. Claude Code and most coding agents ship ripgrep as
+// their search tool, so this is not a synthetic baseline: it is the thing a provider
+// has to beat to be worth installing at all.
+//
+// Differs from the git-grep baseline in two ways that matter: it reads the working
+// tree rather than a git revision, and it respects .gitignore by default. The probe
+// therefore runs it inside a worktree materialized at the target revision.
+
+import { existsSync, mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { elapsed, firstLine, materialiseWorktree, run } from './shared.mjs';
+
+export const PROVIDER_ID = 'ripgrep';
+
+const MAX_FILE_BYTES = 512 * 1024;
+// Code only, matching the git-grep baseline's pathspec so the two are comparable.
+const TYPES = ['ts', 'js', 'py', 'go', 'rust'];
+
+export function createRipgrepAdapter({ binary = 'rg', worktreeRoot }) {
+  mkdirSync(worktreeRoot, { recursive: true });
+
+  return function retrieveByRipgrep({ repo, revision, query, queryTokens = [], limit = 20 }) {
+    const started = process.hrtime.bigint();
+    const repoId = repo.replace(/\/+$/, '').split('/').pop();
+    const worktree = join(worktreeRoot, `rg-${repoId}-${revision.slice(0, 12)}`);
+    const materialised = materialiseWorktree({ repo, revision, worktree });
+    if (!materialised.ok) {
+      return unavailable({ query, revision, started, reason: materialised.reason });
+    }
+    try {
+      // One pass per token, then rank by how many distinct terms hit the file —
+      // the same ranking the git-grep baseline uses, so the two are comparable.
+      const hits = new Map();
+      for (const token of [...queryTokens].sort()) {
+        for (const path of countLines(binary, worktree, token)) {
+          const entry = hits.get(path) ?? { path, matched: 0 };
+          entry.matched += 1;
+          hits.set(path, entry);
+        }
+      }
+      const ranked = [...hits.values()]
+        .sort(
+          (left, right) =>
+            right.matched - left.matched ||
+            left.path.split('/').length - right.path.split('/').length ||
+            left.path.localeCompare(right.path)
+        )
+        .slice(0, limit);
+      const bytes = ranked.reduce((total, entry) => total + fileBytes(worktree, entry.path), 0);
+      return {
+        provider_id: PROVIDER_ID,
+        query,
+        indexed_revision: revision,
+        files: ranked.map((entry) => entry.path),
+        ranking: ranked.map((entry, index) => ({ ...entry, rank: index + 1 })),
+        tokens_delivered: Math.ceil(bytes / 4),
+        payload_kind: 'whole-files',
+        latency_ms: elapsed(started),
+        holds_index: false,
+      };
+    } catch (error) {
+      return unavailable({ query, revision, started, reason: `search: ${firstLine(error)}` });
+    } finally {
+      rmSync(worktree, { recursive: true, force: true });
+      try {
+        run('git', ['-C', repo, 'worktree', 'prune']);
+      } catch {
+        // Best-effort bookkeeping.
+      }
+    }
+  };
+}
+
+function countLines(binary, worktree, token) {
+  const args = ['--files-with-matches', '--fixed-strings', '--ignore-case'];
+  for (const type of TYPES) args.push('--type', type);
+  args.push('--', token, '.');
+  try {
+    return run(binary, args, { cwd: worktree }).split('\n').filter(Boolean).map(strip);
+  } catch (error) {
+    // ripgrep exits 1 when nothing matched, which is an answer not a failure.
+    if (error?.status === 1) return [];
+    throw error;
+  }
+}
+
+function strip(path) {
+  return path.replace(/^\.\//, '');
+}
+
+function fileBytes(worktree, path) {
+  const full = join(worktree, path);
+  if (!existsSync(full)) return 0;
+  try {
+    const size = Number.parseInt(run('wc', ['-c', full]).trim().split(/\s+/)[0], 10);
+    // Same cap as every other whole-file arm: nobody reads a huge blob entire.
+    return Number.isFinite(size) && size <= MAX_FILE_BYTES ? size : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function unavailable({ query, revision, started, reason }) {
+  return {
+    provider_id: PROVIDER_ID,
+    query,
+    indexed_revision: revision,
+    files: [],
+    ranking: [],
+    tokens_delivered: 0,
+    payload_kind: 'whole-files',
+    latency_ms: elapsed(started),
+    unavailable_reason: reason,
+  };
+}

--- a/scripts/context-retrieval/adapters/shared.mjs
+++ b/scripts/context-retrieval/adapters/shared.mjs
@@ -1,0 +1,72 @@
+// Helpers every adapter needs, in one place.
+//
+// They were copied into eight adapter files, which the clone gate correctly flagged:
+// `run`, `elapsed` and `firstLine` were byte-identical across codesearch, repomix,
+// repomapper, ripgrep, graphify, keyword-search, cli-indexed-mcp and jcodemunch, and
+// `unavailableShape` differed only in its payload_kind string. Duplicated helpers in a
+// measurement harness are worse than duplicated helpers elsewhere: a fix applied to one
+// copy silently leaves the other arms measuring something different, which is how four
+// adapters ended up with four disagreeing definitions of a file path.
+
+import { execFileSync } from 'node:child_process';
+import { rmSync } from 'node:fs';
+
+// The third parameter is an OPTIONS OBJECT, not a cwd. Three call sites passed a bare
+// worktree path here during consolidation, and because a spread string contributes no
+// keys the cwd was silently never set — ripgrep searched the harness's own repository
+// instead of the tree under test and returned this repo's files. Pass { cwd } explicitly.
+export function run(command, args, options = {}) {
+  if (typeof options !== 'object' || options === null) {
+    throw new TypeError(
+      `run(): third argument must be an options object, received ${typeof options}`
+    );
+  }
+  return execFileSync(command, args, {
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    ...options,
+  });
+}
+
+export function elapsed(started) {
+  return Math.round((Number(process.hrtime.bigint() - started) / 1e6) * 1000) / 1000;
+}
+
+// Tools report failures on stderr at arbitrary length; one line is enough to classify.
+export function firstLine(error) {
+  const text = error?.stderr || error?.message || String(error);
+  return String(text).split('\n')[0].slice(0, 200);
+}
+
+// The shape an arm returns when it could not answer. Distinct from an empty answer:
+// an arm that ran and found nothing is a result, an arm that could not run is not, and
+// collapsing the two is the single largest distortion available in this benchmark.
+export function unavailableShape({ providerId, query, revision, started, payloadKind, reason }) {
+  return {
+    provider_id: providerId,
+    query,
+    indexed_revision: revision,
+    files: [],
+    ranking: [],
+    tokens_delivered: 0,
+    payload_kind: payloadKind,
+    latency_ms: elapsed(started),
+    unavailable_reason: reason,
+  };
+}
+
+// Materialise a repository at one revision. Every adapter needs this and eight of them
+// had spelled it out inline, which the clone gate flagged five times over. Returning a
+// result rather than throwing keeps the caller's error path explicit: a worktree that
+// cannot be created is an unavailable arm, not a retrieval failure, and the two must not
+// collapse into the same published number.
+export function materialiseWorktree({ repo, revision, worktree }) {
+  rmSync(worktree, { recursive: true, force: true });
+  try {
+    run('git', ['-C', repo, 'worktree', 'add', '--detach', '--force', worktree, revision]);
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, reason: `worktree-failed: ${firstLine(error)}` };
+  }
+}

--- a/scripts/context-retrieval/adapters/shared.test.mjs
+++ b/scripts/context-retrieval/adapters/shared.test.mjs
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+
+import { materialiseWorktree, run, unavailableShape } from './shared.mjs';
+
+test('run refuses a positional cwd instead of silently ignoring it', () => {
+  // Three adapters passed a bare worktree path as the third argument during
+  // consolidation. Because spreading a string contributes no keys, cwd was never set and
+  // ripgrep searched the harness's own repository — returning this repo's files while
+  // claiming to have searched the tree under test. A silent wrong answer is the worst
+  // failure mode available here, so the signature now rejects it.
+  assert.throws(() => run('/bin/echo', ['x'], '/some/path'), /options object/);
+});
+
+test('run honours an explicit cwd', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'cr-shared-'));
+  const out = run('/bin/sh', ['-c', 'pwd'], { cwd: dir }).trim();
+  // macOS resolves /var through a symlink to /private/var, so compare the leaf.
+  assert.equal(out.split('/').pop(), dir.split('/').pop());
+});
+
+test('materialiseWorktree reports failure rather than throwing', () => {
+  // A tree that cannot be created is an unavailable arm, not a retrieval failure. The
+  // two must stay distinguishable: collapsing "could not run" into "found nothing" is
+  // the single largest distortion available in this benchmark.
+  const result = materialiseWorktree({
+    repo: '/nonexistent/repo',
+    revision: 'deadbeef',
+    worktree: join(mkdtempSync(join(tmpdir(), 'cr-shared-')), 'wt'),
+  });
+  assert.equal(result.ok, false);
+  assert.match(result.reason, /^worktree-failed:/);
+});
+
+test('materialiseWorktree checks out the requested revision', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'cr-shared-repo-'));
+  const git = (...args) => execFileSync('git', ['-C', dir, ...args], { encoding: 'utf8' });
+  git('init', '-q');
+  git('config', 'user.email', 'test@example.com');
+  git('config', 'user.name', 'test');
+  execFileSync('touch', [join(dir, 'a.ts')]);
+  git('add', '-A');
+  git('commit', '-qm', 'one');
+  const revision = git('rev-parse', 'HEAD').trim();
+
+  const worktree = join(mkdtempSync(join(tmpdir(), 'cr-shared-wt-')), 'wt');
+  assert.equal(materialiseWorktree({ repo: dir, revision, worktree }).ok, true);
+  assert.equal(
+    execFileSync('git', ['-C', worktree, 'rev-parse', 'HEAD'], { encoding: 'utf8' }).trim(),
+    revision
+  );
+});
+
+test('the unavailable shape carries no results and no cost', () => {
+  const shape = unavailableShape({
+    providerId: 'x',
+    query: 'q',
+    revision: 'r',
+    started: process.hrtime.bigint(),
+    payloadKind: 'chunks',
+    reason: 'because',
+  });
+  assert.deepEqual(shape.files, []);
+  assert.deepEqual(shape.ranking, []);
+  assert.equal(shape.tokens_delivered, 0);
+  assert.equal(shape.unavailable_reason, 'because');
+});


### PR DESCRIPTION
Third of the stack. Depends on #171 (`paths.mjs`).

Sixteen adapters. The code is mostly mechanical; the comments carry the value, because most of these files record a defect that made a working tool look broken.

## Worth reviewing

**`extractPaths` is exported.** It used to live inside the adapter closure, reachable only by running a real tool against a real worktree — which is how three defects survived in it: a sort inversion, absolute paths silently dropped (the capture group began `[\w.-]`, which cannot match a leading `/`), and an extension allowlist narrower than the ground truth. It now has 8 direct tests.

**The `if (!reuseIndex)` guard in the `finally` block must stay that shape.** Written as `if (reuseIndex) return;` it does not skip teardown — a `return` in `finally` *replaces the value the `try` block produced*. Every fixed-index call resolved to `undefined`, so an entire tier recorded nothing, which read as tools failing to scale. `generic-cli-reuse.test.mjs` fails if it regresses; I verified that by reintroducing the bug.

**`controls.mjs` draws from every tracked file, not source only.** Ground truth is not restricted to code. This weakens the floor, which flatters every real provider — so the conservative source-only draw ships beside it, not instead of it.

**`repomix.mjs` reports every packed file.** Truncating to 20 took `.editorconfig` and `.github/…`, so both packer arms read 0.0% while delivering every required file in 103 of 108 cases.

## Verification

20 tests across `generic-cli`, `generic-cli-reuse`, `controls`, `jcodemunch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)