### PR TITLE
feat(retrieval): scoring runner, reporters, and corpus builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,6 @@ cache.bin
 # Local agent logs / scratch
 .agent-logs/
 .devin/
+
+# Cache written into the working tree by repo-map providers under benchmark
+.repomap.tags.cache.v1/

--- a/package.json
+++ b/package.json
@@ -25,6 +25,10 @@
     "corpus:context-snapshot": "node scripts/agent-task-corpus/prepare-context-snapshot.mjs",
     "corpus:context-run": "node scripts/agent-task-corpus/context-provider-run-cli.mjs",
     "corpus:context-evaluate": "node scripts/agent-task-corpus/context-provider-evaluate-cli.mjs",
+    "retrieval:corpus": "node scripts/context-retrieval/build-corpus.mjs",
+    "retrieval:score": "node scripts/context-retrieval/score.mjs",
+    "retrieval:staleness": "node scripts/context-retrieval/probe-staleness.mjs",
+    "retrieval:candidates": "node scripts/context-retrieval/probe-candidates.mjs",
     "runtime:detect": "node scripts/runtime-failure-capsule/cli.mjs detect",
     "runtime:qualify": "node scripts/runtime-failure-capsule/cli.mjs qualify",
     "runtime:qualify-portfolio": "node scripts/runtime-failure-capsule/cli.mjs qualify-portfolio",
@@ -47,6 +51,7 @@
     "test:graph-context": "node --test scripts/run-structural-context-evaluation.test.mjs",
     "test:corpus-contracts": "node --test scripts/agent-task-corpus/*.test.mjs",
     "test:context-provider-plan": "node --test scripts/agent-task-corpus/context-provider-plan.test.mjs",
+    "test:retrieval": "node --test scripts/context-retrieval/*.test.mjs",
     "test:runtime-failure-capsule": "node --test scripts/runtime-failure-capsule/*.test.mjs",
     "test:verification-receipts": "node --test scripts/verification-receipts/*.test.mjs",
     "test:automation": "node --test scripts/emit-foundry-receipt.test.mjs",
@@ -62,7 +67,8 @@
     "quality:complexity": "node scripts/check-changed-complexity.mjs",
     "quality:cycles": "biome lint --only=suspicious/noImportCycles .",
     "quality:dependencies": "pnpm audit --audit-level high",
-    "quality:duplication": "jscpd apps/desktop/src apps/landing-page-astro/src scripts --min-lines 8 --min-tokens 60 --mode strict --format typescript,tsx,javascript --cross-formats js-ts --ignore '**/fixtures/**,**/generated/**,**/gen/**,**/node_modules/**,**/dist/**,**/out/**,**/coverage/**' --threshold 0.81 --reporters console,threshold --no-colors --no-tips"
+    "quality:duplication": "jscpd apps/desktop/src apps/landing-page-astro/src scripts --min-lines 8 --min-tokens 60 --mode strict --format typescript,tsx,javascript --cross-formats js-ts --ignore '**/fixtures/**,**/generated/**,**/gen/**,**/node_modules/**,**/dist/**,**/out/**,**/coverage/**' --threshold 0.81 --reporters console,threshold --no-colors --no-tips",
+    "retrieval:discover": "node scripts/context-retrieval/discover-candidates.mjs --registry benchmarks/context-retrieval/candidates.json --fresh-since 2026-02-22"
   },
   "license": "ISC",
   "lint-staged": {

--- a/scripts/context-retrieval/abandon.test.mjs
+++ b/scripts/context-retrieval/abandon.test.mjs
@@ -1,0 +1,107 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+
+import { isHardFailure, scoreRetrieval } from './score.mjs';
+
+// This file used to assert on score.mjs's SOURCE TEXT — matching the literal expression
+// `consecutiveHardFailures = hard ? consecutiveHardFailures + 1 : 0`. That tests the
+// spelling of an implementation, not its behaviour: extracting the loop into a named
+// function broke the test while leaving the behaviour identical, which is exactly
+// backwards from what a test should do. These drive the real code instead.
+
+function fixture(caseCount) {
+  const dir = mkdtempSync(join(tmpdir(), 'cr-abandon-'));
+  const git = (...args) => execFileSync('git', ['-C', dir, ...args], { encoding: 'utf8' });
+  git('init', '-q');
+  git('config', 'user.email', 'test@example.com');
+  git('config', 'user.name', 'test');
+  writeFileSync(join(dir, 'app.ts'), 'export const a = 1;\n');
+  git('add', '-A');
+  git('commit', '-qm', 'one');
+  const revision = git('rev-parse', 'HEAD').trim();
+  return {
+    repo: dir,
+    corpus: {
+      repository: { id: 'fixture', head: revision },
+      counts: { cases: caseCount, path_leak: 0, baseline_blind: 0, multi_file: 0 },
+      cases: Array.from({ length: caseCount }, (_, index) => ({
+        case_id: `c${index}`,
+        base_revision: revision,
+        query: `query ${index}`,
+        query_tokens: ['query'],
+        required_files: ['app.ts'],
+        retrieval: { path_leak: false },
+      })),
+    },
+  };
+}
+
+const emptyResponse = (reason) => ({
+  provider_id: 'stub',
+  files: [],
+  ranking: [],
+  tokens_delivered: 0,
+  payload_kind: 'chunks',
+  latency_ms: 1,
+  ...(reason ? { unavailable_reason: reason } : {}),
+});
+
+test('an arm that cannot index is abandoned rather than retried for every case', async () => {
+  // One arm burned roughly 55 minutes proving a repository unindexable 11 times at a
+  // 5-minute call timeout apiece. Three strikes and the arm stops.
+  const { repo, corpus } = fixture(30);
+  let calls = 0;
+  const adapters = new Map([
+    [
+      'stub',
+      () => {
+        calls += 1;
+        return emptyResponse('index step failed');
+      },
+    ],
+  ]);
+  const report = await scoreRetrieval({ corpus, repo, providerIds: ['stub'], adapters });
+  assert.equal(calls, 3, `adapter was called ${calls} times; it should stop after 3`);
+  const arm = report.providers.find((entry) => entry.provider_id === 'stub');
+  assert.ok(arm.abandoned, 'abandonment was not recorded in the artifact');
+  assert.equal(arm.abandoned.after_cases, 3);
+  assert.equal(arm.abandoned.remaining, 27);
+});
+
+test('the failure counter is consecutive, so an arm that recovers keeps going', async () => {
+  // Cumulative counting would abandon a flaky-but-working arm on its third bad case
+  // anywhere in the corpus. Here every other case fails, so it must never abandon.
+  const { repo, corpus } = fixture(12);
+  let calls = 0;
+  const adapters = new Map([
+    [
+      'stub',
+      () => {
+        calls += 1;
+        return calls % 2 === 0 ? emptyResponse('index step failed') : emptyResponse();
+      },
+    ],
+  ]);
+  const report = await scoreRetrieval({ corpus, repo, providerIds: ['stub'], adapters });
+  assert.equal(calls, 12, 'the arm was abandoned despite recovering between failures');
+  assert.equal(report.providers[0].abandoned, undefined);
+});
+
+test('an empty result is a result; only index, worktree and capacity refusals are hard', () => {
+  // A query that returns nothing is an answer. Failing to index is not. A capacity
+  // refusal is also hard: retrying cannot make a snapshot smaller than the ceiling
+  // that rejected it.
+  assert.equal(isHardFailure('index step failed'), true);
+  assert.equal(isHardFailure('worktree: fatal: invalid reference'), true);
+  assert.equal(isHardFailure('snapshot exceeds the 40 MB import limit'), true);
+  assert.equal(isHardFailure('refused: safety limit reached'), true);
+
+  assert.equal(isHardFailure('no output'), false);
+  assert.equal(isHardFailure(undefined), false);
+  assert.equal(isHardFailure(''), false);
+  assert.equal(isHardFailure('query: timed out'), false);
+});

--- a/scripts/context-retrieval/build-corpus.mjs
+++ b/scripts/context-retrieval/build-corpus.mjs
@@ -1,0 +1,331 @@
+#!/usr/bin/env node
+
+// Builds a retrieval-evaluation corpus from a local repository's own fix history.
+// Ground truth is the set of code files a real fix had to touch; the query is the
+// commit subject. No network, no agent, no model.
+
+import { execFileSync } from 'node:child_process';
+import { mkdir, rename, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+export const RETRIEVAL_CORPUS_SCHEMA_VERSION = 'codevetter.context-retrieval-corpus.v1';
+export const MAX_REQUIRED_FILES = 8;
+
+const UNIT_SEPARATOR = '\u001f';
+
+// Bookkeeping that rides along in fix commits without being part of the fix.
+const NOISE_DIRECTORY = /(^|\/)(docs|openspec|\.github|node_modules|\.changeset)\//;
+// .rst and .webp were missing from this list, and the omission put flask's
+// CHANGES.rst into the ground truth of 14 of its 39 cases and hugo's golden .webp
+// fixtures into 2 more. A changelog entry is not a file anyone had to locate, so
+// those cases were rewarding a tool for returning a changelog. `got`, the corpus
+// the published field measurement uses, contains neither and is unaffected.
+const NOISE_EXTENSION = /\.(md|mdx|rst|png|jpe?g|svg|ico|gif|webp|jsonl|snap|lock|txt)$/i;
+const LOCKFILE = /(^|\/)(pnpm-lock\.yaml|package-lock\.json|Cargo\.lock|yarn\.lock)$/;
+const TEST_FILE = /(\.test\.|\.spec\.|(^|\/)(tests?|__tests__|e2e)\/)/;
+// Version manifests ride along with releases. Nobody had to *find* them, so they
+// only count as ground truth when the change is genuinely about the manifest.
+const VERSION_MANIFEST =
+  /(^|\/)(package\.json|tauri\.conf\.json|Cargo\.toml|wrangler\.jsonc?|tsconfig(\.\w+)?\.json)$/;
+const SUBJECT_PREFIX = /^(\w+)(\([^)]*\))?!?:\s*/;
+// Sweeps and releases are not retrieval tasks: nothing had to be located.
+const EXCLUDED_SUBJECT = /^(release|chore|revert|merge|docs|style|format|bump|wip|deps)\b/i;
+const FIX_SUBJECT = /^(fix|bug|hotfix|patch|repair|correct)/i;
+// Vocabulary that appears in fix subjects without naming anything retrievable.
+// "fix email manager bugs" is not a retrieval task: after removing the generic
+// words and the repository's own name, nothing is left to search for, and the
+// case rewards whichever provider happens to prefix-match a common filename.
+const GENERIC_TOKEN = new Set([
+  'again',
+  'also',
+  'better',
+  'broken',
+  'bugs',
+  'catch',
+  'cases',
+  'change',
+  'changes',
+  'cleanup',
+  'correct',
+  'correctly',
+  'crash',
+  'error',
+  'errors',
+  'fail',
+  'failing',
+  'fails',
+  'fixes',
+  'handle',
+  'handling',
+  'improve',
+  'issue',
+  'issues',
+  'minor',
+  'misc',
+  'various',
+  'proper',
+  'properly',
+  'quick',
+  'small',
+  'stuff',
+  'things',
+  'update',
+  'updates',
+  'wrong',
+]);
+const MINIMUM_SPECIFIC_TOKENS = 2;
+const STOPWORDS = new Set([
+  'after',
+  'again',
+  'against',
+  'always',
+  'before',
+  'being',
+  'below',
+  'between',
+  'both',
+  'during',
+  'each',
+  'from',
+  'into',
+  'more',
+  'must',
+  'never',
+  'only',
+  'other',
+  'over',
+  'same',
+  'should',
+  'some',
+  'such',
+  'than',
+  'that',
+  'then',
+  'there',
+  'these',
+  'this',
+  'those',
+  'through',
+  'under',
+  'until',
+  'when',
+  'where',
+  'which',
+  'while',
+  'with',
+  'without',
+]);
+
+export function buildRetrievalCorpus({
+  repo = process.cwd(),
+  limit = 600,
+  maxRequiredFiles = MAX_REQUIRED_FILES,
+  fixesOnly = true,
+} = {}) {
+  const root = resolve(repo);
+  const repoId = git(root, ['rev-parse', '--show-toplevel']).split('/').pop();
+  const log = git(root, ['log', '--no-merges', `--max-count=${limit}`, '--format=%H%x1f%s%x1f%aI']);
+  const cases = [];
+  const rejected = [];
+  for (const line of log.split('\n').filter(Boolean)) {
+    const [commit, subject, authoredAt] = line.split(UNIT_SEPARATOR);
+    const outcome = buildCase({
+      root,
+      repoId,
+      commit,
+      subject,
+      authoredAt,
+      maxRequiredFiles,
+      fixesOnly,
+    });
+    if (outcome.case) cases.push(outcome.case);
+    else rejected.push({ commit, subject, reason: outcome.reason });
+  }
+  cases.sort((left, right) => left.case_id.localeCompare(right.case_id));
+  return {
+    schema_version: RETRIEVAL_CORPUS_SCHEMA_VERSION,
+    repository: { id: repoId, head: git(root, ['rev-parse', 'HEAD']) },
+    selection: {
+      commits_scanned: log.split('\n').filter(Boolean).length,
+      fixes_only: fixesOnly,
+      max_required_files: maxRequiredFiles,
+    },
+    counts: {
+      cases: cases.length,
+      path_leak: cases.filter((entry) => entry.retrieval.path_leak).length,
+      baseline_blind: cases.filter((entry) => !entry.retrieval.path_leak).length,
+      multi_file: cases.filter((entry) => entry.required_files.length > 1).length,
+    },
+    cases,
+    rejected_sample: rejected.slice(0, 20),
+  };
+}
+
+function buildCase({ root, repoId, commit, subject, authoredAt, maxRequiredFiles, fixesOnly }) {
+  if (EXCLUDED_SUBJECT.test(subject)) return { reason: 'excluded-subject' };
+  const query = subject.replace(SUBJECT_PREFIX, '').trim();
+  if (fixesOnly && !FIX_SUBJECT.test(subject)) return { reason: 'not-a-fix' };
+  if (query.length < 12) return { reason: 'query-too-short' };
+  let base;
+  try {
+    base = git(root, ['rev-parse', `${commit}^`]);
+  } catch {
+    return { reason: 'root-commit' };
+  }
+  const changed = git(root, ['show', '--name-only', '--format=', commit])
+    .split('\n')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+  if (changed.length === 0) return { reason: 'no-files' };
+
+  const kept = changed.filter((path) => !isNoise(path));
+  const excluded = changed.filter((path) => isNoise(path));
+  const sources = kept.filter((path) => !TEST_FILE.test(path));
+  // A test co-located with a changed source is derivable from it, so counting it
+  // as ground truth would hand every provider free recall.
+  const derivable = kept.filter(
+    (path) => TEST_FILE.test(path) && sources.some((source) => sharesStem(source, path))
+  );
+  const candidates = [
+    ...sources,
+    ...kept.filter((path) => TEST_FILE.test(path) && !derivable.includes(path)),
+  ]
+    .sort()
+    .filter((path, index, all) => all.indexOf(path) === index);
+  const substantive = candidates.filter((path) => !VERSION_MANIFEST.test(path));
+  const incidental =
+    substantive.length > 0 ? candidates.filter((path) => VERSION_MANIFEST.test(path)) : [];
+  const required = substantive.length > 0 ? substantive : candidates;
+
+  if (required.length === 0) return { reason: 'no-code-files' };
+  if (required.length > maxRequiredFiles) return { reason: 'too-broad' };
+
+  const queryTokens = tokenize(query);
+  // A query has to name something. Repo-name tokens are excluded too: matching
+  // "email" inside email-manager discriminates nothing.
+  const repoTokens = tokenize(repoId);
+  const specific = [...queryTokens].filter(
+    (token) => !GENERIC_TOKEN.has(token) && !repoTokens.has(token)
+  );
+  if (specific.length < MINIMUM_SPECIFIC_TOKENS) return { reason: 'query-not-specific' };
+
+  const overlaps = required.map((path) => ({
+    path,
+    shared: [...pathTokens(path)].filter((token) => queryTokens.has(token)).sort(),
+  }));
+  return {
+    case: {
+      case_id: `${repoId}-${commit.slice(0, 12)}`,
+      repository: repoId,
+      commit,
+      base_revision: base,
+      authored_at: authoredAt,
+      query,
+      query_tokens: [...queryTokens].sort(),
+      specific_tokens: specific.sort(),
+      required_files: required,
+      derivable_files: derivable.sort(),
+      incidental_files: incidental.sort(),
+      excluded_files: excluded.sort(),
+      retrieval: {
+        // Whether query vocabulary leaks into the file path. This is a property of the
+        // query, not a difficulty label: content search does not read paths.
+        path_leak: overlaps.some((entry) => entry.shared.length > 0),
+        path_leak_ratio: round(
+          overlaps.filter((entry) => entry.shared.length > 0).length / required.length
+        ),
+        shared_tokens: overlaps
+          .filter((entry) => entry.shared.length > 0)
+          .map((entry) => ({ path: entry.path, tokens: entry.shared })),
+      },
+    },
+  };
+}
+
+export function tokenize(text) {
+  const spaced = String(text).replace(/([a-z0-9])([A-Z])/g, '$1 $2');
+  const tokens = spaced
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((token) => token.length >= 4 && !STOPWORDS.has(token) && !/^\d+$/.test(token));
+  return new Set(tokens);
+}
+
+export function pathTokens(path) {
+  return tokenize(path.replace(/\.[a-z0-9]+$/i, '').replace(/[/\\]/g, ' '));
+}
+
+function sharesStem(source, test) {
+  const stem = (value) =>
+    value
+      .split('/')
+      .pop()
+      .replace(/\.(test|spec)\./, '.')
+      .replace(/\.[a-z0-9]+$/i, '');
+  return stem(source) === stem(test);
+}
+
+function isNoise(path) {
+  return NOISE_DIRECTORY.test(path) || NOISE_EXTENSION.test(path) || LOCKFILE.test(path);
+}
+
+export function git(root, args) {
+  return execFileSync('git', ['-C', root, ...args], {
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+  }).trim();
+}
+
+function round(value) {
+  return Math.round(value * 1000) / 1000;
+}
+
+async function writeJsonAtomic(path, value) {
+  const destination = resolve(path);
+  await mkdir(dirname(destination), { recursive: true });
+  const temporary = `${destination}.tmp-${process.pid}`;
+  await writeFile(temporary, `${JSON.stringify(value, null, 2)}\n`);
+  await rename(temporary, destination);
+}
+
+function parseArgs(args) {
+  const options = { repo: process.cwd(), limit: 600, out: undefined, fixesOnly: true };
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    if (argument === '--all-commits') {
+      options.fixesOnly = false;
+      continue;
+    }
+    if (!['--repo', '--limit', '--out'].includes(argument)) {
+      throw new Error(`unknown argument: ${argument}`);
+    }
+    const value = args[index + 1];
+    if (!value || value.startsWith('--')) throw new Error(`${argument} requires a value`);
+    index += 1;
+    if (argument === '--repo') options.repo = value;
+    if (argument === '--limit') options.limit = Number.parseInt(value, 10);
+    if (argument === '--out') options.out = value;
+  }
+  return options;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    const options = parseArgs(process.argv.slice(2));
+    const corpus = buildRetrievalCorpus(options);
+    if (options.out) await writeJsonAtomic(options.out, corpus);
+    process.stdout.write(
+      `Repository: ${corpus.repository.id}\n` +
+        `Cases: ${corpus.counts.cases} (${corpus.counts.multi_file} multi-file)\n` +
+        `Path-leak queries: ${corpus.counts.path_leak}\n` +
+        `No path leak: ${corpus.counts.baseline_blind}\n` +
+        (options.out ? `Artifact: ${options.out}\n` : '')
+    );
+  } catch (error) {
+    process.stderr.write(
+      `Corpus build failed: ${error instanceof Error ? error.message : String(error)}\n`
+    );
+    process.exitCode = 2;
+  }
+}

