### PR TITLE
refactor: remove shared AI gateway preset

### DIFF
--- a/apps/desktop/src-tauri/src/commands/business_rule_archaeology/synthesis_command.rs
+++ b/apps/desktop/src-tauri/src/commands/business_rule_archaeology/synthesis_command.rs
@@ -154,7 +154,6 @@ impl ArchaeologyProviderFactory for EnvironmentArchaeologyProviderFactory {
             ArchaeologyProviderKind::Local => None,
             ArchaeologyProviderKind::Hosted => {
                 let variable = match descriptor.provider_identity.as_str() {
-                    "free-ai" => "FREE_AI_API_KEY",
                     "openai" => "OPENAI_API_KEY",
                     "anthropic" => "ANTHROPIC_API_KEY",
                     "openrouter" => "OPENROUTER_API_KEY",

--- a/apps/desktop/src-tauri/src/commands/business_rule_archaeology/synthesis_runtime.rs
+++ b/apps/desktop/src-tauri/src/commands/business_rule_archaeology/synthesis_runtime.rs
@@ -554,10 +554,6 @@ pub(crate) fn resolve_trusted_provider_configuration(
             validate_provider_descriptor(&descriptor)?;
             descriptor
         }
-        "free-ai" => canonical_hosted_descriptor(
-            "free-ai",
-            "https://ai-gateway.sassmaker.com/v1/chat/completions",
-        ),
         "openai" => canonical_hosted_descriptor("openai", "https://api.openai.com/v1/responses"),
         "anthropic" => {
             canonical_hosted_descriptor("anthropic", "https://api.anthropic.com/v1/messages")
@@ -572,8 +568,7 @@ pub(crate) fn resolve_trusted_provider_configuration(
         return Err("Hosted archaeology synthesis cannot accept a local endpoint".into());
     }
 
-    let expected_cost = if user.provider_identity == "local" || user.provider_identity == "free-ai"
-    {
+    let expected_cost = if user.provider_identity == "local" {
         ArchaeologyCostClass::Free
     } else {
         ArchaeologyCostClass::Paid
@@ -2231,7 +2226,6 @@ fn validate_provider_descriptor(descriptor: &ArchaeologyProviderDescriptor) -> R
         }
         (ArchaeologyProviderKind::Hosted, ArchaeologyNetworkScope::Remote) => {
             let allowed = match descriptor.provider_identity.as_str() {
-                "free-ai" => "https://ai-gateway.sassmaker.com/v1/chat/completions",
                 "openai" => "https://api.openai.com/v1/responses",
                 "anthropic" => "https://api.anthropic.com/v1/messages",
                 "openrouter" => "https://openrouter.ai/api/v1/chat/completions",
@@ -2381,7 +2375,7 @@ fn validate_selection_identity(
         return Err("Archaeology synthesis provider selection is invalid or unbounded".into());
     }
     let expected_cost = match selection.provider_identity.as_str() {
-        "local" | "free-ai" => ArchaeologyCostClass::Free,
+        "local" => ArchaeologyCostClass::Free,
         "openai" | "anthropic" | "openrouter" => ArchaeologyCostClass::Paid,
         _ if descriptor.kind == ArchaeologyProviderKind::Local => ArchaeologyCostClass::Free,
         _ => return Err("Archaeology synthesis provider cost class is unknown".into()),

--- a/apps/desktop/src/lib/review-service.test.ts
+++ b/apps/desktop/src/lib/review-service.test.ts
@@ -125,7 +125,7 @@ describe('buildActiveStandardsContext', () => {
 
 describe('PROVIDER_PRESETS', () => {
   it('exposes a base url and model for each known provider', () => {
-    for (const key of ['free-ai', 'anthropic', 'openai', 'openrouter']) {
+    for (const key of ['anthropic', 'openai', 'openrouter']) {
       const preset = PROVIDER_PRESETS[key];
       assert.ok(preset, `missing preset for ${key}`);
       assert.match(preset.baseUrl, /^https:\/\//);

--- a/apps/desktop/src/lib/review-service.ts
+++ b/apps/desktop/src/lib/review-service.ts
@@ -125,10 +125,6 @@ export function getActiveStandardsPackId(): string | null {
 }
 
 export const PROVIDER_PRESETS: Record<string, { baseUrl: string; model: string }> = {
-  'free-ai': {
-    baseUrl: 'https://ai-gateway.sassmaker.com/v1',
-    model: 'auto',
-  },
   anthropic: {
     baseUrl: 'https://api.anthropic.com/v1',
     model: 'claude-sonnet-4-20250514',


### PR DESCRIPTION
Removes the retired shared-gateway preset from the desktop and archaeology synthesis paths.\n\nChecks:\n- focused review-service tests (11 passed)\n- desktop production build\n- cargo check (warning-only)