### PR TITLE
CLI spec coverage and preflight verification

### DIFF
--- a/apps/desktop/scripts/verify-cli-release.mjs
+++ b/apps/desktop/scripts/verify-cli-release.mjs
@@ -12,6 +12,9 @@ const requiredHelpFragments = [
   '--preview <url>',
   '--repo <path>',
   '--task <text>',
+  '--preflight',
+  '--spec <path>',
+  '--requirement <id>',
   '--baseline-repo <path>',
   '--json',
 ];

--- a/apps/desktop/scripts/verify-cli-release.test.mjs
+++ b/apps/desktop/scripts/verify-cli-release.test.mjs
@@ -22,6 +22,9 @@ Options:
   --preview <url>
   --repo <path>
   --task <text>
+  --preflight
+  --spec <path>
+  --requirement <id>
   --baseline-repo <path>
   --json
 `;
@@ -50,7 +53,7 @@ test('qualifies the tracked version, help surface, and bundle declarations', asy
 
   assert.equal(result.version, TRACKED_VERSION);
   assert.equal(result.bundleEntry, 'binaries/codevetter');
-  assert.equal(result.helpContracts, 9);
+  assert.equal(result.helpContracts, 12);
   assert.ok(result.bytes > 0);
 });
 
@@ -81,6 +84,32 @@ test('fails when a documented T-Rex flag disappears', async (t) => {
   });
 
   assert.throws(() => qualifyCli({ binaryPath }), /CLI help is missing required contract: --json/);
+});
+
+test('fails when the spec verification contract disappears', async (t) => {
+  const directory = await mkdtemp(join(tmpdir(), 'codevetter-cli-'));
+  t.after(() => rm(directory, { recursive: true, force: true }));
+  const binaryPath = await fakeCli(directory, {
+    help: HELP.replace('--requirement <id>', '--criterion <id>'),
+  });
+
+  assert.throws(
+    () => qualifyCli({ binaryPath }),
+    /CLI help is missing required contract: --requirement <id>/
+  );
+});
+
+test('fails when the preflight contract disappears', async (t) => {
+  const directory = await mkdtemp(join(tmpdir(), 'codevetter-cli-'));
+  t.after(() => rm(directory, { recursive: true, force: true }));
+  const binaryPath = await fakeCli(directory, {
+    help: HELP.replace('--preflight', '--execute-only'),
+  });
+
+  assert.throws(
+    () => qualifyCli({ binaryPath }),
+    /CLI help is missing required contract: --preflight/
+  );
 });
 
 test('fails when either Tauri bundle declaration drops the CLI', async (t) => {

--- a/apps/desktop/src-tauri/src/bin/codevetter.rs
+++ b/apps/desktop/src-tauri/src/bin/codevetter.rs
@@ -1,5 +1,6 @@
 use codevetter_desktop::commands::local_check::{
-    run_local_check, LocalCheckInput, LocalCheckReceipt, LocalCheckStatus, LocalCheckTarget,
+    preflight_local_check, run_local_check_with_progress, LocalCheckInput,
+    LocalCheckPreflightReceipt, LocalCheckReceipt, LocalCheckStatus, LocalCheckTarget,
     LocalCheckVerdict,
 };
 use codevetter_desktop::commands::trex_preview::{
@@ -24,6 +25,9 @@ Options:
   --preview <url>  Existing HTTP(S) preview containing the change
   --repo <path>    Repository path (defaults to the current directory)
   --task <text>    Intended behavior for the change
+  --preflight      Validate source, specs, and targets without model or project execution
+  --spec <path>    Repo-relative Markdown spec (repeatable)
+  --requirement <id>  Requirement id explicitly bound to correctness (repeatable)
   --agent <name>   Review executor: claude, gemini, or codex (default: claude)
   --test-adapter <adapter>  Explicit correctness adapter
   --test-target <path>      Explicit correctness target
@@ -58,6 +62,8 @@ struct CheckArguments {
     repo_path: PathBuf,
     change: String,
     task: String,
+    spec_paths: Vec<PathBuf>,
+    selected_requirement_ids: Vec<String>,
     review_agent: String,
     test_target: Option<LocalCheckTarget>,
     performance_target: Option<LocalCheckTarget>,
@@ -65,11 +71,12 @@ struct CheckArguments {
     samples: u8,
     warmups: u8,
     timeout_ms: u64,
+    preflight: bool,
     output: OutputMode,
 }
 
 enum CliCommand {
-    Check(CheckArguments),
+    Check(Box<CheckArguments>),
     Trex(TrexArguments),
     Help,
     Version,
@@ -98,16 +105,20 @@ async fn run() -> Result<i32, String> {
             println!("codevetter {}", app_version());
             Ok(0)
         }
-        CliCommand::Check(arguments) => run_check(arguments).await,
+        CliCommand::Check(arguments) => run_check(*arguments).await,
         CliCommand::Trex(arguments) => run_trex(arguments).await,
     }
 }
 
 async fn run_check(arguments: CheckArguments) -> Result<i32, String> {
-    let receipt = run_local_check(LocalCheckInput {
+    let output = arguments.output;
+    let preflight = arguments.preflight;
+    let input = LocalCheckInput {
         repo_path: arguments.repo_path,
         change: arguments.change,
         task: arguments.task,
+        spec_paths: arguments.spec_paths,
+        selected_requirement_ids: arguments.selected_requirement_ids,
         review_agent: arguments.review_agent,
         test_target: arguments.test_target,
         performance_target: arguments.performance_target,
@@ -115,9 +126,28 @@ async fn run_check(arguments: CheckArguments) -> Result<i32, String> {
         samples: arguments.samples,
         warmups: arguments.warmups,
         timeout_ms: arguments.timeout_ms,
+    };
+    if preflight {
+        let receipt = preflight_local_check(&input).await?;
+        match output {
+            OutputMode::Json => println!(
+                "{}",
+                serde_json::to_string(&receipt)
+                    .map_err(|error| format!("serialize local check preflight: {error}"))?
+            ),
+            OutputMode::Human => print!("{}", render_human_preflight(&receipt)),
+        }
+        return Ok(preflight_exit_code(receipt.status));
+    }
+
+    let human_progress = output == OutputMode::Human;
+    let receipt = run_local_check_with_progress(input, |progress| {
+        if human_progress {
+            eprintln!("[codevetter] {}: {}", progress.stage, progress.state);
+        }
     })
     .await?;
-    match arguments.output {
+    match output {
         OutputMode::Json => println!(
             "{}",
             serde_json::to_string(&receipt)
@@ -235,6 +265,8 @@ fn parse_check(
     let mut pull_request = None;
     let mut range = None;
     let mut task = None;
+    let mut spec_paths = Vec::new();
+    let mut selected_requirement_ids = Vec::new();
     let mut review_agent = "claude".to_string();
     let mut test_adapter = None;
     let mut test_target = None;
@@ -246,6 +278,7 @@ fn parse_check(
     let mut samples = 3;
     let mut warmups = 1;
     let mut timeout_ms = 30_000;
+    let mut preflight = false;
     let mut output = OutputMode::Human;
     while let Some(argument) = arguments.next() {
         match argument.as_str() {
@@ -253,6 +286,11 @@ fn parse_check(
             "--pr" => pull_request = Some(required_value(&mut arguments, "--pr")?),
             "--range" => range = Some(required_value(&mut arguments, "--range")?),
             "--task" => task = Some(required_value(&mut arguments, "--task")?),
+            "--preflight" => preflight = true,
+            "--spec" => spec_paths.push(PathBuf::from(required_value(&mut arguments, "--spec")?)),
+            "--requirement" => {
+                selected_requirement_ids.push(required_value(&mut arguments, "--requirement")?)
+            }
             "--agent" => review_agent = required_value(&mut arguments, "--agent")?,
             "--test-adapter" => {
                 test_adapter = Some(required_value(&mut arguments, "--test-adapter")?)
@@ -294,10 +332,15 @@ fn parse_check(
         performance_target,
         performance_name,
     )?;
-    Ok(CliCommand::Check(CheckArguments {
+    if spec_paths.is_empty() && !selected_requirement_ids.is_empty() {
+        return Err("--requirement requires at least one --spec".into());
+    }
+    Ok(CliCommand::Check(Box::new(CheckArguments {
         repo_path: repo_path.unwrap_or_else(|| cwd.to_path_buf()),
         change,
         task: task.ok_or_else(|| "--task is required".to_string())?,
+        spec_paths,
+        selected_requirement_ids,
         review_agent,
         test_target,
         performance_target,
@@ -305,8 +348,9 @@ fn parse_check(
         samples,
         warmups,
         timeout_ms,
+        preflight,
         output,
-    }))
+    })))
 }
 
 fn paired_target(
@@ -359,16 +403,16 @@ fn default_app_data_dir() -> Result<PathBuf, String> {
     #[cfg(target_os = "macos")]
     {
         let home = std::env::var_os("HOME").ok_or_else(|| "HOME is unavailable".to_string())?;
-        return Ok(PathBuf::from(home)
+        Ok(PathBuf::from(home)
             .join("Library")
             .join("Application Support")
-            .join("com.codevetter.desktop"));
+            .join("com.codevetter.desktop"))
     }
     #[cfg(target_os = "windows")]
     {
         let app_data =
             std::env::var_os("APPDATA").ok_or_else(|| "APPDATA is unavailable".to_string())?;
-        return Ok(PathBuf::from(app_data).join("com.codevetter.desktop"));
+        Ok(PathBuf::from(app_data).join("com.codevetter.desktop"))
     }
     #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
     {
@@ -399,13 +443,48 @@ fn local_check_exit_code(verdict: LocalCheckVerdict) -> i32 {
     }
 }
 
-fn render_human_check(receipt: &LocalCheckReceipt) -> String {
-    let status = |value: LocalCheckStatus| {
-        serde_json::to_value(value)
-            .ok()
-            .and_then(|value| value.as_str().map(ToOwned::to_owned))
-            .unwrap_or_else(|| "unknown".into())
+fn preflight_exit_code(status: LocalCheckStatus) -> i32 {
+    if status == LocalCheckStatus::Ready {
+        0
+    } else {
+        2
+    }
+}
+
+fn render_human_preflight(receipt: &LocalCheckPreflightReceipt) -> String {
+    let target = |value: Option<&LocalCheckTarget>| {
+        value
+            .map(|target| format!("{} {}", target.adapter, target.target))
+            .unwrap_or_else(|| "unavailable".into())
     };
+    let mut output = format!(
+        "preflight: {}\nhead: {}\ncorrectness target: {}\nperformance target: {}\n",
+        local_status_text(receipt.status),
+        receipt.source.head_sha,
+        target(receipt.correctness_target.as_ref()),
+        target(receipt.performance_target.as_ref()),
+    );
+    if let Some(spec) = receipt.spec_coverage.as_ref() {
+        output.push_str(&format!(
+            "specs: {} source(s), {} requirement(s), {} selected\n",
+            spec.sources.len(),
+            spec.summary.total_requirements,
+            spec.summary.selected_for_execution,
+        ));
+    }
+    if !receipt.limitations.is_empty() {
+        output.push_str("limitations:\n");
+        for limitation in &receipt.limitations {
+            output.push_str(&format!("- {limitation}\n"));
+        }
+    }
+    if receipt.status == LocalCheckStatus::Ready {
+        output.push_str("next: rerun this command without --preflight to execute verification\n");
+    }
+    output
+}
+
+fn render_human_check(receipt: &LocalCheckReceipt) -> String {
     let verdict = serde_json::to_value(receipt.verdict)
         .ok()
         .and_then(|value| value.as_str().map(ToOwned::to_owned))
@@ -413,11 +492,39 @@ fn render_human_check(receipt: &LocalCheckReceipt) -> String {
     let mut output = format!(
         "verdict: {verdict}\nhead: {}\nreview: {}\ncorrectness: {}\nperformance: {}\noptimization: {}\n",
         receipt.source.head_sha,
-        status(receipt.stages.review.status),
-        status(receipt.stages.correctness.status),
-        status(receipt.stages.performance.status),
-        status(receipt.stages.optimization.status),
+        local_status_text(receipt.stages.review.status),
+        local_status_text(receipt.stages.correctness.status),
+        local_status_text(receipt.stages.performance.status),
+        local_status_text(receipt.stages.optimization.status),
     );
+    render_review_findings(&mut output, &receipt.stages.review.evidence);
+    if let Some(spec) = receipt.spec_coverage.as_ref() {
+        let percent = |value: Option<u8>| {
+            value
+                .map(|number| format!("{number}%"))
+                .unwrap_or_else(|| "n/a".into())
+        };
+        output.push_str(&format!(
+            "specs: {} source(s), {} requirement(s)\nspec review input: {}/{} ({})\nspec executable evidence: {}/{} ({})\nspec verified: {}/{} ({})\n",
+            spec.sources.len(),
+            spec.summary.total_requirements,
+            spec.summary.review_input_requirements,
+            spec.summary.total_requirements,
+            percent(spec.summary.review_input_coverage_percent),
+            spec.summary.verified + spec.summary.contradicted,
+            spec.summary.total_requirements,
+            percent(spec.summary.executable_evidence_coverage_percent),
+            spec.summary.verified,
+            spec.summary.total_requirements,
+            percent(spec.summary.verified_coverage_percent),
+        ));
+        if !spec.limitations.is_empty() {
+            output.push_str("spec limitations:\n");
+            for limitation in spec.limitations.iter().take(8) {
+                output.push_str(&format!("- {limitation}\n"));
+            }
+        }
+    }
     if let Some(command) = receipt
         .stages
         .optimization
@@ -434,6 +541,76 @@ fn render_human_check(receipt: &LocalCheckReceipt) -> String {
         }
     }
     output
+}
+
+fn local_status_text(status: LocalCheckStatus) -> String {
+    serde_json::to_value(status)
+        .ok()
+        .and_then(|value| value.as_str().map(ToOwned::to_owned))
+        .unwrap_or_else(|| "unknown".into())
+}
+
+fn render_review_findings(output: &mut String, evidence: &serde_json::Value) {
+    let Some(findings) = evidence
+        .get("findings")
+        .and_then(serde_json::Value::as_array)
+    else {
+        return;
+    };
+    let mut findings = findings.iter().collect::<Vec<_>>();
+    findings.sort_by_key(|finding| {
+        match finding.get("severity").and_then(serde_json::Value::as_str) {
+            Some("critical") => 0,
+            Some("high") => 1,
+            Some("medium") => 2,
+            Some("low") => 3,
+            _ => 4,
+        }
+    });
+    if findings.is_empty() {
+        return;
+    }
+    output.push_str("review findings:\n");
+    for finding in findings.into_iter().take(3) {
+        let severity = finding
+            .get("severity")
+            .and_then(serde_json::Value::as_str)
+            .map(|value| terminal_text(value, 16))
+            .unwrap_or_else(|| "unknown".into());
+        let title = finding
+            .get("title")
+            .and_then(serde_json::Value::as_str)
+            .map(|value| terminal_text(value, 180))
+            .unwrap_or_else(|| "Untitled finding".into());
+        let location = finding
+            .get("filePath")
+            .and_then(serde_json::Value::as_str)
+            .map(|path| {
+                let path = terminal_text(path, 180);
+                finding
+                    .get("line")
+                    .and_then(serde_json::Value::as_u64)
+                    .map(|line| format!(" ({path}:{line})"))
+                    .unwrap_or_else(|| format!(" ({path})"))
+            })
+            .unwrap_or_default();
+        output.push_str(&format!("- {severity}: {title}{location}\n"));
+    }
+}
+
+fn terminal_text(value: &str, max_chars: usize) -> String {
+    value
+        .chars()
+        .filter_map(|character| match character {
+            '\n' | '\r' | '\t' => Some(' '),
+            value if value.is_control() => None,
+            value => Some(value),
+        })
+        .take(max_chars)
+        .collect::<String>()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 fn render_human_receipt(receipt: &TrexPreviewReceipt) -> String {
@@ -566,6 +743,7 @@ mod tests {
                     limitations: vec!["Candidate edits remain external.".into()],
                 },
             },
+            spec_coverage: None,
             verdict,
             limitations: vec!["Candidate edits remain external.".into()],
         }
@@ -647,6 +825,13 @@ mod tests {
                 "main...HEAD".into(),
                 "--task".into(),
                 "Reduce parser latency without changing output".into(),
+                "--preflight".into(),
+                "--spec".into(),
+                "docs/parser.md".into(),
+                "--spec".into(),
+                "docs/architecture.md".into(),
+                "--requirement".into(),
+                "parser-output-stable".into(),
                 "--test-adapter".into(),
                 "node-test".into(),
                 "--test-target".into(),
@@ -667,7 +852,19 @@ mod tests {
         assert_eq!(arguments.repo_path, Path::new("/tmp/widget"));
         assert_eq!(arguments.change, "main...HEAD");
         assert_eq!(arguments.review_agent, "claude");
+        assert_eq!(
+            arguments.spec_paths,
+            vec![
+                PathBuf::from("docs/parser.md"),
+                PathBuf::from("docs/architecture.md")
+            ]
+        );
+        assert_eq!(
+            arguments.selected_requirement_ids,
+            vec!["parser-output-stable"]
+        );
         assert_eq!(arguments.samples, 5);
+        assert!(arguments.preflight);
         assert_eq!(arguments.output, OutputMode::Json);
         assert_eq!(
             arguments
@@ -703,6 +900,19 @@ mod tests {
                 "https://github.com/acme/widget/pull/1".into(),
                 "--task".into(),
                 "Review this".into(),
+            ],
+            cwd,
+        )
+        .is_err());
+        assert!(parse_arguments(
+            [
+                "check".into(),
+                "--range".into(),
+                "main...HEAD".into(),
+                "--task".into(),
+                "Review this".into(),
+                "--requirement".into(),
+                "missing-spec".into(),
             ],
             cwd,
         )
@@ -754,5 +964,74 @@ mod tests {
         let payload = serde_json::to_value(&passed).expect("receipt JSON");
         assert_eq!(payload["schema_version"], "codevetter.local-check/v1");
         assert_eq!(payload["stages"]["correctness"]["status"], "passed");
+        assert!(payload.get("spec_coverage").is_none());
+
+        let mut spec_passed = passed.clone();
+        spec_passed.spec_coverage = Some(
+            serde_json::from_value(serde_json::json!({
+                "schema_version": "codevetter.spec-coverage/v1",
+                "head_sha": "b".repeat(40),
+                "sources": [{"path": "docs/product.md", "sha256": format!("sha256:{}", "c".repeat(64)), "bytes": 42}],
+                "requirements": [],
+                "summary": {
+                    "total_requirements": 5,
+                    "review_input_requirements": 5,
+                    "selected_for_execution": 2,
+                    "verified": 2,
+                    "contradicted": 0,
+                    "review_only": 3,
+                    "unverified": 0,
+                    "review_input_coverage_percent": 100,
+                    "executable_evidence_coverage_percent": 40,
+                    "verified_coverage_percent": 40
+                },
+                "limitations": []
+            }))
+            .expect("spec coverage"),
+        );
+        let spec_output = render_human_check(&spec_passed);
+        assert!(spec_output.contains("spec review input: 5/5 (100%)"));
+        assert!(spec_output.contains("spec executable evidence: 2/5 (40%)"));
+        assert!(spec_output.contains("spec verified: 2/5 (40%)"));
+
+        let mut findings = passed.clone();
+        findings.stages.review.evidence = serde_json::json!({
+            "findings": [
+                {"severity": "low", "title": "Fourth finding", "filePath": "src/four.ts", "line": 4},
+                {"severity": "high", "title": "Unsafe\nterminal\u{1b}[31m title", "filePath": "src/high.ts", "line": 9},
+                {"severity": "critical", "title": "Critical finding", "filePath": "src/critical.ts", "line": 2},
+                {"severity": "medium", "title": "Medium finding", "filePath": "src/medium.ts"}
+            ]
+        });
+        let findings_output = render_human_check(&findings);
+        assert!(findings_output.contains("review findings:"));
+        assert!(findings_output.contains("- critical: Critical finding (src/critical.ts:2)"));
+        assert!(findings_output.contains("- high: Unsafe terminal[31m title (src/high.ts:9)"));
+        assert!(findings_output.contains("- medium: Medium finding (src/medium.ts)"));
+        assert!(!findings_output.contains("Fourth finding"));
+
+        let preflight = LocalCheckPreflightReceipt {
+            schema_version: "codevetter.local-check-preflight/v1".into(),
+            ran_at: "2026-08-29T00:00:00Z".into(),
+            repo_path: passed.repo_path.clone(),
+            task: passed.task.clone(),
+            source: passed.source.clone(),
+            spec_coverage: None,
+            correctness_target: Some(LocalCheckTarget {
+                adapter: "vitest".into(),
+                target: "test/parser.test.ts".into(),
+                name: None,
+                source: "discovered:fixture".into(),
+            }),
+            performance_target: None,
+            status: LocalCheckStatus::Ready,
+            limitations: vec!["No dedicated performance workload matched".into()],
+        };
+        let preflight_output = render_human_preflight(&preflight);
+        assert_eq!(preflight_exit_code(preflight.status), 0);
+        assert!(preflight_output.contains("preflight: ready"));
+        assert!(preflight_output.contains("correctness target: vitest test/parser.test.ts"));
+        assert!(preflight_output.contains("performance target: unavailable"));
+        assert!(preflight_output.contains("rerun this command without --preflight"));
     }
 }

--- a/apps/desktop/src-tauri/src/commands/local_check.rs
+++ b/apps/desktop/src-tauri/src/commands/local_check.rs
@@ -18,6 +18,10 @@ use super::evidence_scope::{
     EvidenceScopeKind, EvidenceScopePlan,
 };
 use super::review::run_cli_review_core;
+use super::spec_coverage::{
+    compose_spec_coverage, load_spec_packet, validate_selected_requirements, SpecCoverageReceipt,
+    SpecEvidenceReference, SpecExecutionOutcome,
+};
 use super::trex_preview::{resolve_scope_change, TrexSourceReceipt};
 
 const MAX_RUNTIME_OUTPUT_BYTES: usize = 512 * 1024;
@@ -77,8 +81,31 @@ pub struct LocalCheckReceipt {
     pub task: String,
     pub source: TrexSourceReceipt,
     pub stages: LocalCheckStages,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub spec_coverage: Option<SpecCoverageReceipt>,
     pub verdict: LocalCheckVerdict,
     pub limitations: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LocalCheckPreflightReceipt {
+    pub schema_version: String,
+    pub ran_at: String,
+    pub repo_path: String,
+    pub task: String,
+    pub source: TrexSourceReceipt,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub spec_coverage: Option<SpecCoverageReceipt>,
+    pub correctness_target: Option<LocalCheckTarget>,
+    pub performance_target: Option<LocalCheckTarget>,
+    pub status: LocalCheckStatus,
+    pub limitations: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LocalCheckProgress {
+    pub stage: &'static str,
+    pub state: &'static str,
 }
 
 #[derive(Debug, Clone)]
@@ -86,6 +113,8 @@ pub struct LocalCheckInput {
     pub repo_path: PathBuf,
     pub change: String,
     pub task: String,
+    pub spec_paths: Vec<PathBuf>,
+    pub selected_requirement_ids: Vec<String>,
     pub review_agent: String,
     pub test_target: Option<LocalCheckTarget>,
     pub performance_target: Option<LocalCheckTarget>,
@@ -96,30 +125,47 @@ pub struct LocalCheckInput {
 }
 
 pub async fn run_local_check(input: LocalCheckInput) -> Result<LocalCheckReceipt, String> {
-    validate_input(&input)?;
-    let repo_path = canonical_clean_repository(&input.repo_path)?;
-    let repo_text = repo_path.to_string_lossy().into_owned();
-    let source = resolve_scope_change(&repo_text, &input.change).await?;
-    require_checked_out_head(&repo_path, &source.head_sha)?;
+    run_local_check_with_progress(input, |_| {}).await
+}
+
+pub async fn run_local_check_with_progress<F>(
+    input: LocalCheckInput,
+    mut on_progress: F,
+) -> Result<LocalCheckReceipt, String>
+where
+    F: FnMut(LocalCheckProgress),
+{
+    on_progress(LocalCheckProgress {
+        stage: "preflight",
+        state: "running",
+    });
+    let prepared = prepare_local_check(&input).await?;
+    on_progress(LocalCheckProgress {
+        stage: "preflight",
+        state: "completed",
+    });
+    let PreparedLocalCheck {
+        repo_path,
+        repo_text,
+        source,
+        spec_packet,
+        test_plan,
+        performance_plan,
+        correctness_target,
+        performance_target,
+        performance_selection_limitation,
+    } = prepared;
     let diff_range = format!("{}...{}", source.base_sha, source.head_sha);
+    let review_task = compose_review_task(&input.task, spec_packet.as_ref());
     let app_data_dir = default_app_data_dir()?;
     let connection =
         db::init_db(app_data_dir).map_err(|error| format!("open CodeVetter database: {error}"))?;
     let db = DbState(std::sync::Arc::new(std::sync::Mutex::new(connection)));
 
-    let test_plan = discover_plan(&repo_text, &input.change, EvidenceScopeConsumer::Testing).await;
-    let performance_plan = discover_plan(
-        &repo_text,
-        &input.change,
-        EvidenceScopeConsumer::Performance,
-    )
-    .await;
-    let correctness_target = select_target(input.test_target.clone(), test_plan.as_ref().ok());
-    let performance_target = select_target(
-        input.performance_target.clone(),
-        performance_plan.as_ref().ok(),
-    );
-
+    on_progress(LocalCheckProgress {
+        stage: "correctness",
+        state: "running",
+    });
     let correctness = run_runtime_stage(
         &repo_path,
         "run",
@@ -131,6 +177,7 @@ pub async fn run_local_check(input: LocalCheckInput) -> Result<LocalCheckReceipt
         test_plan.err(),
     )
     .await;
+    on_progress(progress_for_stage("correctness", &correctness));
     let baseline = input
         .baseline_repo_path
         .as_ref()
@@ -141,6 +188,14 @@ pub async fn run_local_check(input: LocalCheckInput) -> Result<LocalCheckReceipt
     } else {
         "diagnose-performance"
     };
+    on_progress(LocalCheckProgress {
+        stage: "performance",
+        state: if performance_target.is_some() {
+            "running"
+        } else {
+            "skipped"
+        },
+    });
     let performance = run_runtime_stage(
         &repo_path,
         performance_operation,
@@ -149,22 +204,28 @@ pub async fn run_local_check(input: LocalCheckInput) -> Result<LocalCheckReceipt
         input.warmups,
         input.timeout_ms,
         baseline.as_deref(),
-        performance_plan.err(),
+        performance_plan.err().or(performance_selection_limitation),
     )
     .await;
+    on_progress(progress_for_stage("performance", &performance));
     let review_runtime_context = vec![
         runtime_stage_review_context("correctness", &correctness),
         runtime_stage_review_context("performance", &performance),
     ];
+    on_progress(LocalCheckProgress {
+        stage: "review",
+        state: "running",
+    });
     let review = run_review_stage(
         db,
         &repo_text,
         &diff_range,
-        &input.task,
+        &review_task,
         &input.review_agent,
         review_runtime_context,
     )
     .await;
+    on_progress(progress_for_stage("review", &review));
     let optimization = optimization_stage(
         &repo_path,
         &source.base_sha,
@@ -177,6 +238,8 @@ pub async fn run_local_check(input: LocalCheckInput) -> Result<LocalCheckReceipt
         input.samples,
         input.warmups,
         input.timeout_ms,
+        &input.spec_paths,
+        &input.selected_requirement_ids,
     );
     let stages = LocalCheckStages {
         review,
@@ -184,9 +247,32 @@ pub async fn run_local_check(input: LocalCheckInput) -> Result<LocalCheckReceipt
         performance,
         optimization,
     };
-    let verdict = aggregate_verdict(&stages);
+    let spec_coverage = spec_packet.map(|packet| {
+        let review_completed = matches!(
+            stages.review.status,
+            LocalCheckStatus::Completed | LocalCheckStatus::NeedsAttention
+        );
+        let execution = match stages.correctness.status {
+            LocalCheckStatus::Passed => SpecExecutionOutcome::Passed,
+            LocalCheckStatus::Failed => SpecExecutionOutcome::Failed,
+            _ => SpecExecutionOutcome::Unavailable,
+        };
+        compose_spec_coverage(
+            packet,
+            &input.selected_requirement_ids,
+            &source.head_sha,
+            review_completed,
+            execution,
+            correctness_spec_evidence(&stages.correctness),
+        )
+    });
+    let verdict = apply_spec_confidence(aggregate_verdict(&stages), spec_coverage.as_ref());
     let limitations = collect_limitations(&stages);
 
+    on_progress(LocalCheckProgress {
+        stage: "done",
+        state: verdict_name(verdict),
+    });
     Ok(LocalCheckReceipt {
         schema_version: "codevetter.local-check/v1".into(),
         run_id: format!("local-check-{}", uuid::Uuid::new_v4()),
@@ -195,9 +281,160 @@ pub async fn run_local_check(input: LocalCheckInput) -> Result<LocalCheckReceipt
         task: input.task,
         source,
         stages,
+        spec_coverage,
         verdict,
         limitations,
     })
+}
+
+pub async fn preflight_local_check(
+    input: &LocalCheckInput,
+) -> Result<LocalCheckPreflightReceipt, String> {
+    let prepared = prepare_local_check(input).await?;
+    let PreparedLocalCheck {
+        repo_text,
+        source,
+        spec_packet,
+        test_plan,
+        performance_plan,
+        correctness_target,
+        performance_target,
+        performance_selection_limitation,
+        ..
+    } = prepared;
+    let spec_coverage = spec_packet.map(|packet| {
+        compose_spec_coverage(
+            packet,
+            &input.selected_requirement_ids,
+            &source.head_sha,
+            false,
+            SpecExecutionOutcome::Unavailable,
+            None,
+        )
+    });
+    let mut limitations = Vec::new();
+    if correctness_target.is_none() {
+        limitations.push(
+            test_plan
+                .err()
+                .unwrap_or_else(|| "No defensible correctness target matched this change".into()),
+        );
+    }
+    if performance_target.is_none() {
+        limitations.push(
+            performance_plan
+                .err()
+                .or(performance_selection_limitation)
+                .unwrap_or_else(|| {
+                    "No dedicated performance workload matched; use explicit --perf-adapter and --perf-target to opt in"
+                        .into()
+                }),
+        );
+    }
+    if let Some(summary) = spec_coverage.as_ref().map(|coverage| &coverage.summary) {
+        if summary.total_requirements == 0 {
+            limitations.push(
+                "Supplied specs contain no explicit `### Requirement:` sections; review was not started"
+                    .into(),
+            );
+        } else if summary.selected_for_execution == 0 {
+            limitations.push(
+                "No extracted requirement is bound to correctness; select at least one --requirement before review"
+                    .into(),
+            );
+        }
+    }
+    let status = if correctness_target.is_some()
+        && spec_coverage.as_ref().is_none_or(|coverage| {
+            coverage.summary.total_requirements > 0 && coverage.summary.selected_for_execution > 0
+        }) {
+        LocalCheckStatus::Ready
+    } else {
+        LocalCheckStatus::NoConfidence
+    };
+
+    Ok(LocalCheckPreflightReceipt {
+        schema_version: "codevetter.local-check-preflight/v1".into(),
+        ran_at: chrono::Utc::now().to_rfc3339(),
+        repo_path: repo_text,
+        task: input.task.clone(),
+        source,
+        spec_coverage,
+        correctness_target,
+        performance_target,
+        status,
+        limitations,
+    })
+}
+
+#[derive(Debug)]
+struct PreparedLocalCheck {
+    repo_path: PathBuf,
+    repo_text: String,
+    source: TrexSourceReceipt,
+    spec_packet: Option<super::spec_coverage::SpecPacket>,
+    test_plan: Result<EvidenceScopePlan, String>,
+    performance_plan: Result<EvidenceScopePlan, String>,
+    correctness_target: Option<LocalCheckTarget>,
+    performance_target: Option<LocalCheckTarget>,
+    performance_selection_limitation: Option<String>,
+}
+
+async fn prepare_local_check(input: &LocalCheckInput) -> Result<PreparedLocalCheck, String> {
+    validate_input(input)?;
+    let repo_path = canonical_clean_repository(&input.repo_path)?;
+    if let Some(baseline) = input.baseline_repo_path.as_ref() {
+        canonical_clean_repository(baseline)?;
+    }
+    let repo_text = repo_path.to_string_lossy().into_owned();
+    let source = resolve_scope_change(&repo_text, &input.change).await?;
+    require_checked_out_head(&repo_path, &source.head_sha)?;
+    let spec_packet = load_spec_packet(&repo_path, &input.spec_paths)?;
+    validate_selected_requirements(spec_packet.as_ref(), &input.selected_requirement_ids)?;
+    let test_plan = discover_plan(&repo_text, &input.change, EvidenceScopeConsumer::Testing).await;
+    let performance_plan = discover_plan(
+        &repo_text,
+        &input.change,
+        EvidenceScopeConsumer::Performance,
+    )
+    .await;
+    let correctness_target = select_target(input.test_target.clone(), test_plan.as_ref().ok());
+    let (performance_target, performance_selection_limitation) = select_performance_target(
+        input.performance_target.clone(),
+        performance_plan.as_ref().ok(),
+    );
+
+    Ok(PreparedLocalCheck {
+        repo_path,
+        repo_text,
+        source,
+        spec_packet,
+        test_plan,
+        performance_plan,
+        correctness_target,
+        performance_target,
+        performance_selection_limitation,
+    })
+}
+
+fn apply_spec_confidence(
+    verdict: LocalCheckVerdict,
+    coverage: Option<&SpecCoverageReceipt>,
+) -> LocalCheckVerdict {
+    if verdict != LocalCheckVerdict::PassedWithLimits {
+        return verdict;
+    }
+    let Some(summary) = coverage.map(|value| &value.summary) else {
+        return verdict;
+    };
+    if summary.total_requirements == 0
+        || summary.selected_for_execution == 0
+        || summary.verified + summary.contradicted < summary.selected_for_execution
+    {
+        LocalCheckVerdict::NoConfidence
+    } else {
+        verdict
+    }
 }
 
 fn validate_input(input: &LocalCheckInput) -> Result<(), String> {
@@ -216,6 +453,9 @@ fn validate_input(input: &LocalCheckInput) -> Result<(), String> {
     if !(100..=120_000).contains(&input.timeout_ms) {
         return Err("Runtime timeout must be between 100 and 120,000 milliseconds".into());
     }
+    if input.spec_paths.is_empty() && !input.selected_requirement_ids.is_empty() {
+        return Err("Selected requirements require at least one spec path".into());
+    }
     if let Some(target) = input.test_target.as_ref() {
         validate_target(target, false)?;
     }
@@ -223,6 +463,35 @@ fn validate_input(input: &LocalCheckInput) -> Result<(), String> {
         validate_target(target, true)?;
     }
     Ok(())
+}
+
+fn correctness_spec_evidence(stage: &LocalCheckStage) -> Option<SpecEvidenceReference> {
+    if !matches!(
+        stage.status,
+        LocalCheckStatus::Passed | LocalCheckStatus::Failed
+    ) {
+        return None;
+    }
+    let target = stage.target.as_ref();
+    Some(SpecEvidenceReference {
+        stage: "correctness".into(),
+        status: match stage.status {
+            LocalCheckStatus::Passed => "passed",
+            LocalCheckStatus::Failed => "failed",
+            _ => unreachable!(),
+        }
+        .into(),
+        adapter: target.map(|value| value.adapter.clone()),
+        target: target.map(|value| value.target.clone()),
+        source: target.map(|value| value.source.clone()),
+    })
+}
+
+fn compose_review_task(task: &str, packet: Option<&super::spec_coverage::SpecPacket>) -> String {
+    packet
+        .filter(|packet| !packet.review_context.is_empty())
+        .map(|packet| format!("{task}\n\n{}", packet.review_context))
+        .unwrap_or_else(|| task.to_string())
 }
 
 fn validate_target(target: &LocalCheckTarget, performance: bool) -> Result<(), String> {
@@ -438,6 +707,47 @@ fn select_target(
     explicit.or_else(|| plan?.candidates.first().map(candidate_target))
 }
 
+fn select_performance_target(
+    explicit: Option<LocalCheckTarget>,
+    plan: Option<&EvidenceScopePlan>,
+) -> (Option<LocalCheckTarget>, Option<String>) {
+    if let Some(target) = explicit {
+        return (Some(target), None);
+    }
+    let Some(plan) = plan else {
+        return (None, None);
+    };
+    if let Some(candidate) = plan
+        .candidates
+        .iter()
+        .find(|candidate| dedicated_performance_candidate(candidate))
+    {
+        return (Some(candidate_target(candidate)), None);
+    }
+    (
+        None,
+        Some(
+            "Discovery found no dedicated performance workload; generic tests require explicit --perf-adapter and --perf-target selection"
+                .into(),
+        ),
+    )
+}
+
+fn dedicated_performance_candidate(candidate: &EvidenceScopeCandidate) -> bool {
+    if candidate.adapter == "go-bench" || candidate.name.is_some() {
+        return true;
+    }
+    candidate
+        .target
+        .split(|character: char| !character.is_ascii_alphanumeric())
+        .any(|token| {
+            matches!(
+                token.to_ascii_lowercase().as_str(),
+                "bench" | "benchmark" | "benchmarks" | "perf" | "performance" | "load"
+            )
+        })
+}
+
 fn candidate_target(candidate: &EvidenceScopeCandidate) -> LocalCheckTarget {
     LocalCheckTarget {
         adapter: candidate.adapter.clone(),
@@ -642,6 +952,8 @@ fn optimization_stage(
     samples: u8,
     warmups: u8,
     timeout_ms: u64,
+    spec_paths: &[PathBuf],
+    selected_requirement_ids: &[String],
 ) -> LocalCheckStage {
     let Some(target) = target else {
         return LocalCheckStage {
@@ -692,6 +1004,8 @@ fn optimization_stage(
         samples,
         warmups,
         timeout_ms,
+        spec_paths,
+        selected_requirement_ids,
     );
     LocalCheckStage {
         status: if matches!(performance.status, LocalCheckStatus::Passed | LocalCheckStatus::Completed) {
@@ -723,6 +1037,8 @@ fn render_candidate_command(
     samples: u8,
     warmups: u8,
     timeout_ms: u64,
+    spec_paths: &[PathBuf],
+    selected_requirement_ids: &[String],
 ) -> String {
     let correctness = correctness_target
         .map(|selected| {
@@ -744,12 +1060,22 @@ fn render_candidate_command(
         .as_ref()
         .map(|value| format!(" --perf-name {}", shell_token(value)))
         .unwrap_or_default();
+    let specs = spec_paths
+        .iter()
+        .map(|path| format!(" --spec {}", shell_token(&path.to_string_lossy())))
+        .collect::<String>();
+    let requirements = selected_requirement_ids
+        .iter()
+        .map(|id| format!(" --requirement {}", shell_token(id)))
+        .collect::<String>();
     format!(
-        "codevetter check --repo <candidate-worktree> --range {} --task {} --agent {}{} --perf-adapter {} --perf-target {}{} --baseline-repo {} --samples {} --warmups {} --timeout-ms {}",
+        "codevetter check --repo <candidate-worktree> --range {} --task {} --agent {}{}{}{} --perf-adapter {} --perf-target {}{} --baseline-repo {} --samples {} --warmups {} --timeout-ms {}",
         shell_token(&format!("{base_sha}...HEAD")),
         shell_token(task),
         shell_token(review_agent),
         correctness,
+        specs,
+        requirements,
         shell_token(&target.adapter),
         shell_token(&target.target),
         performance_name,
@@ -780,6 +1106,33 @@ fn no_confidence_stage(
         target,
         evidence: json!({"verdict": {"status": "no_confidence"}}),
         limitations: vec![limitation],
+    }
+}
+
+fn progress_for_stage(stage: &'static str, result: &LocalCheckStage) -> LocalCheckProgress {
+    LocalCheckProgress {
+        stage,
+        state: status_name(result.status),
+    }
+}
+
+fn status_name(status: LocalCheckStatus) -> &'static str {
+    match status {
+        LocalCheckStatus::Passed => "passed",
+        LocalCheckStatus::Completed => "completed",
+        LocalCheckStatus::Ready => "ready",
+        LocalCheckStatus::NeedsAttention => "needs_attention",
+        LocalCheckStatus::Failed => "failed",
+        LocalCheckStatus::NoConfidence => "no_confidence",
+    }
+}
+
+fn verdict_name(verdict: LocalCheckVerdict) -> &'static str {
+    match verdict {
+        LocalCheckVerdict::PassedWithLimits => "passed_with_limits",
+        LocalCheckVerdict::NeedsAttention => "needs_attention",
+        LocalCheckVerdict::Failed => "failed",
+        LocalCheckVerdict::NoConfidence => "no_confidence",
     }
 }
 
@@ -821,16 +1174,16 @@ fn default_app_data_dir() -> Result<PathBuf, String> {
     #[cfg(target_os = "macos")]
     {
         let home = std::env::var_os("HOME").ok_or_else(|| "HOME is unavailable".to_string())?;
-        return Ok(PathBuf::from(home)
+        Ok(PathBuf::from(home)
             .join("Library")
             .join("Application Support")
-            .join("com.codevetter.desktop"));
+            .join("com.codevetter.desktop"))
     }
     #[cfg(target_os = "windows")]
     {
         let app_data =
             std::env::var_os("APPDATA").ok_or_else(|| "APPDATA is unavailable".to_string())?;
-        return Ok(PathBuf::from(app_data).join("com.codevetter.desktop"));
+        Ok(PathBuf::from(app_data).join("com.codevetter.desktop"))
     }
     #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
     {
@@ -887,6 +1240,38 @@ mod tests {
             optimization: stage(LocalCheckStatus::NoConfidence),
         };
         assert_eq!(aggregate_verdict(&stages), LocalCheckVerdict::NoConfidence);
+    }
+
+    #[test]
+    fn review_only_spec_coverage_cannot_preserve_a_passing_verdict() {
+        let coverage: SpecCoverageReceipt = serde_json::from_value(json!({
+            "schema_version": "codevetter.spec-coverage/v1",
+            "head_sha": "a".repeat(40),
+            "sources": [],
+            "requirements": [],
+            "summary": {
+                "total_requirements": 2,
+                "review_input_requirements": 2,
+                "selected_for_execution": 0,
+                "verified": 0,
+                "contradicted": 0,
+                "review_only": 2,
+                "unverified": 0,
+                "review_input_coverage_percent": 100,
+                "executable_evidence_coverage_percent": 0,
+                "verified_coverage_percent": 0
+            },
+            "limitations": []
+        }))
+        .expect("coverage");
+        assert_eq!(
+            apply_spec_confidence(LocalCheckVerdict::PassedWithLimits, Some(&coverage)),
+            LocalCheckVerdict::NoConfidence
+        );
+        assert_eq!(
+            apply_spec_confidence(LocalCheckVerdict::Failed, Some(&coverage)),
+            LocalCheckVerdict::Failed
+        );
     }
 
     #[test]
@@ -951,12 +1336,93 @@ mod tests {
             3,
             1,
             30_000,
+            &[PathBuf::from("docs/parser.md")],
+            &["parser-output-stable".into()],
         );
         assert!(command.contains("--task 'Preserve parser output'"));
         assert!(command.contains("--agent codex"));
         assert!(command.contains("--test-target test/parser.test.mjs"));
         assert!(command.contains("--perf-target test/parser.performance.test.mjs"));
+        assert!(command.contains("--spec docs/parser.md"));
+        assert!(command.contains("--requirement parser-output-stable"));
         assert!(command.contains("--baseline-repo /tmp/baseline"));
+    }
+
+    #[test]
+    fn review_task_includes_cited_specs_without_calling_them_proof() {
+        let repo = tempfile::tempdir().expect("repo");
+        let docs = repo.path().join("docs");
+        std::fs::create_dir_all(&docs).expect("docs");
+        std::fs::write(
+            docs.join("product.md"),
+            "### Requirement: account-lockout\nLock after five failed attempts.\n",
+        )
+        .expect("spec");
+        let packet = load_spec_packet(repo.path(), &[PathBuf::from("docs/product.md")])
+            .expect("packet")
+            .expect("some packet");
+        let task = compose_review_task("Preserve authentication", Some(&packet));
+        assert!(task.starts_with("Preserve authentication"));
+        assert!(task.contains("[account-lockout] docs/product.md:1"));
+        assert!(task.contains("not executable proof"));
+    }
+
+    #[test]
+    fn automatic_performance_requires_a_dedicated_workload() {
+        let candidate = |target: &str, adapter: &str, name: Option<&str>| EvidenceScopeCandidate {
+            id: format!("scope-{target}"),
+            adapter: adapter.into(),
+            target: target.into(),
+            name: name.map(ToOwned::to_owned),
+            reason: "fixture".into(),
+            source_paths: Vec::new(),
+            confidence_milli: 900,
+            testing_supported: true,
+            performance_supported: true,
+        };
+        assert!(!dedicated_performance_candidate(&candidate(
+            "test/parser.test.ts",
+            "vitest",
+            None,
+        )));
+        assert!(dedicated_performance_candidate(&candidate(
+            "test/parser.performance.test.ts",
+            "vitest",
+            None,
+        )));
+        assert!(dedicated_performance_candidate(&candidate(
+            "benchmark_test.go",
+            "go-bench",
+            Some("BenchmarkParse"),
+        )));
+    }
+
+    #[test]
+    fn explicit_performance_target_bypasses_discovery_filter() {
+        let explicit = LocalCheckTarget {
+            adapter: "vitest".into(),
+            target: "test/parser.test.ts".into(),
+            name: None,
+            source: "explicit".into(),
+        };
+        let (selected, limitation) = select_performance_target(Some(explicit.clone()), None);
+        assert_eq!(selected, Some(explicit));
+        assert!(limitation.is_none());
+    }
+
+    #[test]
+    fn progress_names_are_stable_and_machine_bounded() {
+        assert_eq!(
+            progress_for_stage("review", &stage(LocalCheckStatus::NeedsAttention)),
+            LocalCheckProgress {
+                stage: "review",
+                state: "needs_attention",
+            }
+        );
+        assert_eq!(
+            verdict_name(LocalCheckVerdict::PassedWithLimits),
+            "passed_with_limits"
+        );
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/commands/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mod.rs
@@ -49,6 +49,7 @@ pub mod session_adapters;
 pub mod session_retention;
 pub mod sessions;
 pub mod setup;
+pub mod spec_coverage;
 pub mod structural_graph;
 pub mod synthetic_qa;
 pub mod taste;

--- a/apps/desktop/src-tauri/src/commands/spec_coverage.rs
+++ b/apps/desktop/src-tauri/src/commands/spec_coverage.rs
@@ -1,0 +1,627 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Component, Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use super::secret_policy::{is_sensitive_path, looks_like_secret};
+
+const MAX_SPEC_FILES: usize = 8;
+const MAX_SPEC_FILE_BYTES: u64 = 64 * 1024;
+const MAX_SPEC_TOTAL_BYTES: u64 = 256 * 1024;
+const MAX_REQUIREMENTS: usize = 128;
+const MAX_REQUIREMENT_BYTES: usize = 8 * 1024;
+const MAX_REVIEW_CONTEXT_BYTES: usize = 16 * 1024;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SpecSource {
+    pub path: String,
+    pub sha256: String,
+    pub bytes: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExtractedRequirement {
+    pub id: String,
+    pub title: String,
+    pub text: String,
+    pub source_path: String,
+    pub start_line: usize,
+    pub end_line: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct SpecPacket {
+    pub sources: Vec<SpecSource>,
+    pub requirements: Vec<ExtractedRequirement>,
+    pub review_context: String,
+    pub review_requirement_ids: BTreeSet<String>,
+    pub limitations: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SpecExecutionOutcome {
+    Passed,
+    Failed,
+    Unavailable,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SpecEvidenceReference {
+    pub stage: String,
+    pub status: String,
+    pub adapter: Option<String>,
+    pub target: Option<String>,
+    pub source: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RequirementStatus {
+    Verified,
+    Contradicted,
+    ReviewOnly,
+    Unverified,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RequirementCoverage {
+    #[serde(flatten)]
+    pub requirement: ExtractedRequirement,
+    pub selected_for_execution: bool,
+    pub supplied_to_review: bool,
+    pub status: RequirementStatus,
+    pub evidence: Option<SpecEvidenceReference>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SpecCoverageSummary {
+    pub total_requirements: usize,
+    pub review_input_requirements: usize,
+    pub selected_for_execution: usize,
+    pub verified: usize,
+    pub contradicted: usize,
+    pub review_only: usize,
+    pub unverified: usize,
+    pub review_input_coverage_percent: Option<u8>,
+    pub executable_evidence_coverage_percent: Option<u8>,
+    pub verified_coverage_percent: Option<u8>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SpecCoverageReceipt {
+    pub schema_version: String,
+    pub head_sha: String,
+    pub sources: Vec<SpecSource>,
+    pub requirements: Vec<RequirementCoverage>,
+    pub summary: SpecCoverageSummary,
+    pub limitations: Vec<String>,
+}
+
+pub fn load_spec_packet(repo_path: &Path, paths: &[PathBuf]) -> Result<Option<SpecPacket>, String> {
+    if paths.is_empty() {
+        return Ok(None);
+    }
+    if paths.len() > MAX_SPEC_FILES {
+        return Err(format!(
+            "At most {MAX_SPEC_FILES} spec files may be checked at once"
+        ));
+    }
+
+    let repo = repo_path
+        .canonicalize()
+        .map_err(|error| format!("Could not resolve repository for spec input: {error}"))?;
+    let mut seen_paths = BTreeSet::new();
+    let mut seen_requirements = BTreeMap::<String, String>::new();
+    let mut sources = Vec::new();
+    let mut requirements = Vec::new();
+    let mut total_bytes = 0_u64;
+
+    for relative in paths {
+        let logical_path = validate_relative_markdown_path(relative)?;
+        if !seen_paths.insert(logical_path.clone()) {
+            return Err(format!(
+                "Spec path `{logical_path}` was supplied more than once"
+            ));
+        }
+        let candidate = repo.join(relative);
+        let canonical = candidate
+            .canonicalize()
+            .map_err(|error| format!("Spec `{logical_path}` is unavailable: {error}"))?;
+        if !canonical.starts_with(&repo) || !canonical.is_file() {
+            return Err(format!(
+                "Spec `{logical_path}` must be a contained repository file"
+            ));
+        }
+        let bytes = canonical
+            .metadata()
+            .map_err(|error| format!("Could not inspect spec `{logical_path}`: {error}"))?
+            .len();
+        if bytes > MAX_SPEC_FILE_BYTES {
+            return Err(format!(
+                "Spec `{logical_path}` exceeds the 64 KiB file limit"
+            ));
+        }
+        total_bytes = total_bytes.saturating_add(bytes);
+        if total_bytes > MAX_SPEC_TOTAL_BYTES {
+            return Err("Combined spec input exceeds the 256 KiB limit".into());
+        }
+        let source_bytes = std::fs::read(&canonical)
+            .map_err(|error| format!("Could not read spec `{logical_path}`: {error}"))?;
+        let source = std::str::from_utf8(&source_bytes)
+            .map_err(|_| format!("Spec `{logical_path}` must be UTF-8 Markdown"))?;
+        if looks_like_secret(source) {
+            return Err(format!(
+                "Spec `{logical_path}` contains secret-like material"
+            ));
+        }
+        let extracted = extract_requirements(&logical_path, source)?;
+        for requirement in &extracted {
+            if let Some(existing) = seen_requirements.insert(
+                requirement.id.clone(),
+                format!("{}:{}", requirement.source_path, requirement.start_line),
+            ) {
+                return Err(format!(
+                    "Requirement id `{}` is duplicated at {} and {}:{}",
+                    requirement.id, existing, requirement.source_path, requirement.start_line
+                ));
+            }
+        }
+        requirements.extend(extracted);
+        if requirements.len() > MAX_REQUIREMENTS {
+            return Err(format!(
+                "Spec input exceeds the {MAX_REQUIREMENTS} requirement limit"
+            ));
+        }
+        sources.push(SpecSource {
+            path: logical_path,
+            sha256: format!("sha256:{:x}", Sha256::digest(&source_bytes)),
+            bytes: source_bytes.len(),
+        });
+    }
+
+    let (review_context, review_requirement_ids, mut limitations) =
+        build_review_context(&requirements);
+    if requirements.is_empty() {
+        limitations.push(
+            "No explicit `Requirement:` sections were found; CodeVetter did not invent requirements"
+                .into(),
+        );
+    }
+    Ok(Some(SpecPacket {
+        sources,
+        requirements,
+        review_context,
+        review_requirement_ids,
+        limitations,
+    }))
+}
+
+pub fn validate_selected_requirements(
+    packet: Option<&SpecPacket>,
+    selected_ids: &[String],
+) -> Result<(), String> {
+    if selected_ids.is_empty() {
+        return Ok(());
+    }
+    let packet = packet.ok_or_else(|| "--requirement requires at least one --spec".to_string())?;
+    let known = packet
+        .requirements
+        .iter()
+        .map(|requirement| requirement.id.as_str())
+        .collect::<BTreeSet<_>>();
+    let mut seen = BTreeSet::new();
+    for id in selected_ids {
+        if !seen.insert(id.as_str()) {
+            return Err(format!("Requirement `{id}` was selected more than once"));
+        }
+        if !known.contains(id.as_str()) {
+            return Err(format!(
+                "Selected requirement `{id}` was not found in the supplied specs"
+            ));
+        }
+    }
+    Ok(())
+}
+
+pub fn compose_spec_coverage(
+    packet: SpecPacket,
+    selected_ids: &[String],
+    head_sha: &str,
+    review_completed: bool,
+    execution: SpecExecutionOutcome,
+    evidence: Option<SpecEvidenceReference>,
+) -> SpecCoverageReceipt {
+    let selected = selected_ids
+        .iter()
+        .map(String::as_str)
+        .collect::<BTreeSet<_>>();
+    let requirements = packet
+        .requirements
+        .into_iter()
+        .map(|requirement| {
+            let selected_for_execution = selected.contains(requirement.id.as_str());
+            let supplied_to_review = packet.review_requirement_ids.contains(&requirement.id);
+            let (status, requirement_evidence) = if selected_for_execution {
+                match execution {
+                    SpecExecutionOutcome::Passed => (RequirementStatus::Verified, evidence.clone()),
+                    SpecExecutionOutcome::Failed => {
+                        (RequirementStatus::Contradicted, evidence.clone())
+                    }
+                    SpecExecutionOutcome::Unavailable if review_completed && supplied_to_review => {
+                        (RequirementStatus::ReviewOnly, None)
+                    }
+                    SpecExecutionOutcome::Unavailable => (RequirementStatus::Unverified, None),
+                }
+            } else if review_completed && supplied_to_review {
+                (RequirementStatus::ReviewOnly, None)
+            } else {
+                (RequirementStatus::Unverified, None)
+            };
+            RequirementCoverage {
+                requirement,
+                selected_for_execution,
+                supplied_to_review,
+                status,
+                evidence: requirement_evidence,
+            }
+        })
+        .collect::<Vec<_>>();
+    let total = requirements.len();
+    let count = |status| {
+        requirements
+            .iter()
+            .filter(|item| item.status == status)
+            .count()
+    };
+    let verified = count(RequirementStatus::Verified);
+    let contradicted = count(RequirementStatus::Contradicted);
+    let review_only = count(RequirementStatus::ReviewOnly);
+    let unverified = count(RequirementStatus::Unverified);
+    let review_input = requirements
+        .iter()
+        .filter(|item| item.supplied_to_review)
+        .count();
+    let selected_count = requirements
+        .iter()
+        .filter(|item| item.selected_for_execution)
+        .count();
+    let mut limitations = packet.limitations;
+    limitations.push(
+        "Review-input coverage records criteria supplied to a model; it is not executable proof"
+            .into(),
+    );
+    if selected_count == 0 && total > 0 {
+        limitations.push(
+            "No requirement was explicitly bound to the correctness target; executable coverage is zero"
+                .into(),
+        );
+    }
+    if unverified + review_only > 0 {
+        limitations.push(format!(
+            "{} requirement(s) remain without executable proof",
+            unverified + review_only
+        ));
+    }
+
+    SpecCoverageReceipt {
+        schema_version: "codevetter.spec-coverage/v1".into(),
+        head_sha: head_sha.into(),
+        sources: packet.sources,
+        summary: SpecCoverageSummary {
+            total_requirements: total,
+            review_input_requirements: review_input,
+            selected_for_execution: selected_count,
+            verified,
+            contradicted,
+            review_only,
+            unverified,
+            review_input_coverage_percent: percentage(review_input, total),
+            executable_evidence_coverage_percent: percentage(verified + contradicted, total),
+            verified_coverage_percent: percentage(verified, total),
+        },
+        requirements,
+        limitations,
+    }
+}
+
+fn validate_relative_markdown_path(path: &Path) -> Result<String, String> {
+    if path.as_os_str().is_empty()
+        || path.is_absolute()
+        || path
+            .components()
+            .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        return Err("Spec paths must be contained repository-relative paths".into());
+    }
+    let logical = path
+        .to_str()
+        .ok_or_else(|| "Spec paths must be valid UTF-8".to_string())?
+        .replace('\\', "/");
+    if is_sensitive_path(&logical) {
+        return Err(format!("Spec `{logical}` uses a sensitive path"));
+    }
+    let extension = path
+        .extension()
+        .and_then(|value| value.to_str())
+        .map(str::to_ascii_lowercase);
+    if !matches!(extension.as_deref(), Some("md" | "markdown")) {
+        return Err(format!("Spec `{logical}` must be a Markdown file"));
+    }
+    Ok(logical)
+}
+
+fn extract_requirements(path: &str, source: &str) -> Result<Vec<ExtractedRequirement>, String> {
+    let normalized = source.replace("\r\n", "\n").replace('\r', "\n");
+    let lines = normalized.lines().collect::<Vec<_>>();
+    let mut starts = Vec::new();
+    for (index, line) in lines.iter().enumerate() {
+        if let Some(title) = requirement_heading(line) {
+            let id = slugify(title);
+            if id.is_empty() {
+                return Err(format!(
+                    "Requirement at {path}:{} has no usable id",
+                    index + 1
+                ));
+            }
+            starts.push((index, id, title.to_string()));
+        }
+    }
+    let mut requirements = Vec::new();
+    for (position, (start, id, title)) in starts.iter().enumerate() {
+        let end = starts
+            .get(position + 1)
+            .map(|(next, _, _)| *next)
+            .unwrap_or(lines.len());
+        let text = lines[*start + 1..end]
+            .iter()
+            .map(|line| line.trim_end())
+            .collect::<Vec<_>>()
+            .join("\n")
+            .trim()
+            .to_string();
+        if text.len() > MAX_REQUIREMENT_BYTES {
+            return Err(format!(
+                "Requirement `{id}` at {path}:{} exceeds 8 KiB",
+                start + 1
+            ));
+        }
+        requirements.push(ExtractedRequirement {
+            id: id.clone(),
+            title: title.clone(),
+            text,
+            source_path: path.into(),
+            start_line: start + 1,
+            end_line: end.max(start + 1),
+        });
+    }
+    Ok(requirements)
+}
+
+fn requirement_heading(line: &str) -> Option<&str> {
+    let trimmed = line.trim_start();
+    let hashes = trimmed
+        .chars()
+        .take_while(|character| *character == '#')
+        .count();
+    if !(1..=6).contains(&hashes) || trimmed.as_bytes().get(hashes) != Some(&b' ') {
+        return None;
+    }
+    trimmed[hashes + 1..]
+        .strip_prefix("Requirement:")
+        .map(str::trim)
+        .filter(|title| !title.is_empty())
+}
+
+fn slugify(value: &str) -> String {
+    value
+        .chars()
+        .flat_map(char::to_lowercase)
+        .fold(
+            (String::new(), false),
+            |(mut output, separator), character| {
+                if character.is_ascii_alphanumeric() || matches!(character, '.' | '_') {
+                    if separator && !output.is_empty() {
+                        output.push('-');
+                    }
+                    output.push(character);
+                    (output, false)
+                } else {
+                    (output, true)
+                }
+            },
+        )
+        .0
+        .trim_matches('-')
+        .to_string()
+}
+
+fn build_review_context(
+    requirements: &[ExtractedRequirement],
+) -> (String, BTreeSet<String>, Vec<String>) {
+    let mut context = String::from(
+        "Documented requirements follow. Treat them as review criteria and cited hypotheses, not executable proof. Cite requirement ids in related findings.\n",
+    );
+    let mut included = BTreeSet::new();
+    let mut limitations = Vec::new();
+    for requirement in requirements {
+        let block = format!(
+            "\n[{}] {}:{}\n{}\n",
+            requirement.id, requirement.source_path, requirement.start_line, requirement.text
+        );
+        if context.len().saturating_add(block.len()) > MAX_REVIEW_CONTEXT_BYTES {
+            limitations.push(format!(
+                "Review context stopped after {} of {} requirements at the 16 KiB bound",
+                included.len(),
+                requirements.len()
+            ));
+            break;
+        }
+        context.push_str(&block);
+        included.insert(requirement.id.clone());
+    }
+    if included.is_empty() {
+        context.clear();
+    }
+    (context, included, limitations)
+}
+
+fn percentage(part: usize, total: usize) -> Option<u8> {
+    (total > 0).then(|| ((part * 100 + total / 2) / total) as u8)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_spec(root: &Path, relative: &str, content: &str) {
+        let path = root.join(relative);
+        std::fs::create_dir_all(path.parent().expect("parent")).expect("create parent");
+        std::fs::write(path, content).expect("write spec");
+    }
+
+    #[test]
+    fn extracts_explicit_requirements_with_stable_anchors() {
+        let repo = tempfile::tempdir().expect("repo");
+        write_spec(
+            repo.path(),
+            "docs/product.md",
+            "# Product\n\n### Requirement: Account Lockout\nUsers SHALL lock after five attempts.\n\n#### Scenario: failure\n- **WHEN** five attempts fail\n- **THEN** access is denied\n\n### Requirement: audit-log\nEvery denial is recorded.\n",
+        );
+        let packet = load_spec_packet(repo.path(), &[PathBuf::from("docs/product.md")])
+            .expect("packet")
+            .expect("some packet");
+        assert_eq!(packet.requirements.len(), 2);
+        assert_eq!(packet.requirements[0].id, "account-lockout");
+        assert_eq!(packet.requirements[0].start_line, 3);
+        assert_eq!(packet.requirements[0].end_line, 9);
+        assert_eq!(packet.requirements[1].id, "audit-log");
+        assert!(packet.sources[0].sha256.starts_with("sha256:"));
+        assert!(packet
+            .review_context
+            .contains("[account-lockout] docs/product.md:3"));
+    }
+
+    #[test]
+    fn rejects_unsafe_duplicate_and_secret_bearing_specs() {
+        let repo = tempfile::tempdir().expect("repo");
+        write_spec(repo.path(), "docs/a.md", "### Requirement: same\nOne.\n");
+        write_spec(repo.path(), "docs/b.md", "### Requirement: same\nTwo.\n");
+        assert!(load_spec_packet(repo.path(), &[PathBuf::from("../outside.md")]).is_err());
+        assert!(load_spec_packet(
+            repo.path(),
+            &[PathBuf::from("docs/a.md"), PathBuf::from("docs/b.md")]
+        )
+        .is_err());
+        write_spec(
+            repo.path(),
+            "docs/secret.md",
+            "### Requirement: secret\npassword=correct-horse-battery-staple\n",
+        );
+        assert!(load_spec_packet(repo.path(), &[PathBuf::from("docs/secret.md")]).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_symlink_escape_and_non_markdown_input() {
+        use std::os::unix::fs::symlink;
+
+        let repo = tempfile::tempdir().expect("repo");
+        let outside = tempfile::NamedTempFile::new().expect("outside");
+        let link = repo.path().join("escaped.md");
+        symlink(outside.path(), &link).expect("symlink");
+        assert!(load_spec_packet(repo.path(), &[PathBuf::from("escaped.md")]).is_err());
+        std::fs::write(
+            repo.path().join("spec.txt"),
+            "### Requirement: one\nText.\n",
+        )
+        .expect("text file");
+        assert!(load_spec_packet(repo.path(), &[PathBuf::from("spec.txt")]).is_err());
+    }
+
+    #[test]
+    fn selected_requirements_must_exist_and_be_unique() {
+        let repo = tempfile::tempdir().expect("repo");
+        write_spec(
+            repo.path(),
+            "spec.md",
+            "### Requirement: expected\nBehavior.\n",
+        );
+        let packet = load_spec_packet(repo.path(), &[PathBuf::from("spec.md")])
+            .expect("packet")
+            .expect("some packet");
+        assert!(validate_selected_requirements(Some(&packet), &["missing".into()]).is_err());
+        assert!(validate_selected_requirements(
+            Some(&packet),
+            &["expected".into(), "expected".into()]
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn coverage_only_verifies_explicitly_selected_requirements() {
+        let repo = tempfile::tempdir().expect("repo");
+        write_spec(
+            repo.path(),
+            "docs/product.md",
+            "### Requirement: one\nFirst.\n### Requirement: two\nSecond.\n",
+        );
+        let packet = load_spec_packet(repo.path(), &[PathBuf::from("docs/product.md")])
+            .expect("packet")
+            .expect("some packet");
+        let receipt = compose_spec_coverage(
+            packet,
+            &["one".into()],
+            &"a".repeat(40),
+            true,
+            SpecExecutionOutcome::Passed,
+            Some(SpecEvidenceReference {
+                stage: "correctness".into(),
+                status: "passed".into(),
+                adapter: Some("node-test".into()),
+                target: Some("tests/one.test.mjs".into()),
+                source: Some("explicit".into()),
+            }),
+        );
+        assert_eq!(receipt.requirements[0].status, RequirementStatus::Verified);
+        assert_eq!(
+            receipt.requirements[1].status,
+            RequirementStatus::ReviewOnly
+        );
+        assert_eq!(
+            receipt.summary.executable_evidence_coverage_percent,
+            Some(50)
+        );
+        assert_eq!(receipt.summary.verified_coverage_percent, Some(50));
+    }
+
+    #[test]
+    fn failed_bound_target_contradicts_without_claiming_success() {
+        let repo = tempfile::tempdir().expect("repo");
+        write_spec(
+            repo.path(),
+            "spec.md",
+            "### Requirement: expected\nBehavior.\n",
+        );
+        let packet = load_spec_packet(repo.path(), &[PathBuf::from("spec.md")])
+            .expect("packet")
+            .expect("some packet");
+        let receipt = compose_spec_coverage(
+            packet,
+            &["expected".into()],
+            &"b".repeat(40),
+            true,
+            SpecExecutionOutcome::Failed,
+            None,
+        );
+        assert_eq!(
+            receipt.requirements[0].status,
+            RequirementStatus::Contradicted
+        );
+        assert_eq!(
+            receipt.summary.executable_evidence_coverage_percent,
+            Some(100)
+        );
+        assert_eq!(receipt.summary.verified_coverage_percent, Some(0));
+    }
+}


### PR DESCRIPTION
## Summary
- bind Markdown requirements to review and executable evidence
- add no-execution preflight and human progress output
- qualify the packaged CLI contract

## Local qualification
- targeted Rust suites: 12 + 7 + 6 passed
- CLI release-contract tests: 6 passed
- packaged CLI qualification: 1.11.0, 12 help contracts
- repository code-health gates passed

Relates to #178 and #181.