--- a/scripts/context-retrieval/build-corpus.test.mjs
+++ b/scripts/context-retrieval/build-corpus.test.mjs
@@ -1,0 +1,160 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import { buildRetrievalCorpus, pathTokens, tokenize } from './build-corpus.mjs';
+import { retrieveByKeyword } from './adapters/keyword-search.mjs';
+import { renderRetrievalScore, scoreRetrieval } from './score.mjs';
+
+async function fixtureRepo() {
+  const root = await mkdtemp(join(tmpdir(), 'codevetter-retrieval-'));
+  const run = (...args) => execFileSync('git', ['-C', root, ...args], { encoding: 'utf8' });
+  run('init', '--initial-branch=main');
+  run('config', 'user.email', 'fixture@example.com');
+  run('config', 'user.name', 'Fixture');
+  const commit = async (message, files) => {
+    for (const [path, contents] of Object.entries(files)) {
+      await writeFile(join(root, path), contents);
+    }
+    run('add', '-A');
+    run('commit', '-m', message);
+  };
+  await commit('feat: seed the fixture tree', {
+    'ledger.ts': 'export function settle(rows) {\n  return rows;\n}\n',
+    'ledger.test.ts': 'test("settle", () => {});\n',
+    'unrelated.ts': 'export const spare = 1;\n',
+    'package.json': '{ "version": "1.0.0" }\n',
+    'README.md': '# fixture\n',
+  });
+  await commit('fix: settle pending ledger rows before payout', {
+    'ledger.ts': 'export function settle(rows) {\n  return rows.filter(Boolean);\n}\n',
+    'ledger.test.ts': 'test("settle", () => { /* pending */ });\n',
+    'package.json': '{ "version": "1.0.1" }\n',
+    'README.md': '# fixture updated\n',
+  });
+  await commit('release: cut 1.0.2', { 'package.json': '{ "version": "1.0.2" }\n' });
+  return root;
+}
+
+test('tokenization splits camel case and drops noise words', () => {
+  assert.deepEqual([...tokenize('settle PendingLedger rows with the payout')].sort(), [
+    'ledger',
+    'payout',
+    'pending',
+    'rows',
+    'settle',
+  ]);
+  assert.deepEqual([...pathTokens('apps/desktop/src/lib/warm-verification.ts')].sort(), [
+    'apps',
+    'desktop',
+    'verification',
+    'warm',
+  ]);
+});
+
+test('ground truth excludes docs, releases, derivable tests, and version manifests', async () => {
+  const root = await fixtureRepo();
+  try {
+    const corpus = buildRetrievalCorpus({ repo: root, limit: 10 });
+    assert.equal(corpus.counts.cases, 1);
+    const [entry] = corpus.cases;
+
+    assert.equal(entry.query, 'settle pending ledger rows before payout');
+    // The source file is the only thing anyone had to locate.
+    assert.deepEqual(entry.required_files, ['ledger.ts']);
+    // A test sharing its stem with a changed source is free recall, not ground truth.
+    assert.deepEqual(entry.derivable_files, ['ledger.test.ts']);
+    // A version bump rode along; it is recorded but not scored.
+    assert.deepEqual(entry.incidental_files, ['package.json']);
+    assert.deepEqual(entry.excluded_files, ['README.md']);
+    assert.equal(entry.base_revision.length, 40);
+    assert.notEqual(entry.base_revision, entry.commit);
+    assert.equal(entry.retrieval.path_leak, true);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('a manifest-only change keeps the manifest as ground truth', async () => {
+  const root = await fixtureRepo();
+  try {
+    await writeFile(join(root, 'package.json'), '{ "version": "1.0.3", "type": "module" }\n');
+    execFileSync('git', ['-C', root, 'add', '-A'], { encoding: 'utf8' });
+    execFileSync('git', ['-C', root, 'commit', '-m', 'fix: declare the module type correctly'], {
+      encoding: 'utf8',
+    });
+    const corpus = buildRetrievalCorpus({ repo: root, limit: 10 });
+    const manifestCase = corpus.cases.find((entry) => entry.query.includes('module type'));
+    assert.deepEqual(manifestCase.required_files, ['package.json']);
+    assert.deepEqual(manifestCase.incidental_files, []);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('keyword retrieval reads the pre-fix revision and reports its identity', async () => {
+  const root = await fixtureRepo();
+  try {
+    const corpus = buildRetrievalCorpus({ repo: root, limit: 10 });
+    const [entry] = corpus.cases;
+    const response = retrieveByKeyword({
+      repo: root,
+      revision: entry.base_revision,
+      query: entry.query,
+      queryTokens: entry.query_tokens,
+    });
+
+    assert.equal(response.indexed_revision, entry.base_revision);
+    assert.ok(response.files.includes('ledger.ts'));
+    assert.ok(!response.files.includes('README.md'), 'markdown is outside the code pathspec');
+    assert.ok(response.tokens_delivered > 0);
+    assert.equal(
+      response.ranking[0].path,
+      'ledger.ts',
+      'the file matching the most query terms ranks first'
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('scoring is deterministic and stratifies by what the baseline actually missed', async () => {
+  const root = await fixtureRepo();
+  try {
+    const corpus = buildRetrievalCorpus({ repo: root, limit: 10 });
+    const first = await scoreRetrieval({ corpus, repo: root });
+    const second = await scoreRetrieval({ corpus, repo: root });
+
+    const stable = (score) => ({
+      ...score,
+      cases: score.cases.map(({ latency_ms: _latency, ...rest }) => rest),
+      providers: score.providers.map((provider) => ({
+        provider_id: provider.provider_id,
+        summary: Object.fromEntries(
+          Object.entries(provider.summary).map(([name, row]) => {
+            const { median_latency_ms: _median, ...rest } = row;
+            return [name, rest];
+          })
+        ),
+      })),
+    });
+    assert.deepEqual(stable(second), stable(first));
+
+    const summary = first.providers[0].summary;
+    assert.equal(summary.all.cases, corpus.counts.cases);
+    assert.equal(
+      summary.baseline_missed.cases + summary.baseline_solved.cases,
+      summary.all.cases,
+      'every case lands in exactly one difficulty stratum'
+    );
+    // By construction the solved stratum is the set with full recall at 10.
+    assert.equal(summary.baseline_solved.full_recall_at_10, 1);
+    assert.equal(summary.baseline_missed.full_recall_at_10, 0);
+    assert.match(renderRetrievalScore(first), /baseline missed/);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/scripts/context-retrieval/discover-candidates.mjs
+++ b/scripts/context-retrieval/discover-candidates.mjs
@@ -1,0 +1,232 @@
+#!/usr/bin/env node
+
+// Reproducible candidate discovery.
+//
+// The registry started as a list assembled from memory, which is not a defensible
+// basis for a published benchmark: a reader cannot tell whether a tool is absent
+// because it failed a criterion or because nobody thought of it. This runs the
+// search instead, records the exact queries, and diffs the result against the
+// registry so the omissions are visible.
+//
+// Recall over precision on purpose. These queries pull in plenty of things that are
+// not context providers; triage is a separate, human-auditable step, and a false
+// positive costs a line of triage while a false negative silently shrinks the field.
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+// Keyword queries are AND-matched over name and description by the GitHub API, so
+// long phrases return nothing. Short pairs are what actually recall the category.
+export const KEYWORD_QUERIES = [
+  'code context',
+  'codebase context',
+  'code search',
+  'code retrieval',
+  'semantic code',
+  'codebase index',
+  'repo map',
+  'code rag',
+  'code graph',
+  'code intelligence',
+  'symbol search',
+  'codebase memory',
+  'context compression',
+  'repository digest',
+  'code navigation',
+  'ast search',
+  'codebase understanding',
+  'code embedding',
+  'grep alternative',
+  'token efficient',
+];
+
+export const TOPIC_QUERIES = [
+  'code-search',
+  'code-intelligence',
+  'codebase',
+  'code-analysis',
+  'rag',
+  'mcp',
+  'static-analysis',
+  'developer-tools',
+  // The ecosystem tags `mcp-server`, not `mcp`, and this category is mostly MCP
+  // servers. The rest close gaps that let real members through untagged — one
+  // 67.7k-star member carries no topics at all, so topic queries alone are blind
+  // to it regardless of how many are added.
+  'mcp-server',
+  'code-graph',
+  'semantic-search',
+  'context-engineering',
+  'agentic-coding',
+  'tree-sitter',
+  'grep',
+  'code-navigation',
+];
+
+// The category's own vocabulary. A repository has to make a claim about code or a
+// codebase to be a candidate at all; this is what separates the hits from the
+// general-purpose agents and model repos the queries also return.
+const SIGNAL = /\b(code|codebase|repo|repositor|symbol|ast|grep|source)\w*\b/i;
+const PURPOSE =
+  /\b(context|search|retriev|index|graph|rag|embed|semantic|navigat|understand|map|digest|compress|memory|token)\w*\b/i;
+
+export function parseSweep(text) {
+  const found = new Map();
+  for (const line of text.split('\n')) {
+    if (!line.trim().startsWith('[')) continue;
+    let rows;
+    try {
+      rows = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    for (const row of rows) {
+      if (!row?.fullName) continue;
+      found.set(row.fullName, {
+        full_name: row.fullName,
+        stars: row.stargazersCount ?? 0,
+        pushed_at: row.pushedAt ?? null,
+        description: (row.description ?? '').slice(0, 240),
+      });
+    }
+  }
+  return [...found.values()];
+}
+
+export function triage(rows, { minStars = 1000, freshSince } = {}) {
+  const kept = [];
+  const dropped = [];
+  for (const row of rows) {
+    const text = `${row.full_name} ${row.description}`;
+    const reason =
+      row.stars < minStars
+        ? 'below-star-floor'
+        : freshSince && row.pushed_at && row.pushed_at < freshSince
+          ? 'stale-over-six-months'
+          : !SIGNAL.test(text)
+            ? 'no-code-signal'
+            : !PURPOSE.test(text)
+              ? 'no-retrieval-purpose'
+              : null;
+    if (reason) dropped.push({ ...row, reason });
+    else kept.push(row);
+  }
+  const rank = (a, b) => b.stars - a.stars;
+  return { kept: kept.sort(rank), dropped: dropped.sort(rank) };
+}
+
+// Registry ids are short slugs; repository names are owner/name. Match on the tail
+// with separators normalized, so `Codevetter/graphify` lines up with `graphify`.
+export function diffAgainstRegistry(kept, registry) {
+  // Match on FULL owner/name, never on the tail. Dropping the owner reported RepoWise
+  // as covered because `repowise-npm` was present, while the 6.2k-star AGPL
+  // `repowise-dev/repowise` had never been evaluated — a different tool with the same
+  // name. The same collision recurs for codesearch, octocode, codegraph,
+  // claude-context and semble, so this is the common case, not an edge case.
+  //
+  // Both schema keys are read because the registry uses `repo` on older entries and
+  // `repository` on newer ones. The previous version read only `repository`, which no
+  // older entry had, so that half of the dedupe was dead code and the diff fell back
+  // to matching ids alone.
+  const knownSlugs = new Set();
+  const knownIds = new Set();
+  for (const candidate of registry.candidates ?? []) {
+    knownIds.add(normalize(candidate.id));
+    const slug = candidate.repo ?? candidate.repository;
+    if (slug && slug.includes('/')) knownSlugs.add(normalize(slug));
+  }
+  const missing = [];
+  for (const row of kept) {
+    const slug = normalize(row.full_name);
+    if (knownSlugs.has(slug)) continue;
+    // A bare id match with no recorded slug is weak evidence: it is how the
+    // same-name-different-owner miss happened. Surface it as needs-verification
+    // rather than silently treating it as covered.
+    const tail = normalize(row.full_name.split('/').pop());
+    missing.push(
+      knownIds.has(tail) && knownSlugs.size > 0
+        ? {
+            ...row,
+            name_collision: `id "${tail}" exists in the registry but no slug matches ${row.full_name} — verify these are the same project`,
+          }
+        : row
+    );
+  }
+  return { known_slugs: knownSlugs.size, known_ids: knownIds.size, missing };
+}
+
+function normalize(value) {
+  return String(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, '');
+}
+
+// Held at 1,000 by owner decision. Recorded tension: this benchmark's own evidence is
+// that stars are anti-correlated with retrieval quality, and fully-local, actively
+// maintained members sit at 84-533 stars — so the floor is a deliberate scope limit,
+// not a quality signal. Sub-floor finds stay in the registry marked
+// `excluded-below-star-floor` so the exclusion is auditable rather than invisible.
+export function runSweep({ gh = 'gh', minStars = 1000 } = {}) {
+  const chunks = [];
+  for (const query of KEYWORD_QUERIES) {
+    // 200 not 50: best-match ordering meant a query like `code graph` filled its 50
+    // slots with repositories whose NAMES contain the tokens and never reached the
+    // 67.7k-star project that is the largest member of the category.
+    chunks.push(search(gh, ['search', 'repos', query, `--stars=>=${minStars}`, '--limit', '200']));
+  }
+  for (const topic of TOPIC_QUERIES) {
+    chunks.push(
+      search(gh, ['search', 'repos', '--topic', topic, `--stars=>=${minStars}`, '--limit', '200'])
+    );
+  }
+  return chunks.join('\n');
+}
+
+function search(gh, args) {
+  try {
+    return execFileSync(gh, [...args, '--json', 'fullName,stargazersCount,pushedAt,description'], {
+      encoding: 'utf8',
+      maxBuffer: 32 * 1024 * 1024,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+  } catch {
+    return '[]';
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const args = process.argv.slice(2);
+  const get = (flag, fallback) => {
+    const at = args.indexOf(flag);
+    return at === -1 ? fallback : args[at + 1];
+  };
+  const text = get('--from')
+    ? readFileSync(get('--from'), 'utf8')
+    : runSweep({ minStars: Number(get('--min-stars', '1000')) });
+  const { kept, dropped } = triage(parseSweep(text), {
+    minStars: Number(get('--min-stars', '1000')),
+    freshSince: get('--fresh-since'),
+  });
+  const registry = JSON.parse(readFileSync(get('--registry'), 'utf8'));
+  const { missing } = diffAgainstRegistry(kept, registry);
+  process.stdout.write(
+    `${JSON.stringify(
+      {
+        queries: { keyword: KEYWORD_QUERIES, topic: TOPIC_QUERIES },
+        surfaced: kept.length,
+        dropped: dropped.length,
+        drop_reasons: tally(dropped),
+        missing_from_registry: missing,
+      },
+      null,
+      2
+    )}\n`
+  );
+}
+
+function tally(rows) {
+  const counts = {};
+  for (const row of rows) counts[row.reason] = (counts[row.reason] ?? 0) + 1;
+  return counts;
+}

--- a/scripts/context-retrieval/discover-candidates.test.mjs
+++ b/scripts/context-retrieval/discover-candidates.test.mjs
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { TOPIC_QUERIES, diffAgainstRegistry, triage } from './discover-candidates.mjs';
+
+test('matching is owner-aware: same name, different owner is not covered', () => {
+  // The exact miss: repowise-npm was registered; repowise-dev/repowise (6.2k stars,
+  // AGPL, a different tool) had never been evaluated and was reported as covered.
+  const registry = { candidates: [{ id: 'repowise-npm', repo: 'someone/repowise-npm' }] };
+  const { missing } = diffAgainstRegistry(
+    [{ full_name: 'repowise-dev/repowise', stars: 6165, description: 'codebase intelligence' }],
+    registry
+  );
+  assert.equal(missing.length, 1, 'a different owner must not be treated as covered');
+});
+
+test('both registry schema keys are honoured', () => {
+  // Older entries use `repo`, newer ones `repository`. Reading only one made half the
+  // dedupe dead code, which is why the diff silently fell back to matching ids.
+  const viaRepo = diffAgainstRegistry(
+    [{ full_name: 'Graphify-Labs/graphify', stars: 1, description: '' }],
+    { candidates: [{ id: 'graphify', repo: 'Graphify-Labs/graphify' }] }
+  );
+  assert.equal(viaRepo.missing.length, 0);
+  const viaRepository = diffAgainstRegistry(
+    [{ full_name: 'repowise-dev/repowise', stars: 1, description: '' }],
+    { candidates: [{ id: 'repowise', repository: 'repowise-dev/repowise' }] }
+  );
+  assert.equal(viaRepository.missing.length, 0);
+});
+
+test('a bare id match with no slug is surfaced as needing verification', () => {
+  const { missing } = diffAgainstRegistry(
+    [{ full_name: 'google/codesearch', stars: 3997, description: 'trigram index' }],
+    { candidates: [{ id: 'codesearch' }, { id: 'other', repo: 'a/b' }] }
+  );
+  assert.equal(missing.length, 1);
+  assert.match(missing[0].name_collision, /verify these are the same project/);
+});
+
+test('topic list covers the tags the ecosystem actually uses', () => {
+  // `mcp` alone missed a category that is mostly MCP servers.
+  assert.ok(TOPIC_QUERIES.includes('mcp-server'));
+  assert.ok(TOPIC_QUERIES.includes('code-graph'));
+  assert.ok(TOPIC_QUERIES.includes('semantic-search'));
+});
+
+test('the star floor is 1000 and sub-floor tools are dropped with a reason', () => {
+  // Owner decision. The tension is recorded rather than argued: sub-floor members exist
+  // and are kept in the registry as excluded-below-star-floor so the scope limit stays
+  // auditable instead of looking like an oversight.
+  const { kept, dropped } = triage(
+    [
+      {
+        full_name: 'ory/lumen',
+        stars: 251,
+        description: 'local semantic code search',
+        pushed_at: '2026-08-01',
+      },
+      {
+        full_name: 'BeaconBay/ck',
+        stars: 1703,
+        description: 'semantic code search grep',
+        pushed_at: '2026-08-01',
+      },
+    ],
+    { minStars: 1000 }
+  );
+  assert.deepEqual(
+    kept.map((r) => r.full_name),
+    ['BeaconBay/ck']
+  );
+  assert.equal(dropped[0].reason, 'below-star-floor');
+});

--- a/scripts/context-retrieval/field-report.mjs
+++ b/scripts/context-retrieval/field-report.mjs
@@ -1,0 +1,118 @@
+// Consolidates the per-arm artifacts of a single-project full-field run into one
+// report, and applies the reliability gates ACROSS the merged field.
+//
+// The gates have to be applied here rather than per artifact. Each arm ran in its own
+// score.mjs process so that one 60-minute tool could not gate the other twenty-three,
+// and the consequence is that every individual artifact reports "controls absent" —
+// the controls are real, they are simply in sibling files. A per-artifact gate reading
+// would have been a false alarm, and ignoring the gate because it looked like a false
+// alarm is how a real one gets waved through, so it is recomputed on the union instead.
+import { readFileSync, readdirSync } from 'node:fs';
+
+import { checkControlsLose, checkControlsPresent, REQUIRED_CONTROLS } from './gates.mjs';
+
+const dir = process.argv[2];
+// baseline_missed is deliberately absent. Each arm ran in its own process, and that
+// subset is defined relative to whatever baseline was present in the run that produced
+// it — so semble's "baseline_missed" holds 49 cases while repowise's holds 81, and the
+// two columns are not measuring the same thing. Comparing them would have read as a
+// hard-subset finding. no_path_leak survives because it is defined by per-case corpus
+// metadata rather than by the run's own contents, and it is 54 cases for every arm.
+const SUBSETS = [
+  ['all', 'every case'],
+  ['no_path_leak', 'cases whose query does not name a file in the answer'],
+];
+
+const arms = [];
+let meta = null;
+for (const file of readdirSync(dir)) {
+  if (!file.endsWith('.json') || file.startsWith('EXCLUDED-')) continue;
+  const score = JSON.parse(readFileSync(`${dir}/${file}`, 'utf8'));
+  meta ??= { repo: score.repository, tier: score.tier, counts: score.corpus_counts };
+  for (const p of score.providers ?? []) {
+    arms.push({ id: p.provider_id, summary: p.summary, outcomes: p.outcomes ?? {} });
+  }
+}
+
+const pct = (v) => (Number.isFinite(v) ? `${(v * 100).toFixed(1)}%` : '—');
+const num = (v) => (Number.isFinite(v) ? Math.round(v).toLocaleString('en-US') : '—');
+
+// A packer that ships the whole repository is not competing on ranking, so it is listed
+// apart rather than sorted into the same order. Mixing the two produced the benchmark's
+// most misread row: "0.0% recall" for an arm that in fact delivered every required file.
+const PACKERS = new Set(['repomix-pack-all', 'repomix-compressed']);
+const CONTROLS = new Set(REQUIRED_CONTROLS);
+
+function row(arm, subset) {
+  const s = arm.summary[subset];
+  if (!s) return null;
+  return {
+    id: arm.id,
+    cases: s.cases,
+    r1k: s.mean_recall_at_1000_tokens,
+    r4k: s.mean_recall_at_4000_tokens,
+    r16k: s.mean_recall_at_16000_tokens,
+    tokens: s.median_tokens_delivered,
+    latency: s.median_latency_ms,
+    unavailable: s.cases ? s.unavailable / s.cases : null,
+    answered: arm.outcomes.answered ?? null,
+  };
+}
+
+const out = [];
+out.push(`# Full field on one project — ${meta.repo.id}`);
+out.push('');
+out.push(
+  `\`${meta.repo.id}\` @ \`${meta.repo.head.slice(0, 12)}\` — ${meta.tier} tier, ` +
+    `${meta.counts.cases} cases, ${meta.counts.multi_file} of them spanning more than one file. ` +
+    `Public repository, so the corpus and every number below can be rebuilt by someone else.`
+);
+out.push('');
+
+// Gates, on the union.
+const ids = arms.map((a) => a.id);
+const present = checkControlsPresent(ids);
+const scored = arms
+  .filter((a) => a.summary.all)
+  .map((a) => ({ provider_id: a.id, summary: a.summary }));
+const lose = checkControlsLose({ providers: scored });
+out.push('## Gates');
+out.push('');
+out.push(
+  `- controls present: **${present.ok ? 'pass' : `FAIL — missing ${present.missing.join(', ')}`}**`
+);
+out.push(
+  `- controls lose to the field: **${lose.ok === false ? `FAIL — ${lose.reason}` : lose.ok ? 'pass' : 'not evaluated'}**`
+);
+out.push('');
+
+for (const [subset, gloss] of SUBSETS) {
+  const rows = arms.map((a) => row(a, subset)).filter(Boolean);
+  if (!rows.length) continue;
+  const retrievers = rows.filter((r) => !PACKERS.has(r.id));
+  retrievers.sort((x, y) => (y.r4k ?? -1) - (x.r4k ?? -1));
+  const n = retrievers[0]?.cases ?? 0;
+  out.push(`## ${subset} — ${gloss} (${n} cases)`);
+  out.push('');
+  out.push('| Arm | r@1k | r@4k | r@16k | median tokens | p50 ms | unavailable |');
+  out.push('| --- | ---: | ---: | ---: | ---: | ---: | ---: |');
+  for (const r of retrievers) {
+    const label = CONTROLS.has(r.id) ? `_${r.id}_ (control)` : r.id;
+    out.push(
+      `| ${label} | ${pct(r.r1k)} | ${pct(r.r4k)} | ${pct(r.r16k)} | ${num(r.tokens)} | ${num(r.latency)} | ${pct(r.unavailable)} |`
+    );
+  }
+  out.push('');
+  const packers = rows.filter((r) => PACKERS.has(r.id));
+  if (packers.length) {
+    out.push('Whole-repository packers, listed apart because they do not rank:');
+    out.push('');
+    out.push('| Arm | r@1k | r@4k | r@16k | median tokens |');
+    out.push('| --- | ---: | ---: | ---: | ---: |');
+    for (const r of packers) {
+      out.push(`| ${r.id} | ${pct(r.r1k)} | ${pct(r.r4k)} | ${pct(r.r16k)} | ${num(r.tokens)} |`);
+    }
+    out.push('');
+  }
+}
+console.log(out.join('\n'));

--- a/scripts/context-retrieval/fixed-index.test.mjs
+++ b/scripts/context-retrieval/fixed-index.test.mjs
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { admissibleUnderFixedIndex } from './tiers.mjs';
+
+const SP =
+  '/private/tmp/claude-501/-Users-sarthak-Desktop-fleet-codevetter/89a25e80-80a8-452a-bfe6-a8c6ea4ae228/scratchpad';
+const REPO = `${SP}/public/gin`;
+
+// The whole validity of the large tier rests on this: if the index revision is not
+// strictly older than the case, the provider is handed the fix it is being asked to
+// locate, and the entire tier inflates. Asserted against real git history rather
+// than trusted to a comment.
+test('a case is admissible only if the index predates it', async (t) => {
+  const { execFileSync } = await import('node:child_process');
+  let revs;
+  try {
+    revs = execFileSync('git', ['-C', REPO, 'rev-list', '--max-count=3', 'HEAD'], {
+      encoding: 'utf8',
+    })
+      .trim()
+      .split('\n');
+  } catch {
+    t.skip('gin checkout unavailable');
+    return;
+  }
+  const [newest, middle, oldest] = revs;
+
+  // Index older than the case: admissible.
+  assert.equal(
+    admissibleUnderFixedIndex({ repo: REPO, indexRevision: oldest, caseRevision: newest }),
+    true
+  );
+  // Index newer than the case: the fix would already be indexed.
+  assert.equal(
+    admissibleUnderFixedIndex({ repo: REPO, indexRevision: newest, caseRevision: oldest }),
+    false
+  );
+  // Index equal to the case: the fix is in the index.
+  assert.equal(
+    admissibleUnderFixedIndex({ repo: REPO, indexRevision: middle, caseRevision: middle }),
+    false
+  );
+});
+
+test('an unknown revision is inadmissible rather than silently allowed', () => {
+  assert.equal(
+    admissibleUnderFixedIndex({
+      repo: REPO,
+      indexRevision: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+      caseRevision: 'HEAD',
+    }),
+    false
+  );
+});

--- a/scripts/context-retrieval/probe-candidates.mjs
+++ b/scripts/context-retrieval/probe-candidates.mjs
@@ -1,0 +1,243 @@
+#!/usr/bin/env node
+
+// Capability probe over the candidate registry.
+//
+// Hand-integrating twenty tools before knowing which ones even run is the wrong
+// order — of the first four attempted, two were broken on install. This probe
+// establishes eligibility cheaply and uniformly, and its exclusion reasons are
+// themselves a publishable result about the state of the category.
+//
+// Publication requirements this enforces:
+//   - every candidate is reported, including failures, so nothing is quietly dropped
+//   - the installed version is captured at probe time, not taken from the registry
+//   - environment identity is recorded alongside results so numbers stay traceable
+//   - candidates run STRICTLY sequentially behind a memory guard, because several
+//     load embedding models and the machine has already been pushed once
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { mkdir, rename, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+export const PROBE_SCHEMA_VERSION = 'codevetter.context-retrieval-probe.v1';
+
+// Refuse to start another candidate below this much free memory. A probe that
+// crashes the host produces no result and costs the operator their session.
+const MIN_FREE_MEMORY_MB = 2048;
+const NOT_RUNNABLE = new Set(['blocked-egress', 'excluded-inapplicable', 'excluded-stale']);
+// Unknown tiers must sort last, not first: indexOf returns -1 for them.
+const TIER_ORDER = ['light', 'heavy', 'hosted'];
+
+export function environmentIdentity() {
+  const read = (command, args) => {
+    try {
+      return execFileSync(command, args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] })
+        .trim()
+        .split('\n')[0];
+    } catch {
+      return null;
+    }
+  };
+  return {
+    platform: process.platform,
+    arch: process.arch,
+    node: process.version,
+    cpu: read('sysctl', ['-n', 'machdep.cpu.brand_string']),
+    total_memory_mb: Math.round(Number(read('sysctl', ['-n', 'hw.memsize']) ?? 0) / 1048576),
+    git: read('git', ['--version']),
+    uv: read('uv', ['--version']),
+    cargo: read('cargo', ['--version']),
+    docker: read('docker', ['--version']),
+  };
+}
+
+export function freeMemoryMb() {
+  try {
+    const pageSize = Number(
+      execFileSync('sysctl', ['-n', 'hw.pagesize'], { encoding: 'utf8' }).trim()
+    );
+    const stats = execFileSync('vm_stat', { encoding: 'utf8' });
+    const grab = (label) => {
+      const match = new RegExp(`${label}:\\s+(\\d+)`).exec(stats);
+      return match ? Number(match[1]) : 0;
+    };
+    // Free + speculative + inactive + purgeable. The first three alone read 4.4 GB on
+    // a 48 GB machine that `memory_pressure` simultaneously called 71% free, because
+    // macOS parks most reclaimable memory outside those buckets — which had this guard
+    // primed to abort perfectly healthy runs.
+    const pages =
+      grab('Pages free') +
+      grab('Pages speculative') +
+      grab('Pages inactive') +
+      grab('Pages purgeable');
+    const fromPages = Math.round((pages * pageSize) / 1048576);
+    // Cross-check against the kernel's own view and take the larger. `memory_pressure`
+    // is the number Activity Monitor agrees with; page arithmetic is the pessimist.
+    return Math.max(fromPages, pressureFreeMb());
+  } catch {
+    return Number.POSITIVE_INFINITY;
+  }
+}
+
+// The kernel's own free-percentage line, converted to MB. Returns 0 rather than
+// throwing when unavailable, so the page-arithmetic path stays authoritative there.
+function pressureFreeMb() {
+  try {
+    const out = execFileSync('memory_pressure', {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    const percent = /free percentage:\s*(\d+)%/i.exec(out);
+    if (!percent) return 0;
+    const total = Number(execFileSync('sysctl', ['-n', 'hw.memsize'], { encoding: 'utf8' }).trim());
+    return Math.round((total * Number(percent[1])) / 100 / 1048576);
+  } catch {
+    return 0;
+  }
+}
+
+export function loadCandidates(path) {
+  const registry = JSON.parse(readFileSync(path, 'utf8'));
+  if (registry.schema_version !== 'codevetter.context-retrieval-candidates.v1') {
+    throw new Error(`unexpected candidate registry version: ${registry.schema_version}`);
+  }
+  return registry;
+}
+
+export function orderCandidates(candidates) {
+  // Light tiers first so cheap results land before anything risks the machine;
+  // within a tier, priority then stars, so the most informative go first.
+  return [...candidates].sort((left, right) => {
+    const rank = (tier) => {
+      const index = TIER_ORDER.indexOf(tier);
+      return index === -1 ? TIER_ORDER.length : index;
+    };
+    const tier = rank(left.tier) - rank(right.tier);
+    if (tier !== 0) return tier;
+    const priority = (left.priority ?? 99) - (right.priority ?? 99);
+    if (priority !== 0) return priority;
+    return (right.stars ?? 0) - (left.stars ?? 0);
+  });
+}
+
+export function planProbes({ registry, only = [], skipMeasured = true }) {
+  const selected = registry.candidates.filter((candidate) => {
+    if (only.length > 0) return only.includes(candidate.id);
+    // Recorded but not runnable: kept in the registry for transparency, excluded
+    // from the run plan so the plan reflects what will actually execute.
+    if (NOT_RUNNABLE.has(candidate.status)) return false;
+    if (skipMeasured && candidate.status === 'measured') return false;
+    return true;
+  });
+  return orderCandidates(selected);
+}
+
+export function summarizeRegistry(registry) {
+  const byStatus = new Map();
+  const byTier = new Map();
+  for (const candidate of registry.candidates) {
+    byStatus.set(candidate.status, (byStatus.get(candidate.status) ?? 0) + 1);
+    byTier.set(candidate.tier, (byTier.get(candidate.tier) ?? 0) + 1);
+  }
+  return {
+    total: registry.candidates.length,
+    by_status: Object.fromEntries([...byStatus].sort()),
+    by_tier: Object.fromEntries([...byTier].sort()),
+    falsifiable_claims: registry.candidates.filter((candidate) => candidate.falsifiable).length,
+    requires_service: registry.candidates.filter(
+      (candidate) => (candidate.requires ?? []).length > 0
+    ).length,
+  };
+}
+
+export function guardMemory({ minFreeMb = MIN_FREE_MEMORY_MB } = {}) {
+  const free = freeMemoryMb();
+  return {
+    free_mb: free === Number.POSITIVE_INFINITY ? null : free,
+    ok: free >= minFreeMb,
+    minimum_mb: minFreeMb,
+  };
+}
+
+async function writeJsonAtomic(path, value) {
+  const destination = resolve(path);
+  await mkdir(dirname(destination), { recursive: true });
+  const temporary = `${destination}.tmp-${process.pid}`;
+  await writeFile(temporary, `${JSON.stringify(value, null, 2)}\n`);
+  await rename(temporary, destination);
+}
+
+function parseArgs(args) {
+  const options = {
+    registry: 'benchmarks/context-retrieval/candidates.json',
+    only: [],
+    out: undefined,
+  };
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    if (argument === '--plan-only') {
+      options.planOnly = true;
+      continue;
+    }
+    if (!['--registry', '--only', '--out'].includes(argument)) {
+      throw new Error(`unknown argument: ${argument}`);
+    }
+    const value = args[index + 1];
+    if (!value || value.startsWith('--')) throw new Error(`${argument} requires a value`);
+    index += 1;
+    if (argument === '--registry') options.registry = value;
+    if (argument === '--only') options.only = value.split(',');
+    if (argument === '--out') options.out = value;
+  }
+  return options;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    const options = parseArgs(process.argv.slice(2));
+    const registry = loadCandidates(options.registry);
+    const plan = planProbes({ registry, only: options.only });
+    const report = {
+      schema_version: PROBE_SCHEMA_VERSION,
+      surveyed_at: registry.surveyed_at,
+      inclusion_rule: registry.inclusion_rule,
+      environment: environmentIdentity(),
+      memory_guard: guardMemory(),
+      registry_summary: summarizeRegistry(registry),
+      execution_order: plan.map((candidate) => ({
+        id: candidate.id,
+        tier: candidate.tier,
+        stars: candidate.stars,
+        mechanism: candidate.mechanism,
+        interface: candidate.interface,
+        requires: candidate.requires ?? [],
+      })),
+    };
+    if (options.out) await writeJsonAtomic(options.out, report);
+    const guard = report.memory_guard;
+    process.stdout.write(
+      `Candidates: ${report.registry_summary.total} · falsifiable claims: ${report.registry_summary.falsifiable_claims}\n` +
+        `By tier: ${JSON.stringify(report.registry_summary.by_tier)}\n` +
+        `By status: ${JSON.stringify(report.registry_summary.by_status)}\n` +
+        `Free memory: ${guard.free_mb} MB (minimum ${guard.minimum_mb} MB) — ${guard.ok ? 'ok' : 'BLOCKED'}\n` +
+        `Planned order (${plan.length}):\n` +
+        plan
+          .map(
+            (candidate, index) =>
+              `  ${String(index + 1).padStart(2)}. [${candidate.tier}] ${candidate.id} (${candidate.stars}*)${
+                (candidate.requires ?? []).length > 0
+                  ? ` needs ${candidate.requires.join('+')}`
+                  : ''
+              }`
+          )
+          .join('\n') +
+        '\n'
+    );
+  } catch (error) {
+    process.stderr.write(
+      `Probe planning failed: ${error instanceof Error ? error.message : String(error)}\n`
+    );
+    process.exitCode = 2;
+  }
+}

--- a/scripts/context-retrieval/probe-staleness.mjs
+++ b/scripts/context-retrieval/probe-staleness.mjs
@@ -1,0 +1,438 @@
+#!/usr/bin/env node
+
+// Staleness probe: does the provider notice its index is out of date?
+//
+// Every other metric here assumes the index matches the tree. In real use it does
+// not — you indexed this morning and the code moved since. The failure mode that
+// matters is a provider confidently returning code that no longer exists, because
+// an agent will then edit a function that was deleted yesterday.
+//
+// Method, using deletion because "returned a file that is gone" is unfalsifiable
+// in a way that "returned slightly stale content" is not:
+//
+//   1. materialize a worktree at R, where the target file exists
+//   2. let the provider build its index there
+//   3. check out R+1 in the SAME worktree — the file is now gone
+//   4. query WITHOUT re-indexing
+//   5. classify what comes back
+//
+// grep is the reference arm: it holds no index and reads the tree live, so it can
+// never serve a phantom. Its phantom rate is 0 by construction, and every indexed
+// provider is trading exactly that guarantee for speed. The probe measures the price.
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, rmSync } from 'node:fs';
+import { mkdir, rename, writeFile } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+export const STALENESS_SCHEMA_VERSION = 'codevetter.context-retrieval-staleness.v1';
+
+const UNIT = '\u001f';
+
+export const OUTCOMES = Object.freeze({
+  // Best: the provider knows its index no longer matches and says so.
+  REFUSED: 'refused-stale-index',
+  // Acceptable: answers but flags staleness.
+  WARNED: 'warned-stale-index',
+  // Good behaviour, but the operator silently pays a rebuild.
+  REFRESHED: 'auto-refreshed',
+  // Dangerous: hands the agent a file that no longer exists, with no signal.
+  PHANTOM: 'served-phantom',
+  // Answered without the deleted path — correct, though possibly by luck.
+  CLEAN: 'no-phantom',
+  // Answered with nothing: avoids a phantom, demonstrates nothing.
+  EMPTY: 'empty-result',
+  UNAVAILABLE: 'unavailable',
+});
+
+// Terms that a stale index would still associate with the deleted file.
+export function deletionQuery(deletedPath) {
+  const stem = deletedPath
+    .split('/')
+    .pop()
+    .replace(/\.[a-z]+$/i, '');
+  return stem
+    .split(/[^A-Za-z0-9]+/)
+    .filter(Boolean)
+    .join(' ');
+}
+
+export function findDeletionCases({ repo, limit = 40, maxCases = 6 }) {
+  const log = execFileSync(
+    'git',
+    [
+      '-C',
+      repo,
+      'log',
+      '--diff-filter=D',
+      '--name-only',
+      `--format=${UNIT}COMMIT${UNIT}%H`,
+      `--max-count=${limit}`,
+      '--no-merges',
+    ],
+    { encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 }
+  );
+  const cases = [];
+  let commit = null;
+  for (const raw of log.split('\n')) {
+    const line = raw.trim();
+    if (line.startsWith('COMMIT')) {
+      commit = line.split(UNIT)[2];
+      continue;
+    }
+    if (!commit || !line || !/\.(ts|tsx|mjs|js|py|rs|go)$/.test(line)) continue;
+    // Generated or vendored trees are not interesting deletions.
+    if (/(^|\/)(coverage|dist|build|node_modules)\//.test(line)) continue;
+    let parent;
+    try {
+      parent = execFileSync('git', ['-C', repo, 'rev-parse', `${commit}^`], {
+        encoding: 'utf8',
+      }).trim();
+    } catch {
+      continue;
+    }
+    cases.push({
+      deletion_commit: commit,
+      indexed_revision: parent,
+      deleted_path: line,
+      query: deletionQuery(line),
+    });
+    if (cases.length >= maxCases) break;
+  }
+  return cases;
+}
+
+// Each provider needs explicit index-then-query control, which the retrieval
+// adapters deliberately bundle. Declared here rather than reusing them.
+export function providerRunners({
+  graphifyBinary,
+  codesearchBinary,
+  fixtureTool,
+  zoektBinary,
+  sembleBinary,
+  cacheDir,
+}) {
+  const runners = new Map();
+
+  runners.set('keyword-search', {
+    holds_index: false,
+    index: () => ({ ok: true }),
+    query: ({ worktree, query }) => ({
+      output: tryRun('git', [
+        '-C',
+        worktree,
+        'grep',
+        '--name-only',
+        '--ignore-case',
+        '--fixed-strings',
+        '-e',
+        query.split(' ')[0],
+      ]),
+    }),
+  });
+
+  if (graphifyBinary) {
+    runners.set('graphify', {
+      holds_index: true,
+      index: ({ worktree }) => ({
+        ok: tryRun(graphifyBinary, ['update', worktree, '--no-cluster'], worktree) !== null,
+      }),
+      query: ({ worktree, query }) => ({
+        output: tryRun(graphifyBinary, [
+          'query',
+          query,
+          '--graph',
+          join(worktree, 'graphify-out', 'graph.json'),
+          '--budget',
+          '2000',
+        ]),
+      }),
+    });
+  }
+
+  if (codesearchBinary) {
+    runners.set('codesearch', {
+      holds_index: true,
+      index: ({ worktree }) => ({
+        ok: tryRun(codesearchBinary, ['index', 'add', worktree], worktree, cacheDir) !== null,
+      }),
+      // No --sync: the point is to observe the stale index, not refresh it.
+      query: ({ worktree, query }) => ({
+        output: tryRun(
+          codesearchBinary,
+          ['search', query, '--path', worktree, '--compact', '--quiet'],
+          worktree,
+          cacheDir
+        ),
+      }),
+    });
+  }
+
+  if (zoektBinary) {
+    runners.set('zoekt', {
+      holds_index: true,
+      index: ({ worktree }) => ({
+        ok: tryRun(`${zoektBinary}-index`, ['-index', cacheDir, worktree], worktree) !== null,
+      }),
+      query: ({ query }) => ({
+        output: tryRun(zoektBinary, ['-index_dir', cacheDir, '-l', query.split(' ')[0]]),
+      }),
+    });
+  }
+  if (sembleBinary) {
+    runners.set('semble', {
+      holds_index: true,
+      // semble indexes lazily on first search, so the index step is that first query.
+      index: ({ worktree }) => ({
+        ok:
+          tryRun(sembleBinary, ['search', 'initial index warm', '--top-k', '5'], worktree) !== null,
+      }),
+      query: ({ worktree, query }) => ({
+        output: tryRun(sembleBinary, ['search', query, '--top-k', '20'], worktree),
+      }),
+    });
+  }
+  if (fixtureTool) {
+    runners.set('codevetter-structural-context', {
+      holds_index: true,
+      index: ({ worktree, revision, snapshot }) => ({
+        ok: tryRun(fixtureTool, ['build', worktree, revision, snapshot]) !== null,
+      }),
+      query: ({ query, snapshot }) => ({
+        output: tryRun(fixtureTool, ['query', snapshot, query, '60']),
+      }),
+    });
+  }
+
+  return runners;
+}
+
+export function classify({ output, deletedPath, holdsIndex, exitCode = 0 }) {
+  if (output === null) return OUTCOMES.UNAVAILABLE;
+  const text = String(output);
+  const basename = deletedPath.split('/').pop();
+
+  // Primary signal, mechanical: did the provider hand back a path that no longer
+  // exists? This is observable and cannot be argued with. Deliberately checked
+  // BEFORE any prose inspection — the first version of this probe matched the word
+  // "stale" inside its own worktree path and reported every provider as clean.
+  const returnedDeleted = text.includes(deletedPath) || text.includes(basename);
+
+  // Staleness detection only counts on a strong signal: a non-zero exit, or a full
+  // phrase, never a bare keyword that a file path could contain.
+  const declaresStale =
+    exitCode !== 0 ||
+    /\b(index (is )?(stale|out of date|outdated)|stale index|needs? re-?index)\b/i.test(text);
+  if (declaresStale) {
+    return /\b(refus|abort|cannot|declin)/i.test(text) ? OUTCOMES.REFUSED : OUTCOMES.WARNED;
+  }
+
+  if (!returnedDeleted) {
+    // Returning nothing avoids phantoms without demonstrating any awareness, so it
+    // is recorded separately rather than credited as correct exclusion.
+    return text.trim().length === 0 ? OUTCOMES.EMPTY : OUTCOMES.CLEAN;
+  }
+  // A provider holding no index reads the tree live, so a mention means the file
+  // still exists rather than that a phantom was served.
+  return holdsIndex ? OUTCOMES.PHANTOM : OUTCOMES.CLEAN;
+}
+
+export function probeStaleness({ repo, cases, runners, worktreeRoot, snapshotRoot }) {
+  mkdirSync(worktreeRoot, { recursive: true });
+  mkdirSync(snapshotRoot, { recursive: true });
+  const results = [];
+  for (const [providerId, runner] of runners) {
+    for (const entry of cases) {
+      const worktree = join(
+        worktreeRoot,
+        `probe-${providerId}-${entry.deletion_commit.slice(0, 8)}`
+      );
+      const snapshot = join(
+        snapshotRoot,
+        `${providerId}-${entry.deletion_commit.slice(0, 8)}.json`
+      );
+      rmSync(worktree, { recursive: true, force: true });
+      let outcome = OUTCOMES.UNAVAILABLE;
+      let detail = null;
+      try {
+        tryRun('git', [
+          '-C',
+          repo,
+          'worktree',
+          'add',
+          '--detach',
+          '--force',
+          worktree,
+          entry.indexed_revision,
+        ]);
+        if (!existsSync(join(worktree, entry.deleted_path))) {
+          detail = 'target file absent at indexed revision';
+        } else {
+          const indexed = runner.index({ worktree, revision: entry.indexed_revision, snapshot });
+          if (indexed.ok === false) {
+            detail = 'index step failed';
+          } else {
+            // The tree moves under the index. Nothing is re-indexed on purpose.
+            tryRun('git', ['-C', worktree, 'checkout', '--force', entry.deletion_commit]);
+            const stillPresent = existsSync(join(worktree, entry.deleted_path));
+            if (stillPresent) {
+              detail = 'checkout did not remove the file';
+            } else {
+              const { output } = runner.query({ worktree, query: entry.query, snapshot });
+              outcome = classify({
+                output,
+                deletedPath: entry.deleted_path,
+                holdsIndex: runner.holds_index,
+              });
+            }
+          }
+        }
+      } finally {
+        rmSync(worktree, { recursive: true, force: true });
+        rmSync(snapshot, { force: true });
+        tryRun('git', ['-C', repo, 'worktree', 'prune']);
+      }
+      results.push({
+        provider_id: providerId,
+        holds_index: runner.holds_index,
+        deleted_path: entry.deleted_path,
+        query: entry.query,
+        indexed_revision: entry.indexed_revision,
+        deletion_commit: entry.deletion_commit,
+        outcome,
+        detail,
+      });
+    }
+  }
+  return results;
+}
+
+export function summarize(results) {
+  const byProvider = new Map();
+  for (const row of results) {
+    const bucket = byProvider.get(row.provider_id) ?? {
+      provider_id: row.provider_id,
+      outcomes: {},
+      total: 0,
+      holds_index: row.holds_index,
+    };
+    bucket.outcomes[row.outcome] = (bucket.outcomes[row.outcome] ?? 0) + 1;
+    bucket.total += 1;
+    byProvider.set(row.provider_id, bucket);
+  }
+  return [...byProvider.values()]
+    .map((bucket) => {
+      const scored = bucket.total - (bucket.outcomes[OUTCOMES.UNAVAILABLE] ?? 0);
+      const phantoms = bucket.outcomes[OUTCOMES.PHANTOM] ?? 0;
+      return {
+        ...bucket,
+        scored,
+        // The headline: how often the provider handed back code that no longer exists.
+        phantom_rate: scored > 0 ? Math.round((phantoms / scored) * 1000) / 1000 : null,
+        detects_staleness:
+          (bucket.outcomes[OUTCOMES.REFUSED] ?? 0) + (bucket.outcomes[OUTCOMES.WARNED] ?? 0) > 0,
+      };
+    })
+    .sort((left, right) => (left.phantom_rate ?? 0) - (right.phantom_rate ?? 0));
+}
+
+function tryRun(command, args, cwd, cacheDir) {
+  try {
+    return execFileSync(command, args, {
+      encoding: 'utf8',
+      maxBuffer: 64 * 1024 * 1024,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      ...(cwd ? { cwd } : {}),
+      ...(cacheDir
+        ? { env: { ...process.env, CODESEARCH_DATA_DIR: cacheDir, CODESEARCH_HOME: cacheDir } }
+        : {}),
+    });
+  } catch (error) {
+    // git grep exits 1 on no match, which is an answer rather than a failure.
+    if (error?.status === 1 && typeof error.stdout === 'string') return error.stdout;
+    return null;
+  }
+}
+
+async function writeJsonAtomic(path, value) {
+  const destination = resolve(path);
+  await mkdir(dirname(destination), { recursive: true });
+  const temporary = `${destination}.tmp-${process.pid}`;
+  await writeFile(temporary, `${JSON.stringify(value, null, 2)}\n`);
+  await rename(temporary, destination);
+}
+
+// Flags as a table, matching score.mjs. The if/else chain scored cognitive complexity
+// 23 against a ceiling of 20, and a chain is also where a flag's arity goes unstated —
+// which is how a boolean flag elsewhere got handed a value and threw.
+const FLAG_TARGET = {
+  '--repo': 'repo',
+  '--graphify': 'graphifyBinary',
+  '--codesearch': 'codesearchBinary',
+  '--tool': 'fixtureTool',
+  '--zoekt': 'zoektBinary',
+  '--semble': 'sembleBinary',
+  '--cache-dir': 'cacheDir',
+  '--out': 'out',
+  '--max-cases': 'maxCases',
+};
+
+function parseArgs(args) {
+  const options = { repo: process.cwd(), maxCases: 5 };
+  for (let index = 0; index < args.length; index += 1) {
+    const flag = args[index];
+    const target = FLAG_TARGET[flag];
+    if (!target) throw new Error(`unknown argument: ${flag}`);
+    const value = args[index + 1];
+    if (!value || value.startsWith('--')) throw new Error(`${flag} requires a value`);
+    index += 1;
+    options[target] = target === 'maxCases' ? Number.parseInt(value, 10) : value;
+  }
+  return options;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    const options = parseArgs(process.argv.slice(2));
+    const cases = findDeletionCases({ repo: options.repo, maxCases: options.maxCases });
+    if (cases.length === 0) throw new Error('no code-file deletions found in recent history');
+    const runners = providerRunners(options);
+    const base = options.cacheDir ?? join(process.cwd(), '.codevetter-staleness');
+    const results = probeStaleness({
+      repo: options.repo,
+      cases,
+      runners,
+      worktreeRoot: join(base, 'worktrees'),
+      snapshotRoot: join(base, 'snapshots'),
+    });
+    const report = {
+      schema_version: STALENESS_SCHEMA_VERSION,
+      repository: options.repo.split('/').pop(),
+      cases: cases.length,
+      providers: summarize(results),
+      results,
+      method:
+        'Index at R, check out R+1 in the same worktree without re-indexing, query for the deleted file. grep holds no index so its phantom rate is 0 by construction.',
+    };
+    if (options.out) await writeJsonAtomic(options.out, report);
+    process.stdout.write(
+      `Deletion cases: ${cases.length}\n` +
+        `${'provider'.padEnd(32)}scored  phantom  detects-staleness\n` +
+        report.providers
+          .map(
+            (row) =>
+              `${row.provider_id.padEnd(32)}${String(row.scored).padStart(6)}  ${String(
+                row.phantom_rate === null ? 'n/a' : `${(row.phantom_rate * 100).toFixed(0)}%`
+              ).padStart(7)}  ${row.detects_staleness ? 'yes' : 'no'}`
+          )
+          .join('\n') +
+        '\n'
+    );
+  } catch (error) {
+    process.stderr.write(
+      `Staleness probe failed: ${error instanceof Error ? error.message : String(error)}\n`
+    );
+    process.exitCode = 2;
+  }
+}

--- a/scripts/context-retrieval/report-tiered.mjs
+++ b/scripts/context-retrieval/report-tiered.mjs
@@ -1,0 +1,233 @@
+#!/usr/bin/env node
+
+// Per-tier report.
+//
+// Deliberately cannot produce an overall winner. There is no cross-tier or
+// cross-budget aggregate, because on the small tier alone the leader changes at
+// every budget: one provider wins at 1k, another at 4k, a third at 16k. Averaging
+// those would manufacture a single answer out of a genuine disagreement, and the
+// disagreement is the finding.
+//
+// Every row carries its coverage. Six arms in the first version had one repository
+// and six had four, printed identically, which made a hint look like a finding.
+
+import { readFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+import {
+  checkControlsLose,
+  checkControlsPresent,
+  checkRankingComparable,
+  coverageOf,
+} from './gates.mjs';
+
+const BUDGETS = [
+  ['r@1k', 'mean_recall_at_1000_tokens'],
+  ['r@4k', 'mean_recall_at_4000_tokens'],
+  ['r@16k', 'mean_recall_at_16000_tokens'],
+];
+
+// A stored gate verdict describes the run that wrote it, and one run is not necessarily
+// one experiment. When each arm is measured in its own process — which is how a
+// 42-second-per-query tool is kept from gating twenty-four others — every artifact
+// truthfully reports "controls absent", because the controls are in sibling files.
+// Trusting the stored verdict stamped "gate failed" on all 25 arms of a run whose
+// controls were present and losing. A verifier reading that either rejects sound numbers
+// or learns to ignore the gate, and the second is worse. So the gate is recomputed over
+// the union of everything loaded, and a stored failure is honoured only when the union
+// cannot re-derive a pass.
+function unionGatesPass(paths) {
+  const providers = new Set();
+  const scored = [];
+  for (const path of paths) {
+    let score;
+    try {
+      score = JSON.parse(readFileSync(path, 'utf8'));
+    } catch {
+      continue; // Re-read in the main pass, where a bad file fails loudly.
+    }
+    if (score.superseded_by) continue;
+    for (const entry of score.providers ?? []) {
+      providers.add(entry.provider_id);
+      if (entry.summary) scored.push({ provider_id: entry.provider_id, summary: entry.summary });
+    }
+  }
+  return (
+    checkControlsPresent([...providers]).ok && checkControlsLose({ providers: scored }).ok !== false
+  );
+}
+
+export function loadTiered(paths) {
+  const byTier = new Map();
+  const unionOk = unionGatesPass(paths);
+  for (const path of paths) {
+    const score = JSON.parse(readFileSync(path, 'utf8'));
+    // A superseded run stays on disk as evidence for a retraction but must not be
+    // averaged in. Mixing a pre-fix and post-fix measurement of the same provider
+    // produces a number describing neither version.
+    if (score.superseded_by) continue;
+    const tier = score.tier ?? score.repository?.tier ?? 'untiered';
+    const repo = score.repository?.id ?? 'unknown';
+    const bucket = byTier.get(tier) ?? new Map();
+    for (const entry of score.providers ?? []) {
+      const row = bucket.get(entry.provider_id) ?? {
+        provider_id: entry.provider_id,
+        repos: [],
+        tiers: [],
+        samples: [],
+        outcomes: {},
+        gate_failures: [],
+      };
+      row.repos.push(repo);
+      row.tiers.push(tier);
+      row.samples.push(entry.summary?.all ?? {});
+      for (const [key, value] of Object.entries(entry.outcomes ?? {})) {
+        row.outcomes[key] = (row.outcomes[key] ?? 0) + value;
+      }
+      // Only a genuine failure counts: if the union has its controls and they lose, a
+      // per-artifact "controls absent" is an artefact of how the run was split up.
+      if (score.gates?.trustworthy === false && !unionOk) row.gate_failures.push(repo);
+      bucket.set(entry.provider_id, row);
+    }
+    byTier.set(tier, bucket);
+  }
+  return byTier;
+}
+
+function mean(values) {
+  const usable = values.filter((v) => Number.isFinite(v));
+  return usable.length ? usable.reduce((a, b) => a + b, 0) / usable.length : null;
+}
+
+// Weighting is a choice that changes the ranking, so it is made explicitly and both
+// figures are reported. Per-case treats every case equally, so a repository with 88
+// cases outweighs one with 14. Per-repo treats every repository equally, so a small
+// corpus counts as much as a large one. Two arms swapped places between the two on
+// the private tier, which is the same lesson as budget choice: state the convention
+// or the reader cannot tell a finding from an artifact of the averaging.
+function weightedByCases(samples, key) {
+  const scored = samples.filter((s) => Number.isFinite(s[key]));
+  if (scored.length === 0) return null;
+  const withCases = scored.filter((s) => Number.isFinite(s.cases) && s.cases > 0);
+  const total = withCases.reduce((sum, s) => sum + s.cases, 0);
+  // A sample missing its case count must degrade to equal weight, not disappear.
+  // Dropping it silently would remove the arm from the table entirely, which is a
+  // worse failure than weighting it imprecisely.
+  if (!total) return scored.reduce((sum, s) => sum + s[key], 0) / scored.length;
+  return withCases.reduce((sum, s) => sum + s[key] * s.cases, 0) / total;
+}
+
+export function summariseTier(bucket) {
+  return [...bucket.values()]
+    .map((row) => {
+      const scores = {};
+      const scoresPerRepo = {};
+      for (const [label, key] of BUDGETS) {
+        // Per-case is primary: a "251 cases" claim implies each case counted once.
+        scores[label] = weightedByCases(row.samples, key);
+        scoresPerRepo[label] = mean(row.samples.map((s) => s[key]));
+      }
+      const tokens = mean(row.samples.map((s) => s.median_tokens_delivered));
+      const answered = row.outcomes.answered ?? 0;
+      const total = Object.values(row.outcomes).reduce((a, b) => a + b, 0);
+      const cases = row.samples.reduce((sum, sample) => sum + (sample.cases ?? 0), 0);
+      return {
+        ...row,
+        cases,
+        scores,
+        scores_per_repo: scoresPerRepo,
+        tokens,
+        // Answer rate belongs beside accuracy: a provider that silently declines a
+        // fifth of queries is not comparable to one that answers all of them.
+        answer_rate: total ? answered / total : null,
+        coverage: coverageOf(row),
+      };
+    })
+    .sort((a, b) => (b.scores['r@4k'] ?? -1) - (a.scores['r@4k'] ?? -1));
+}
+
+export function renderTier(tierId, rows) {
+  const pct = (v) => (v === null || v === undefined ? 'n/a' : `${(v * 100).toFixed(1)}%`);
+  const out = [`### Tier: ${tierId}`, ''];
+  out.push(
+    'Weighted per case (each case counts once). Per-repo means differ where corpora differ in size.',
+    ''
+  );
+  out.push('| Provider | r@1k | r@4k | r@16k | tokens | answered | coverage | trust |');
+  out.push('| --- | ---: | ---: | ---: | ---: | ---: | --- | --- |');
+  for (const row of rows) {
+    const trust = row.gate_failures.length
+      ? `⚠ gate failed (${row.gate_failures.join(',')})`
+      : 'ok';
+    const strength =
+      row.coverage.strength === 'single-repo' ? `${row.coverage.label} ⚠` : row.coverage.label;
+    out.push(
+      `| ${row.provider_id} | ${pct(row.scores['r@1k'])} | ${pct(row.scores['r@4k'])} | ${pct(row.scores['r@16k'])} | ${row.tokens === null ? 'n/a' : Math.round(row.tokens).toLocaleString('en-US')} | ${pct(row.answer_rate)} | ${strength} | ${trust} |`
+    );
+  }
+  return out.join('\n');
+}
+
+export function render(byTier, { planHash } = {}) {
+  const sections = [];
+  if (planHash) sections.push(`Pre-registered plan: \`${planHash}\``, '');
+  sections.push(
+    'No overall winner is computed. Rankings differ by tier and by budget; that is the result.',
+    ''
+  );
+  // Stable tier order regardless of which files were passed in.
+  const order = ['small', 'medium', 'large', 'untiered'];
+  for (const tier of order) {
+    const bucket = byTier.get(tier);
+    if (!bucket) continue;
+    sections.push(renderTier(tier, summariseTier(bucket)), '');
+  }
+  const perTierLeaders = [];
+  for (const tier of order) {
+    const bucket = byTier.get(tier);
+    if (!bucket) continue;
+    for (const [label] of BUDGETS) {
+      const rows = summariseTier(bucket).filter((r) => r.scores[label] !== null);
+      if (!rows.length) continue;
+      const best = rows.reduce((a, b) => (b.scores[label] > a.scores[label] ? b : a));
+      perTierLeaders.push(
+        `- **${tier} @ ${label}**: ${best.provider_id} (${(best.scores[label] * 100).toFixed(1)}%)`
+      );
+    }
+  }
+  if (perTierLeaders.length) {
+    sections.push('#### Leader by tier and budget', '', ...perTierLeaders, '');
+  }
+  // Stated before anyone reads the leaders: a ranking is only as defensible as the
+  // thinnest arm in it.
+  const comparability = [];
+  for (const tier of order) {
+    const bucket = byTier.get(tier);
+    if (!bucket) continue;
+    const check = checkRankingComparable(summariseTier(bucket));
+    if (!check.ok) comparability.push(`- **${tier}**: ${check.reason}`);
+  }
+  if (comparability.length) {
+    sections.push(
+      '#### ⚠ Ranking comparability',
+      '',
+      'These rankings mix evidence of different strengths. Treat single-repository rows as hints.',
+      '',
+      ...comparability,
+      ''
+    );
+  }
+  return sections.join('\n');
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const args = process.argv.slice(2);
+  const paths = [];
+  let planHash;
+  for (let i = 0; i < args.length; i += 1) {
+    if (args[i] === '--score') paths.push(args[(i += 1)]);
+    else if (args[i] === '--plan-hash') planHash = args[(i += 1)];
+    else throw new Error(`unknown argument: ${args[i]}`);
+  }
+  process.stdout.write(`${render(loadTiered(paths), { planHash })}\n`);
+}

--- a/scripts/context-retrieval/report-tiered.test.mjs
+++ b/scripts/context-retrieval/report-tiered.test.mjs
@@ -1,0 +1,134 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+
+import { loadTiered, render, summariseTier } from './report-tiered.mjs';
+
+const bucket = (rows) => new Map(rows.map((r) => [r.provider_id, r]));
+
+const row = (id, repos, r1, r4, r16, outcomes = { answered: 10 }) => ({
+  provider_id: id,
+  repos,
+  tiers: repos.map(() => 'small'),
+  samples: [
+    {
+      mean_recall_at_1000_tokens: r1,
+      mean_recall_at_4000_tokens: r4,
+      mean_recall_at_16000_tokens: r16,
+      median_tokens_delivered: 1000,
+    },
+  ],
+  outcomes,
+  gate_failures: [],
+});
+
+test('a single-repo row is marked as weaker evidence than a multi-repo row', () => {
+  const rows = summariseTier(
+    bucket([
+      row('narrow', ['gin'], 0.4, 0.4, 0.4),
+      row('broad', ['gin', 'flask', 'express', 'got'], 0.3, 0.3, 0.3),
+    ])
+  );
+  const narrow = rows.find((r) => r.provider_id === 'narrow');
+  const broad = rows.find((r) => r.provider_id === 'broad');
+  assert.equal(narrow.coverage.strength, 'single-repo');
+  assert.equal(broad.coverage.strength, 'broad');
+  // The narrow row still sorts higher on score; the marker is what stops a reader
+  // treating it as equivalent evidence.
+  assert.equal(rows[0].provider_id, 'narrow');
+});
+
+test('answer rate sits beside accuracy so silent decliners are visible', () => {
+  const rows = summariseTier(
+    bucket([row('declines', ['gin'], 0.6, 0.6, 0.6, { answered: 8, 'did-not-index': 2 })])
+  );
+  assert.equal(rows[0].answer_rate, 0.8);
+});
+
+test('no overall winner is produced, only per-tier-per-budget leaders', () => {
+  const byTier = new Map([
+    ['small', bucket([row('a', ['gin'], 0.5, 0.2, 0.2), row('b', ['gin'], 0.1, 0.6, 0.3)])],
+    ['large', bucket([row('a', ['django'], 0.1, 0.1, 0.1), row('b', ['django'], 0.4, 0.4, 0.4)])],
+  ]);
+  const out = render(byTier, { planHash: 'deadbeef' });
+  assert.match(out, /No overall winner is computed/);
+  assert.match(out, /Pre-registered plan: `deadbeef`/);
+  // Different winners in different places must both appear.
+  assert.match(out, /\*\*small @ r@1k\*\*: a/);
+  assert.match(out, /\*\*small @ r@4k\*\*: b/);
+  assert.match(out, /\*\*large @ r@1k\*\*: b/);
+  // And no aggregate row: every leader line must be scoped to a tier and a budget,
+  // so there is nowhere for a single champion to be stated. Checked structurally
+  // rather than by keyword, since the disclaimer itself says "overall winner".
+  // Leader lines only. Other bullet lines exist (the comparability warning names
+  // tiers too), and the property under test is that no leader is stated without a
+  // tier AND a budget attached.
+  const leaderLines = out.split('\n').filter((l) => l.startsWith('- **') && l.includes(' @ r@'));
+  assert.ok(leaderLines.length > 0);
+  for (const line of leaderLines) {
+    assert.match(line, /^- \*\*(small|medium|large|untiered) @ r@(1k|4k|16k)\*\*:/);
+  }
+});
+
+test('a run whose gates failed is marked untrustworthy in its own row', () => {
+  const failing = { ...row('x', ['gin'], 0.5, 0.5, 0.5), gate_failures: ['gin'] };
+  const out = render(new Map([['small', bucket([failing])]]));
+  assert.match(out, /gate failed \(gin\)/);
+});
+
+test('tiers render in a stable order regardless of input order', () => {
+  const byTier = new Map([
+    ['large', bucket([row('a', ['django'], 0.1, 0.1, 0.1)])],
+    ['small', bucket([row('a', ['gin'], 0.2, 0.2, 0.2)])],
+  ]);
+  const out = render(byTier);
+  assert.ok(out.indexOf('Tier: small') < out.indexOf('Tier: large'));
+});
+
+test('a gate verdict stored per-arm does not condemn a run whose controls are present', () => {
+  // When each arm is measured in its own process, every artifact truthfully reports
+  // "controls absent" because the controls live in sibling files. Trusting the stored
+  // verdict stamped "gate failed" on all 25 arms of a run whose controls were present
+  // and losing — and a verifier reading that either rejects sound numbers or learns to
+  // ignore the gate. The union is the experiment, so the union is what gets checked.
+  const dir = mkdtempSync(join(tmpdir(), 'cr-tiered-'));
+  const failed = {
+    ok: false,
+    trustworthy: false,
+    controls_present: { ok: false, missing: ['random-files', 'random-code-files', 'churn-ranked'] },
+  };
+  const arm = (id, r4k) => ({
+    tier: 'small',
+    repository: { id: 'got' },
+    gates: failed,
+    providers: [
+      {
+        provider_id: id,
+        summary: { all: { cases: 108, mean_recall_at_4000_tokens: r4k, unavailable: 0 } },
+        outcomes: { answered: 108 },
+      },
+    ],
+  });
+  const paths = [];
+  for (const [id, r4k] of [
+    ['semble', 0.836],
+    ['random-files', 0.007],
+    ['random-code-files', 0.045],
+    ['churn-ranked', 0.0],
+  ]) {
+    const file = join(dir, `${id}.json`);
+    writeFileSync(file, JSON.stringify(arm(id, r4k)));
+    paths.push(file);
+  }
+
+  const withControls = loadTiered(paths).get('small');
+  for (const [id, row] of withControls) {
+    assert.deepEqual(row.gate_failures, [], `${id} was condemned by a per-arm verdict`);
+  }
+
+  // The gate must still bite when the controls genuinely are not there.
+  const soloed = loadTiered([paths[0]]).get('small');
+  assert.deepEqual(soloed.get('semble').gate_failures, ['got']);
+});

--- a/scripts/context-retrieval/report.mjs
+++ b/scripts/context-retrieval/report.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+
+// Consolidates score artifacts into one publishable table.
+//
+// Reads whatever score files it is given, aligns providers across them, and prints
+// per-repository rows plus a pooled summary. Availability and phantom rate sit
+// beside accuracy on purpose: accuracy alone ranked a tool first that silently
+// refused one query in five and returned deleted files nearly every time.
+
+import { readFileSync } from 'node:fs';
+import { basename } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+export function loadScores(paths) {
+  return paths.map((path) => {
+    const score = JSON.parse(readFileSync(path, 'utf8'));
+    return { repo: score.repository?.id ?? basename(path), score };
+  });
+}
+
+export function loadStaleness(paths) {
+  const phantom = new Map();
+  for (const path of paths) {
+    let report;
+    try {
+      report = JSON.parse(readFileSync(path, 'utf8'));
+    } catch {
+      continue;
+    }
+    for (const provider of report.providers ?? []) {
+      const bucket = phantom.get(provider.provider_id) ?? { phantoms: 0, scored: 0 };
+      bucket.phantoms += provider.outcomes?.['served-phantom'] ?? 0;
+      bucket.scored += provider.scored ?? 0;
+      phantom.set(provider.provider_id, bucket);
+    }
+  }
+  return phantom;
+}
+
+export function buildTable({ scores, phantom }) {
+  const providers = new Map();
+  for (const { repo, score } of scores) {
+    for (const entry of score.providers) {
+      const row = providers.get(entry.provider_id) ?? {
+        provider_id: entry.provider_id,
+        repos: {},
+        fails: 0,
+        cases: 0,
+      };
+      const all = entry.summary.all;
+      row.repos[repo] = {
+        r1k: all.mean_recall_at_1000_tokens,
+        r4k: all.mean_recall_at_4000_tokens,
+        r16k: all.mean_recall_at_16000_tokens,
+        r10: all.mean_recall_at_10,
+        tokens: all.median_tokens_delivered,
+        latency: all.median_latency_ms,
+      };
+      row.fails += all.unavailable;
+      row.cases += all.cases;
+      providers.set(entry.provider_id, row);
+    }
+  }
+  // Ranked by the 4k budget: the tightest budget where every arm returns something.
+  return [...providers.values()]
+    .map((row) => {
+      const repos = Object.values(row.repos);
+      const mean = (pick) =>
+        repos.length === 0 ? 0 : repos.reduce((sum, r) => sum + pick(r), 0) / repos.length;
+      return {
+        ...row,
+        mean_r1k: mean((r) => r.r1k),
+        mean_r4k: mean((r) => r.r4k),
+        mean_r16k: mean((r) => r.r16k),
+        mean_r10: mean((r) => r.r10),
+        median_tokens: median(repos.map((r) => r.tokens)),
+        median_latency: median(repos.map((r) => r.latency)),
+        fail_rate: row.cases > 0 ? row.fails / row.cases : null,
+        phantom_rate: rate(phantom.get(row.provider_id)),
+      };
+    })
+    .sort((left, right) => right.mean_r4k - left.mean_r4k);
+}
+
+export function renderMarkdown(table, repoNames) {
+  const pct = (value) =>
+    value === null || value === undefined ? 'n/a' : `${(value * 100).toFixed(1)}%`;
+  const lines = [
+    `| Provider | r@1k | r@4k | r@16k | r@10 | tokens | p50 ms | fails | phantom |`,
+    `| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |`,
+  ];
+  for (const row of table) {
+    lines.push(
+      `| ${row.provider_id} | ${pct(row.mean_r1k)} | ${pct(row.mean_r4k)} | ${pct(row.mean_r16k)} | ${pct(row.mean_r10)} | ${Math.round(row.median_tokens).toLocaleString('en-US')} | ${Math.round(row.median_latency)} | ${pct(row.fail_rate)} | ${pct(row.phantom_rate)} |`
+    );
+  }
+  return `Repositories: ${repoNames.join(', ')}\n\n${lines.join('\n')}\n`;
+}
+
+function median(values) {
+  const usable = values.filter((value) => Number.isFinite(value)).sort((a, b) => a - b);
+  if (usable.length === 0) return 0;
+  const middle = Math.floor(usable.length / 2);
+  return usable.length % 2 === 0 ? (usable[middle - 1] + usable[middle]) / 2 : usable[middle];
+}
+
+function rate(bucket) {
+  if (!bucket || bucket.scored === 0) return null;
+  return bucket.phantoms / bucket.scored;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const scorePaths = [];
+  const stalenessPaths = [];
+  const args = process.argv.slice(2);
+  for (let index = 0; index < args.length; index += 1) {
+    if (args[index] === '--score') scorePaths.push(args[(index += 1)]);
+    else if (args[index] === '--staleness') stalenessPaths.push(args[(index += 1)]);
+    else throw new Error(`unknown argument: ${args[index]}`);
+  }
+  const scores = loadScores(scorePaths);
+  const table = buildTable({ scores, phantom: loadStaleness(stalenessPaths) });
+  process.stdout.write(
+    renderMarkdown(
+      table,
+      scores.map((entry) => entry.repo)
+    )
+  );
+}

--- a/scripts/context-retrieval/resources.mjs
+++ b/scripts/context-retrieval/resources.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+
+// Resource accounting for provider runs.
+//
+// Footprint is a first-class result, not overhead. A provider that needs gigabytes
+// of RAM or a multi-gigabyte install is unusable in CI or on a laptop beside an IDE,
+// however good its recall — and an unmeasured footprint is how a benchmark run
+// surprises the machine it is running on.
+
+import { execFileSync, spawn } from 'node:child_process';
+import { readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const SAMPLE_INTERVAL_MS = 250;
+
+// The sampler MUST live in its own process. Adapters shell out with execFileSync,
+// which blocks this event loop for the whole subprocess lifetime, so an in-process
+// setInterval never fires while a provider is actually working — it reports the
+// baseline forever and every delta comes out zero.
+export function createResourceMonitor({ intervalMs = SAMPLE_INTERVAL_MS } = {}) {
+  const baseline = processTreeRssKb();
+  const samplePath = join(tmpdir(), `codevetter-rss-${process.pid}-${baseline}.txt`);
+  const seconds = Math.max(0.05, intervalMs / 1000);
+  const child = spawn(
+    '/bin/sh',
+    [
+      '-c',
+      // Total RSS of every process on the box, sampled independently of this Node
+      // process. Coarse, but it cannot be starved by our blocking calls.
+      `while :; do ps -Ao rss= | awk '{s+=$1} END {print s}' >> "${samplePath}"; sleep ${seconds}; done`,
+    ],
+    { stdio: 'ignore', detached: false }
+  );
+
+  return {
+    stop() {
+      child.kill('SIGKILL');
+      let peakKb = baseline;
+      try {
+        for (const line of readFileSync(samplePath, 'utf8').split('\n')) {
+          const value = Number.parseInt(line.trim(), 10);
+          if (Number.isFinite(value) && value > peakKb) peakKb = value;
+        }
+      } catch {
+        // No samples captured; fall back to the baseline rather than inventing one.
+      }
+      rmSync(samplePath, { force: true });
+      return {
+        baseline_rss_mb: round(baseline / 1024),
+        peak_rss_mb: round(peakKb / 1024),
+        // System-wide, so treat as an upper bound on what this provider added.
+        delta_rss_mb: round(Math.max(0, peakKb - baseline) / 1024),
+        scope: 'system-wide-upper-bound',
+      };
+    },
+  };
+}
+
+// System-wide resident total, matching the sampler's scope so baseline and peak are
+// the same measurement. A provider's worker pool and model load are then counted
+// rather than hidden behind a subprocess boundary — at the cost of also counting
+// unrelated system activity, hence the upper-bound label.
+function processTreeRssKb() {
+  try {
+    const output = execFileSync('/bin/sh', ['-c', "ps -Ao rss= | awk '{s+=$1} END {print s}'"], {
+      encoding: 'utf8',
+    });
+    const total = Number.parseInt(output.trim(), 10);
+    return Number.isFinite(total) ? total : 0;
+  } catch {
+    return 0;
+  }
+}
+
+// Exact peak RSS of one command, including children it forks. Preferred over the
+// sampler for per-provider comparison: no background noise and no dependence on our
+// event loop. The sampler stays for whole-run accounting only — a system-wide delta
+// cannot tell a provider's worker pool from an unrelated browser tab.
+export function peakRssMbOf(command, args, options = {}) {
+  if (process.platform !== 'darwin') return { stdout: null, peak_rss_mb: null };
+  // `time -l` reports on stderr, and execFileSync returns stdout, so the report has
+  // to be swapped onto stdout: `2>&1 >/dev/null` duplicates stderr to the pipe first,
+  // then sends the command's own stdout to /dev/null.
+  const script = `{ /usr/bin/time -l ${[command, ...args].map(shellQuote).join(' ')} ; } 2>&1 >/dev/null`;
+  try {
+    return parseTimed(execFileSync('/bin/sh', ['-c', script], { encoding: 'utf8', ...options }));
+  } catch (error) {
+    return parseTimed(`${error?.stdout ?? ''}${error?.stderr ?? ''}`);
+  }
+}
+
+function shellQuote(value) {
+  return `'${String(value).replaceAll("'", `'\\''`)}'`;
+}
+
+function parseTimed(text) {
+  const match = /(\d+)\s+maximum resident set size/.exec(text);
+  return {
+    peak_rss_mb: match ? round(Number.parseInt(match[1], 10) / 1048576) : null,
+  };
+}
+
+export function directoryBytes(path) {
+  try {
+    const output = execFileSync('du', ['-sk', path], { encoding: 'utf8' });
+    return Number.parseInt(output.trim().split(/\s+/)[0], 10) * 1024;
+  } catch {
+    return 0;
+  }
+}
+
+function round(value) {
+  return Math.round(value * 10) / 10;
+}

--- a/scripts/context-retrieval/score.mjs
+++ b/scripts/context-retrieval/score.mjs
@@ -1,0 +1,983 @@
+#!/usr/bin/env node
+
+// Scores provider retrieval against what real fixes had to touch. Deterministic,
+// local, no agent and no model in the loop. Strata are reported separately because
+// an average over easy and hard cases hides the only interesting result: whether
+// a provider finds what plain search could not.
+
+import { readFileSync } from 'node:fs';
+import { mkdir, rename, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { retrieveAgentDefault, retrieveByFilename } from './adapters/agent-default.mjs';
+import { createStructuralGraphAdapter } from './adapters/codevetter-graph.mjs';
+import {
+  retrieveByChurn,
+  retrieveRandomCodeFiles,
+  retrieveRandomFiles,
+} from './adapters/controls.mjs';
+import { createCodesearchAdapter } from './adapters/codesearch.mjs';
+import { createGenericCliAdapter } from './adapters/generic-cli.mjs';
+import { createGraphifyAdapter } from './adapters/graphify.mjs';
+import { createCliIndexedMcpAdapter } from './adapters/cli-indexed-mcp.mjs';
+import { createJcodemunchAdapter } from './adapters/jcodemunch.mjs';
+import { createMcpAdapter } from './adapters/mcp-client.mjs';
+import { createRepomapperAdapter } from './adapters/repomapper.mjs';
+import { createRepomixAdapter } from './adapters/repomix.mjs';
+import { retrieveByKeyword } from './adapters/keyword-search.mjs';
+import { createRipgrepAdapter } from './adapters/ripgrep.mjs';
+import {
+  checkControlsLose,
+  checkControlsPresent,
+  classifyOutcome,
+  flagExtremes,
+  nominateForAudit,
+} from './gates.mjs';
+import { guardMemory } from './probe-candidates.mjs';
+import { classify, countCodeFiles } from './tiers.mjs';
+import { createResourceMonitor, directoryBytes } from './resources.mjs';
+
+export const RETRIEVAL_SCORE_SCHEMA_VERSION = 'codevetter.context-retrieval-score.v1';
+export // Three strikes: enough to distinguish a flake from a tool that cannot index this size.
+const ABANDON_AFTER_HARD_FAILURES = 3;
+
+const CUTOFFS = [5, 10, 20];
+// recall@k is not comparable across providers: ten whole files and ten excerpts are
+// not the same purchase. These budgets ask the question an agent actually faces —
+// given this many tokens of context, how much of what I need do I get?
+export const TOKEN_BUDGETS = [1_000, 4_000, 16_000];
+
+export function resolveAdapters({
+  tool,
+  cacheDir,
+  worktreeRoot,
+  graphifyBinary,
+  codesearchBinary,
+  codegrokCommand,
+  serenaCommand,
+  cocoindexCommand,
+  jcodemunchCommand,
+  repomapper,
+  ripgrepBinary,
+  cliTools = {},
+  repomix = false,
+} = {}) {
+  const adapters = new Map([
+    ['keyword-search', retrieveByKeyword],
+    // The realistic free baseline: what an agent does before installing anything.
+    ['agent-default', retrieveAgentDefault],
+    ['filename-match', retrieveByFilename],
+    ['random-files', retrieveRandomFiles],
+    ['random-code-files', retrieveRandomCodeFiles],
+    ['churn-ranked', retrieveByChurn],
+  ]);
+  if (tool) {
+    adapters.set(
+      'codevetter-structural-context',
+      createStructuralGraphAdapter({ tool, cacheDir, worktreeRoot })
+    );
+  }
+  if (graphifyBinary) {
+    adapters.set(
+      'graphify',
+      createGraphifyAdapter({ binary: graphifyBinary, cacheDir, worktreeRoot })
+    );
+  }
+  if (codesearchBinary) {
+    adapters.set(
+      'codesearch',
+      createCodesearchAdapter({
+        binary: codesearchBinary,
+        worktreeRoot,
+        indexRoot: `${cacheDir}/codesearch-index`,
+      })
+    );
+    // The vendor's own advanced modes, so their claims are testable rather than
+    // taken on trust.
+    adapters.set(
+      'codesearch-rerank',
+      createCodesearchAdapter({
+        binary: codesearchBinary,
+        worktreeRoot,
+        indexRoot: `${cacheDir}/codesearch-index`,
+        rerank: true,
+      })
+    );
+  }
+  if (serenaCommand) {
+    // Serena has no semantic search of any kind. Its retrieval surface is LSP
+    // symbol lookup, which is a different interface class from a prose query.
+    const [bin, ...rest] = serenaCommand.split(' ');
+    const headless = [
+      '--enable-web-dashboard',
+      'False',
+      '--open-web-dashboard',
+      'False',
+      '--enable-gui-log-window',
+      'False',
+    ];
+    adapters.set(
+      'serena',
+      createMcpAdapter({
+        providerId: 'serena',
+        command: bin,
+        args: [...rest, ...headless],
+        // The ide-assistant context exposes only symbol tools — no
+        // search_for_pattern, and no semantic search anywhere. find_symbol with
+        // substring matching is the sole entry point that accepts free text, so the
+        // most distinctive query token is used as the symbol-name probe.
+        toolName: 'find_symbol',
+        buildArguments: ({ query, queryTokens }) => {
+          const longest = [...(queryTokens ?? [])].sort((a, b) => b.length - a.length)[0];
+          return {
+            name_path: longest ?? query.split(' ')[0],
+            substring_matching: true,
+            include_body: false,
+          };
+        },
+        timeoutMs: 240_000,
+      })
+    );
+  }
+  if (cocoindexCommand) {
+    // Indexes from the CLI and answers over MCP `search`. Its wheel omits
+    // sentence-transformers, so this arm only exists once that is installed.
+    adapters.set(
+      'cocoindex-code',
+      createCliIndexedMcpAdapter({
+        providerId: 'cocoindex-code',
+        indexCommand: cocoindexCommand,
+        buildIndexArgs: () => ['index'],
+        serveCommand: `${cocoindexCommand} serve`,
+        toolName: 'search',
+        buildArguments: ({ query, limit }) => ({ query, limit }),
+        worktreeRoot,
+        createMcpAdapter,
+      })
+    );
+  }
+  if (jcodemunchCommand) {
+    // Judging by tool name alone would have wrongly recorded this server as having
+    // no retrieval interface: its six verbs are order/menu/route, and search_symbols
+    // is one of 91 catalog actions reached through `order`.
+    adapters.set(
+      'jcodemunch',
+      createJcodemunchAdapter({
+        command: jcodemunchCommand,
+        worktreeRoot,
+        createMcpAdapter,
+      })
+    );
+  }
+  if (codegrokCommand) {
+    adapters.set(
+      'codegrok',
+      createMcpAdapter({
+        providerId: 'codegrok',
+        command: codegrokCommand,
+        toolName: 'get_sources',
+        indexToolName: 'learn',
+        buildIndexArguments: ({ root }) => ({ path: root }),
+        buildArguments: ({ query, limit }) => ({ question: query, n_results: limit }),
+      })
+    );
+  }
+  if (ripgrepBinary) {
+    adapters.set('ripgrep', createRipgrepAdapter({ binary: ripgrepBinary, worktreeRoot }));
+  }
+  // Config-driven CLI tools: one adapter, one entry each.
+  const cliSpecs = {
+    // zoekt indexes with a separate binary and the flag is -index, not -index_dir.
+    zoekt: (bin) => ({
+      binary: bin,
+      indexBinary: `${bin}-index`,
+      indexArgs: ({ worktree, indexRoot }) => ['-index', indexRoot, worktree],
+      queryArgs: ({ indexRoot, queryTokens, query }) => {
+        const tokens = [...(queryTokens ?? [])].slice(0, 8);
+        const terms = tokens.length > 0 ? tokens : [query.split(' ')[0]];
+        return terms.map((token) => ['-index_dir', indexRoot, '-l', token]);
+      },
+      payloadKind: 'whole-files',
+    }),
+    // GitNexus indexes into <repo>/.gitnexus, so deleting the worktree collects the
+    // index. --index-only stops it writing AGENTS.md and skill files into the tree
+    // under test. Embeddings are opt-in and left off: that is the default a user
+    // gets, and turning them on would measure a model rather than the graph.
+    gitnexus: (bin) => ({
+      binary: bin,
+      indexArgs: ({ worktree }) => [
+        'analyze',
+        worktree,
+        '--index-only',
+        '--skip-skills',
+        '--skip-agents-md',
+        '--name',
+        worktree.split('/').pop(),
+        '--allow-duplicate-name',
+      ],
+      // Without --content the payload is execution flows carrying no filePath at
+      // all, so this is the only mode whose results an agent could actually open.
+      // -l bounds processes rather than files, so the file count per query varies.
+      queryArgs: ({ worktree, query, limit }) => [
+        'query',
+        '-q',
+        query,
+        '-r',
+        worktree.split('/').pop(),
+        '-l',
+        String(limit),
+        '--content',
+      ],
+      payloadKind: 'tool-output',
+    }),
+    // token-savior has two retrieval surfaces and they are different mechanisms, so
+    // they are separate arms rather than one averaged number. `use` sets a global
+    // active project, which is shared mutable state: correct only because providers
+    // and cases run strictly sequentially here.
+    //
+    // Semantic mode needs sqlite-vec and fastembed, neither of which the wheel
+    // pulls. Results are symbols with scores, not files — the cheapest payload of
+    // any arm that answers in natural language.
+    'token-savior': (bin) => ({
+      binary: bin,
+      indexArgs: ({ worktree }) => ['--no-daemon', 'use', worktree],
+      queryArgs: ({ query, limit }) => [
+        '--no-daemon',
+        'search',
+        '--semantic',
+        query,
+        '--limit',
+        String(limit),
+      ],
+      payloadKind: 'tool-output',
+    }),
+    // Regex mode: prose is not a regex, so each token is searched and the hits
+    // unioned, exactly as ast-grep and the git-grep baseline are adapted. It indexes
+    // prose files too, so CHANGELOG hits are expected and are charged for.
+    'token-savior-regex': (bin) => ({
+      binary: bin,
+      indexArgs: ({ worktree }) => ['--no-daemon', 'use', worktree],
+      queryArgs: ({ queryTokens, query, limit }) => {
+        const tokens = [...(queryTokens ?? [])].slice(0, 8);
+        const terms = tokens.length > 0 ? tokens : [query.split(' ')[0]];
+        return terms.map((token) => ['--no-daemon', 'search', token, '--limit', String(limit)]);
+      },
+      payloadKind: 'tool-output',
+    }),
+    // The only provider in this registry that takes an explicit token budget, which
+    // is the axis this benchmark had to invent to compare the others. It is given
+    // 16k, the widest budget scored, and the scorer truncates down from there — so
+    // the tool is asked for its best 16k and judged at 1k, 4k and 16k on that.
+    //
+    // `context` also takes the task in prose via --task, so no query rewriting is
+    // needed. --index points the daemon at the worktree, so revisions are real
+    // checkouts rather than labels.
+    gortex: (bin) => ({
+      binary: bin,
+      indexArgs: ({ worktree }) => ['track', worktree, '--no-progress'],
+      queryArgs: ({ worktree, query, limit }) => [
+        'context',
+        '--task',
+        query,
+        '--index',
+        worktree,
+        '--token-budget',
+        '16000',
+        '--max-symbols',
+        String(limit),
+        '--format',
+        'json',
+        '--no-progress',
+      ],
+      payloadKind: 'tool-output',
+    }),
+    // Graph-backed, and the graph is shared across every repository it has indexed,
+    // so each case deletes its own worktree afterwards. COLUMNS is forced wide
+    // because the output is a Rich table that otherwise wraps each path across four
+    // lines mid-token, which no path parser can reassemble.
+    //
+    // `find content` is full-text, and a prose phrase matches nothing, so each query
+    // token is searched separately and the hits unioned — the same adaptation used
+    // for ast-grep, ripgrep and the git-grep baseline.
+    'code-graph-context': (bin) => ({
+      binary: bin,
+      // ALLOW_DB_DELETION is what makes the per-case cleanup below actually run. Without
+      // it `cgc delete <path> --yes` exits with "Repository deletion is disabled. Set
+      // ALLOW_DB_DELETION=true in config to enable" — a refusal the adapter treated as a
+      // completed cleanup, so the shared graph grew for 108 cases straight. It is set as
+      // a process variable here rather than written into ~/.codegraphcontext/.env: the
+      // harness should not be editing a tool's user configuration to measure it.
+      env: { COLUMNS: '400', TERM: 'dumb', NO_COLOR: '1', ALLOW_DB_DELETION: 'true' },
+      indexArgs: ({ worktree }) => ['index', worktree],
+      queryArgs: ({ queryTokens, query }) => {
+        const tokens = [...(queryTokens ?? [])].slice(0, 8);
+        const terms = tokens.length > 0 ? tokens : [query.split(' ')[0]];
+        return terms.map((token) => ['find', 'content', token]);
+      },
+      // Per case, or the shared graph accumulates every revision it has ever seen. After
+      // one 108-case run it held 110 stale worktree paths, and because the database is
+      // shared across repositories those copies won the result slots: a hand query for
+      // "dnsCache" returned 20 matches of which 19 pointed into earlier cases'
+      // worktrees. The adapter correctly discarded them as absent at this revision,
+      // which left nothing, so the arm recorded 0.0% on all 108 cases with a
+      // 961-function graph built and working.
+      cleanupArgs: ({ worktree }) => ['delete', worktree, '--yes'],
+      payloadKind: 'tool-output',
+    }),
+    // RepoWise (AGPL repowise-dev/repowise, ~6.2k stars). Wrongly excluded earlier:
+    // the exclusion applied to the separate `repowise-npm` package, which calls
+    // api.repowise.ai. This project is local-first — `init` needs no API key and the
+    // docs state source never leaves the network — so it is measurable. Telemetry is
+    // opt-out and was disabled before measuring.
+    //
+    // Mechanism is distinct from every other arm: `init` generates a wiki (222 pages
+    // on gin) and `search` queries those pages, so it retrieves through generated
+    // documentation rather than from code directly. Results still carry real source
+    // paths, so it stays comparable on the same metric.
+    repowise: (bin) => ({
+      binary: bin,
+      // --no-prose renders the wiki from structure with no model and no key, which is
+      // the only variant this benchmark can run under its local-only constraint. This
+      // spec was declared TWICE in this object; the second declaration silently won, so
+      // repowise actually ran without --limit and without --format json — an arm
+      // measured under different settings than the ones recorded here.
+      indexArgs: ({ worktree }) => ['init', worktree, '--no-prose'],
+      // hybrid is its own default-recommended blend of fulltext, semantic and symbol
+      // modes; the alternatives are recorded rather than cherry-picked.
+      queryArgs: ({ query, limit }) => [
+        'search',
+        query,
+        '--mode',
+        'hybrid',
+        '--limit',
+        String(limit),
+        '--format',
+        'json',
+        '--no-workspace',
+      ],
+      payloadKind: 'tool-output',
+    }),
+    // codegraph (colbymchenry, 67.7k stars, MIT). The largest project in this category
+    // and absent from the registry until an independent sweep found it: best-match
+    // ordering never reached it, and it carries no GitHub topics so topic queries were
+    // blind to it. Fully local — SQLite, no API keys.
+    codegraph: (bin) => ({
+      binary: bin,
+      indexArgs: ({ worktree }) => ['init', worktree],
+      // `explore` is the prose entry point (it backs the codegraph_explore MCP tool);
+      // `query` is symbol-name lookup, which is a different question.
+      // No --limit: `explore` bounds output with --max-files instead.
+      queryArgs: ({ worktree, query, limit }) => [
+        'explore',
+        query,
+        '--path',
+        worktree,
+        '--max-files',
+        String(limit),
+      ],
+      payloadKind: 'tool-output',
+    }),
+    // graft (NanoNets, 4.3k stars, MIT). `build` is explicitly model-free; --deep LLM
+    // summaries are opt-in and deliberately not used, so this measures the structural
+    // graph rather than a model. Telemetry disabled before measuring.
+    graft: (bin) => ({
+      binary: bin,
+      indexArgs: ({ worktree }) => ['build', worktree],
+      queryArgs: ({ worktree, query }) => ['ask', query, worktree],
+      payloadKind: 'tool-output',
+    }),
+    // ck (BeaconBay, 1.7k stars, Apache-2.0). Semantic grep, local embeddings. Indexes
+    // on first query, so there is no separate index step to charge.
+    ck: (bin) => ({
+      binary: bin,
+      // --sem not --hybrid: --hybrid silently degraded to semantic-only here and printed
+      // a banner claiming otherwise. Paths come back absolute under "file", which the
+      // worktree-prefix strip already handles.
+      queryArgs: ({ worktree, query, limit }) => [
+        '--json',
+        '--sem',
+        query,
+        '--limit',
+        String(limit),
+        worktree,
+      ],
+      payloadKind: 'tool-output',
+    }),
+    // chunkhound (1.4k stars, MIT). Regex path works without a key; semantic needs a
+    // local embedding endpoint, so the key-free regex mode is what is measured and the
+    // limitation is recorded rather than worked around.
+    chunkhound: (bin) => ({
+      binary: bin,
+      indexArgs: ({ worktree }) => ['index', worktree],
+      // `search` takes query and path positionally; without the path it looks for a
+      // database in the cwd and errors with "Database not found".
+      queryArgs: ({ worktree, query, limit }) => [
+        'search',
+        '--regex',
+        query,
+        worktree,
+        '--page-size',
+        String(limit),
+      ],
+      payloadKind: 'tool-output',
+    }),
+    'ast-grep': (bin) => ({
+      binary: bin,
+      // No prose entry point exists, so each query token becomes a literal pattern
+      // and the matches are unioned: AST-aware keyword search.
+      queryArgs: ({ queryTokens }) =>
+        [...queryTokens]
+          .slice(0, 8)
+          .map((token) => ['run', '-p', token, '--heading', 'never', '.']),
+      payloadKind: 'whole-files',
+    }),
+    'code-review-graph': (bin) => ({
+      binary: bin,
+      // --repo, not --path. --embedding-provider must be paired with
+      // --embedding-model, so both are omitted: the structural build needs neither.
+      // `search` takes no --data-dir and reads the registered repo for the cwd.
+      indexArgs: ({ worktree }) => ['build', '--repo', worktree],
+      // One invocation per query token, not one for the whole sentence. `search` is a
+      // whole-string FTS match: on a real corpus query the single term "dnsCache"
+      // returns 17 nodes and "cache" returns 20, while the commit subject it came from,
+      // "Fix `dnsCache: true` having no effect", returns ZERO. Passing the sentence
+      // scored this tool 0.0% on all 108 cases with a graph of 3,174 nodes built and
+      // working — a misuse of the tool recorded as a property of it.
+      queryArgs: ({ query, queryTokens, limit }) => {
+        const terms = queryTokens?.length ? queryTokens : [query];
+        return terms.map((term) => ['search', term, '--limit', String(limit)]);
+      },
+      payloadKind: 'tool-output',
+    }),
+    ugrep: (bin) => ({
+      binary: bin,
+      // Same shape as the ripgrep and git-grep arms: one pass per token, unioned.
+      queryArgs: ({ queryTokens, query }) => {
+        const terms = [...(queryTokens ?? [])].slice(0, 8);
+        const list = terms.length > 0 ? terms : [query.split(' ')[0]];
+        const types = ['-Ots', '-Otsx', '-Ojs', '-Omjs', '-Opy', '-Ogo', '-Ors'];
+        return list.map((token) => ['-l', '-i', '-F', ...types, token, '.']);
+      },
+      payloadKind: 'whole-files',
+    }),
+    seagoat: (bin) => ({
+      binary: bin,
+      // Requires a seagoat-server analysing the repo; without one it errors, which
+      // the harness records rather than masking.
+      queryArgs: ({ query, worktree }) => [query, worktree],
+      payloadKind: 'chunks',
+    }),
+    semble: (bin) => ({
+      binary: bin,
+      // Indexes lazily on first search; --content code keeps it to source files.
+      queryArgs: ({ query, limit }) => [
+        'search',
+        query,
+        '--top-k',
+        String(limit),
+        '--content',
+        'code',
+      ],
+      payloadKind: 'chunks',
+    }),
+    'cocoindex-code': (bin) => ({
+      binary: bin,
+      indexArgs: ({ worktree }) => [['init', worktree], ['index']],
+      queryArgs: ({ query, limit }) => ['search', query, '--limit', String(limit)],
+      payloadKind: 'chunks',
+    }),
+    grepai: (bin) => ({
+      binary: bin,
+      indexArgs: () => ['init'],
+      queryArgs: ({ query }) => ['search', query],
+      payloadKind: 'chunks',
+    }),
+  };
+  for (const [id, binary] of Object.entries(cliTools)) {
+    const make = cliSpecs[id];
+    if (!make || !binary) continue;
+    adapters.set(
+      id,
+      createGenericCliAdapter({
+        providerId: id,
+        worktreeRoot,
+        indexRoot: `${cacheDir}/${id}-index`,
+        ...make(binary),
+      })
+    );
+  }
+  if (repomapper) {
+    for (const personalize of [false, true]) {
+      const adapter = createRepomapperAdapter({
+        python: repomapper.python,
+        script: repomapper.script,
+        worktreeRoot,
+        personalize,
+      });
+      adapters.set(personalize ? 'repomap-personalized' : 'repomap-global', adapter);
+    }
+  }
+  if (repomix) {
+    adapters.set('repomix-pack-all', createRepomixAdapter({ worktreeRoot }));
+    adapters.set('repomix-compressed', createRepomixAdapter({ worktreeRoot, compress: true }));
+  }
+  return adapters;
+}
+
+// A capacity refusal is as hard as an index failure: retrying cannot make a snapshot
+// smaller than the ceiling that rejected it.
+export function isHardFailure(reason) {
+  return /^(index|worktree)|exceeds?[- ].*limit|import[- ]limit|safety limit/i.test(reason ?? '');
+}
+
+// One arm over the whole corpus. Split out of scoreRetrieval, which scored cognitive
+// complexity 38 against a ceiling of 20.
+//
+// A provider that has failed to index the same repository several times running will
+// keep failing, and each failure costs a full call timeout — one arm burned roughly 55
+// minutes proving a repository unindexable 11 times at 5 minutes apiece. Abandon the arm
+// instead and record why, so the skip is never mistaken for a score. Consecutive rather
+// than cumulative: a provider that recovers continues.
+async function runArm({ adapter, corpus, repo, limit, shuffleQueries }) {
+  const cases = [];
+  let consecutiveHardFailures = 0;
+  let abandoned = null;
+  for (const [index, entry] of corpus.cases.entries()) {
+    if (abandoned) break;
+    // Deliberate mismatch under shuffleQueries: the query belongs to a different case,
+    // the revision still belongs to this one. A provider that ignores the query scores
+    // the same either way, which is the point of the arm.
+    const source = shuffleQueries ? corpus.cases[(index + 1) % corpus.cases.length] : entry;
+    // Awaited because MCP-backed providers are asynchronous; synchronous adapters
+    // resolve immediately.
+    const response = await adapter({
+      repo,
+      revision: entry.base_revision,
+      query: source.query,
+      queryTokens: source.query_tokens,
+      limit,
+    });
+    cases.push({ case: entry, response, measures: measureCase(entry, response) });
+    consecutiveHardFailures = isHardFailure(response.unavailable_reason)
+      ? consecutiveHardFailures + 1
+      : 0;
+    if (consecutiveHardFailures >= ABANDON_AFTER_HARD_FAILURES) {
+      abandoned = {
+        after_cases: cases.length,
+        remaining: corpus.cases.length - cases.length,
+        reason: `${consecutiveHardFailures} consecutive index failures; the arm cannot index this repository`,
+      };
+    }
+  }
+  return { cases, abandoned };
+}
+
+// Outcome taxonomy per provider. Kept separate from the score so that did-not-install
+// can never read as poor retrieval: more candidates in this category fail to start than
+// score badly, and collapsing the two is the largest distortion available here.
+function tagOutcomes(providers) {
+  for (const provider of providers) {
+    const counts = {};
+    for (const entry of provider.cases) {
+      const outcome = classifyOutcome(entry.response);
+      counts[outcome] = (counts[outcome] ?? 0) + 1;
+    }
+    provider.outcomes = counts;
+  }
+}
+
+// Travels with every artifact, so a number cannot be quoted without them.
+function limitationsFor(gates, aborted) {
+  const limitations = [];
+  if (!gates.trustworthy) {
+    const why = [gates.controls_present.reason, gates.controls_lose.reason]
+      .filter(Boolean)
+      .join(' ');
+    limitations.push(`RELIABILITY GATE FAILED — do not publish these numbers: ${why}`);
+  }
+  if (aborted) {
+    limitations.push(
+      `Run aborted by the memory guard after ${aborted.after.length} providers; ${aborted.skipped.length} were not measured.`
+    );
+  }
+  limitations.push(
+    'One repository; results describe this codebase, not codebases in general.',
+    'Ground truth is the files a real fix changed, which is a proxy for the files it had to find.',
+    'Commit subjects were written with the fix in hand, so queries are friendlier than real user prompts.',
+    'Retrieval quality is not task success; a provider can retrieve well and still not help an agent.'
+  );
+  return limitations;
+}
+
+export async function scoreRetrieval({
+  corpus,
+  repo,
+  providerIds = ['keyword-search'],
+  limit = 20,
+  adapters = resolveAdapters(),
+  shuffleQueries = false,
+  cacheDir,
+  minFreeMemoryMb = 3072,
+}) {
+  const providers = [];
+  const provider_abandoned = new Map();
+  let aborted = null;
+  for (const providerId of providerIds) {
+    const adapter = adapters.get(providerId);
+    if (!adapter) throw new Error(`no retrieval adapter registered for "${providerId}"`);
+    // Checked before EVERY provider, not once at startup. One arm alone peaks at 3.1 GB
+    // indexing a 168-file repository, so a run that was safe to begin can become unsafe
+    // midway. Abort with partial results rather than take the machine down.
+    const guard = guardMemory({ minFreeMb: minFreeMemoryMb });
+    if (!guard.ok) {
+      aborted = {
+        after: providers.map((entry) => entry.provider_id),
+        skipped: providerIds.slice(providerIds.indexOf(providerId)),
+        reason: `free memory ${guard.free_mb} MB below the ${guard.minimum_mb} MB floor`,
+      };
+      break;
+    }
+    const monitor = createResourceMonitor();
+    const cacheBefore = cacheDir ? directoryBytes(cacheDir) : 0;
+    const { cases, abandoned } = await runArm({ adapter, corpus, repo, limit, shuffleQueries });
+    if (abandoned) provider_abandoned.set(providerId, abandoned);
+    const resources = monitor.stop();
+    providers.push({
+      provider_id: providerId,
+      cases,
+      resources: {
+        ...resources,
+        index_bytes_added: cacheDir ? Math.max(0, directoryBytes(cacheDir) - cacheBefore) : null,
+      },
+    });
+  }
+  if (providers.length === 0) {
+    throw new Error(`no provider ran: ${aborted?.reason ?? 'empty provider list'}`);
+  }
+  // Difficulty is defined by what the reference baseline actually failed to find,
+  // not by guessing in advance. The first provider is the reference.
+  const baselineMissed = new Set(
+    providers[0].cases
+      .filter((entry) => entry.measures.recall_at_10 < 1)
+      .map((entry) => entry.case.case_id)
+  );
+  for (const provider of providers) provider.summary = summarize(provider.cases, baselineMissed);
+
+  // Gates run before the report is assembled, so a run that cannot be trusted says
+  // so in its own artifact instead of looking like every other run.
+  const summarised = providers.map((p) => ({ provider_id: p.provider_id, summary: p.summary }));
+  const controlsPresent = checkControlsPresent(providers.map((p) => p.provider_id));
+  const controlsLose = controlsPresent.ok
+    ? checkControlsLose({ providers: summarised })
+    : { ok: null };
+  const gates = {
+    controls_present: controlsPresent,
+    controls_lose: controlsLose,
+    // Extreme values are claims about the instrument until a human reads the bytes.
+    needs_raw_payload_check: flagExtremes(summarised),
+    // The plausible middle is where bias hides and where nothing else looks.
+    nominated_for_hand_audit: nominateForAudit({ providers }),
+    trustworthy: controlsPresent.ok && controlsLose.ok !== false,
+  };
+  tagOutcomes(providers);
+
+  return {
+    schema_version: RETRIEVAL_SCORE_SCHEMA_VERSION,
+    repository: corpus.repository,
+    // Measured, not declared: the reporter groups on this, and a hand-set tier is
+    // exactly how a benchmark ends up with a repository filed under the tier that
+    // flatters it.
+    tier: tierOf(repo),
+    tier_code_files: codeFilesOf(repo),
+    corpus_counts: corpus.counts,
+    cutoffs: CUTOFFS,
+    gates,
+    providers: providers.map((provider) => ({
+      provider_id: provider.provider_id,
+      summary: provider.summary,
+      outcomes: provider.outcomes,
+      ...(provider_abandoned.has(provider.provider_id)
+        ? { abandoned: provider_abandoned.get(provider.provider_id) }
+        : {}),
+      resources: provider.resources,
+    })),
+    ...(aborted ? { aborted } : {}),
+    limitations: limitationsFor(gates, aborted),
+    cases: providers.flatMap((provider) =>
+      provider.cases.map((entry) => ({
+        provider_id: provider.provider_id,
+        case_id: entry.case.case_id,
+        path_leak: entry.case.retrieval.path_leak,
+        required_files: entry.case.required_files,
+        ...entry.measures,
+        tokens_delivered: entry.response.tokens_delivered,
+        latency_ms: entry.response.latency_ms,
+        indexed_revision_matches: entry.response.indexed_revision === entry.case.base_revision,
+      }))
+    ),
+  };
+}
+
+function measureCase(entry, response) {
+  const required = new Set(entry.required_files);
+  const measures = { found: [], missed: [] };
+  for (const cutoff of CUTOFFS) {
+    const window = response.files.slice(0, cutoff);
+    const hit = window.filter((path) => required.has(path));
+    measures[`recall_at_${cutoff}`] = round(hit.length / required.size);
+    measures[`precision_at_${cutoff}`] =
+      window.length === 0 ? 0 : round(hit.length / window.length);
+  }
+  // Cost is amortised evenly across returned results, because most providers report
+  // one payload total rather than a per-result cost. Documented approximation, not a
+  // per-file measurement.
+  const perResult =
+    response.files.length > 0 ? (response.tokens_delivered ?? 0) / response.files.length : 0;
+  for (const budget of TOKEN_BUDGETS) {
+    const affordable = perResult > 0 ? Math.floor(budget / perResult) : response.files.length;
+    const window = response.files.slice(0, Math.max(0, affordable));
+    measures[`recall_at_${budget}_tokens`] = round(
+      window.filter((path) => required.has(path)).length / required.size
+    );
+  }
+  const all = response.files.filter((path) => required.has(path));
+  measures.found = all.sort();
+  measures.missed = [...required].filter((path) => !response.files.includes(path)).sort();
+  // Rank of the first correct file: what an agent would actually pay to read past.
+  const firstHit = response.files.findIndex((path) => required.has(path));
+  measures.first_hit_rank = firstHit === -1 ? null : firstHit + 1;
+  return measures;
+}
+
+function summarize(cases, baselineMissed) {
+  const strata = {
+    all: cases,
+    // What the baseline could not fully locate: the only stratum where a context
+    // provider can demonstrate it adds anything.
+    baseline_missed: cases.filter((entry) => baselineMissed.has(entry.case.case_id)),
+    baseline_solved: cases.filter((entry) => !baselineMissed.has(entry.case.case_id)),
+    path_leak: cases.filter((entry) => entry.case.retrieval.path_leak),
+    no_path_leak: cases.filter((entry) => !entry.case.retrieval.path_leak),
+  };
+  const summary = {};
+  for (const [name, group] of Object.entries(strata)) {
+    summary[name] = {
+      cases: group.length,
+      ...Object.fromEntries(
+        CUTOFFS.flatMap((cutoff) => [
+          [
+            `mean_recall_at_${cutoff}`,
+            mean(group.map((entry) => entry.measures[`recall_at_${cutoff}`])),
+          ],
+          [
+            `full_recall_at_${cutoff}`,
+            round(
+              group.filter((entry) => entry.measures[`recall_at_${cutoff}`] === 1).length /
+                (group.length || 1)
+            ),
+          ],
+        ])
+      ),
+      ...Object.fromEntries(
+        TOKEN_BUDGETS.map((budget) => [
+          `mean_recall_at_${budget}_tokens`,
+          mean(group.map((entry) => entry.measures[`recall_at_${budget}_tokens`])),
+        ])
+      ),
+      mean_precision_at_10: mean(group.map((entry) => entry.measures.precision_at_10)),
+      zero_hit_rate: round(
+        group.filter((entry) => entry.measures.first_hit_rank === null).length / (group.length || 1)
+      ),
+      median_tokens_delivered: median(group.map((entry) => entry.response.tokens_delivered)),
+      median_latency_ms: median(group.map((entry) => entry.response.latency_ms)),
+      // Whole files versus excerpts are not the same currency; never blend them.
+      payload_kind: [
+        ...new Set(group.map((entry) => entry.response.payload_kind ?? 'whole-files')),
+      ].sort(),
+      unavailable: group.filter((entry) => entry.response.unavailable_reason).length,
+    };
+  }
+  return summary;
+}
+
+export function renderRetrievalScore(score) {
+  const lines = [
+    `# Retrieval quality — ${score.repository.id}`,
+    '',
+    `Cases: ${score.corpus_counts.cases} · multi-file ${score.corpus_counts.multi_file} · path-leak ${score.corpus_counts.path_leak}`,
+    '',
+    `Reference baseline: \`${score.providers[0]?.provider_id}\`. The **baseline missed** row is the stratum that matters — cases the baseline could not fully locate at rank 10.`,
+    '',
+    '| Provider | Stratum | n | recall@5 | recall@10 | recall@20 | full@10 | prec@10 | never found | payload | tokens | n/a |',
+    '| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | ---: | ---: |',
+  ];
+  for (const provider of score.providers) {
+    for (const stratum of [
+      'all',
+      'baseline_missed',
+      'baseline_solved',
+      'path_leak',
+      'no_path_leak',
+    ]) {
+      const row = provider.summary[stratum];
+      lines.push(
+        `| ${provider.provider_id} | ${stratum.replace(/_/g, ' ')} | ${row.cases} | ${pct(row.mean_recall_at_5)} | ${pct(row.mean_recall_at_10)} | ${pct(row.mean_recall_at_20)} | ${pct(row.full_recall_at_10)} | ${pct(row.mean_precision_at_10)} | ${pct(row.zero_hit_rate)} | ${row.payload_kind.join('+')} | ${row.median_tokens_delivered} | ${row.unavailable} |`
+      );
+    }
+  }
+  lines.push('', '## Limitations', '', ...score.limitations.map((item) => `- ${item}`));
+  return `${lines.join('\n')}\n`;
+}
+
+function mean(values) {
+  const usable = values.filter((value) => Number.isFinite(value));
+  if (usable.length === 0) return 0;
+  return round(usable.reduce((total, value) => total + value, 0) / usable.length);
+}
+
+function tierOf(repo) {
+  try {
+    return classify(countCodeFiles(repo)).id;
+  } catch {
+    return 'untiered';
+  }
+}
+
+function codeFilesOf(repo) {
+  try {
+    return countCodeFiles(repo);
+  } catch {
+    return null;
+  }
+}
+
+function median(values) {
+  const usable = values.filter((value) => Number.isFinite(value)).sort((a, b) => a - b);
+  if (usable.length === 0) return 0;
+  const middle = Math.floor(usable.length / 2);
+  return usable.length % 2 === 0
+    ? round((usable[middle - 1] + usable[middle]) / 2)
+    : usable[middle];
+}
+
+function round(value) {
+  return Math.round(value * 10000) / 10000;
+}
+
+function pct(value) {
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+async function writeAtomic(path, contents) {
+  const destination = resolve(path);
+  await mkdir(dirname(destination), { recursive: true });
+  const temporary = `${destination}.tmp-${process.pid}`;
+  await writeFile(temporary, contents);
+  await rename(temporary, destination);
+}
+
+// Flags as a table rather than a chain of eighteen ifs. The chain scored cognitive
+// complexity 45 against a ceiling of 20, and it hid a live bug: --repomix is a boolean,
+// so `--repomix true` threw "unknown argument: true" and two arms produced nothing at
+// all on their first run. A table makes a flag's arity part of its declaration.
+const BOOLEAN_FLAGS = new Set(['--repomix', '--shuffle-queries']);
+
+const BOOLEAN_TARGET = {
+  '--repomix': 'repomix',
+  '--shuffle-queries': 'shuffleQueries',
+};
+
+const VALUE_TARGET = {
+  '--corpus': 'corpusPath',
+  '--repo': 'repo',
+  '--format': 'format',
+  '--out': 'out',
+  '--tool': 'tool',
+  '--cache-dir': 'cacheDir',
+  '--graphify': 'graphifyBinary',
+  '--codesearch': 'codesearchBinary',
+  '--codegrok': 'codegrokCommand',
+  '--serena': 'serenaCommand',
+  '--cocoindex': 'cocoindexCommand',
+  '--jcodemunch': 'jcodemunchCommand',
+  '--repomapper-python': 'repomapperPython',
+  '--repomapper-script': 'repomapperScript',
+  '--ripgrep': 'ripgrepBinary',
+};
+
+function applyValueFlag(options, flag, value) {
+  if (flag === '--provider') {
+    options.providerIds = value.split(',');
+    return;
+  }
+  if (flag === '--cli-tool') {
+    const [id, binary] = value.split('=');
+    (options.cliTools ??= {})[id] = binary;
+    return;
+  }
+  options[VALUE_TARGET[flag]] = value;
+}
+
+function parseArgs(args) {
+  const options = { repo: process.cwd(), providerIds: ['keyword-search'], format: 'markdown' };
+  for (let index = 0; index < args.length; index += 1) {
+    const flag = args[index];
+    if (BOOLEAN_FLAGS.has(flag)) {
+      options[BOOLEAN_TARGET[flag]] = true;
+      continue;
+    }
+    const takesValue = flag === '--provider' || flag === '--cli-tool' || flag in VALUE_TARGET;
+    if (!takesValue) throw new Error(`unknown argument: ${flag}`);
+    const value = args[index + 1];
+    if (!value || value.startsWith('--')) throw new Error(`${flag} requires a value`);
+    index += 1;
+    applyValueFlag(options, flag, value);
+  }
+  if (!options.corpusPath) throw new Error('--corpus is required');
+  return options;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    const options = parseArgs(process.argv.slice(2));
+    const corpus = JSON.parse(readFileSync(options.corpusPath, 'utf8'));
+    const adapters = resolveAdapters({
+      tool: options.tool,
+      cacheDir: options.cacheDir ? `${options.cacheDir}/snapshots` : undefined,
+      worktreeRoot: options.cacheDir ? `${options.cacheDir}/worktrees` : undefined,
+      graphifyBinary: options.graphifyBinary,
+      codesearchBinary: options.codesearchBinary,
+      codegrokCommand: options.codegrokCommand,
+      serenaCommand: options.serenaCommand,
+      cocoindexCommand: options.cocoindexCommand,
+      jcodemunchCommand: options.jcodemunchCommand,
+      repomapper:
+        options.repomapperPython && options.repomapperScript
+          ? { python: options.repomapperPython, script: options.repomapperScript }
+          : undefined,
+      ripgrepBinary: options.ripgrepBinary,
+      cliTools: options.cliTools ?? {},
+      repomix: options.repomix,
+    });
+    const score = await scoreRetrieval({
+      corpus,
+      repo: options.repo,
+      providerIds: options.providerIds,
+      adapters,
+      shuffleQueries: options.shuffleQueries,
+      cacheDir: options.cacheDir,
+    });
+    const rendered =
+      options.format === 'json'
+        ? `${JSON.stringify(score, null, 2)}\n`
+        : renderRetrievalScore(score);
+    if (options.out) await writeAtomic(options.out, rendered);
+    process.stdout.write(rendered);
+  } catch (error) {
+    process.stderr.write(
+      `Retrieval scoring failed: ${error instanceof Error ? error.message : String(error)}\n`
+    );
+    process.exitCode = 2;
+  }
+}


### PR DESCRIPTION
Fourth of the stack. Depends on #171 (primitives) and #172 (adapters).

## What it does

`score.mjs` runs each arm over a corpus and **charges for the payload**. Recall at a fixed rank let a query-blind churn ranker appear to beat shipping products at 37.3%; charged for what it delivered, it scores 0.0% at a 1k budget. That single change is what made the field legible.

Two safety behaviours worth knowing about:
- **Abandons an arm after 3 consecutive index failures.** One arm spent ~55 minutes proving a repository unindexable eleven times at a five-minute timeout apiece. Consecutive, not cumulative — an arm that recovers continues.
- **Checks free memory before every provider**, not once at startup. One arm peaks at 3.1 GB indexing a 168-file repository, so a run that was safe to begin can become unsafe midway.

`report-tiered.mjs` **cannot emit an overall winner** — there is no cross-tier or cross-budget aggregate to emit, because the leader changes at every budget. It also recomputes the gates over the union of artifacts rather than trusting each one's stored verdict; see #172's discussion of why per-arm runs all report "controls absent".

## Changes CI asked for

The complexity gate flagged `scoreRetrieval` at 38, `parseArgs` at 45, `loadTiered` at 32 and a second `parseArgs` at 23, against a ceiling of 20. All four are split or table-driven now. The flag tables are a genuine improvement beyond the score: a chain is where a flag's arity goes unstated, which is how `--repomix true` threw `unknown argument: true` and two arms produced nothing at all on their first run.

## One test rewritten rather than repaired

`abandon.test.mjs` asserted on `score.mjs`'s **source text** — matching the literal expression `consecutiveHardFailures = hard ? consecutiveHardFailures + 1 : 0`. Extracting that loop into a named function broke the test while the behaviour was identical, which is backwards from what a test is for. It now drives `scoreRetrieval` with a stub adapter and asserts the adapter is called exactly 3 times, that `remaining` is recorded, and that an arm which recovers between failures runs to completion.

## Verification

60 tests. Complexity, duplication (0.78% vs 0.81% ceiling), change-size (16/40 files) and lint all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)