### PR TITLE
[stack 01/40] Native evidence domain models

### DIFF
--- a/apps/macos/CodeVetterPackage/Sources/CodeVetterFeature/CapabilityModels.swift
+++ b/apps/macos/CodeVetterPackage/Sources/CodeVetterFeature/CapabilityModels.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+public struct CapabilityRegistry: Codable, Sendable {
+  public let schemaVersion: String
+  public let authority: String
+  public let capabilities: [Capability]
+
+  enum CodingKeys: String, CodingKey {
+    case schemaVersion = "schema_version"
+    case authority
+    case capabilities
+  }
+
+  public static func bundled() throws -> CapabilityRegistry {
+    guard let url = Bundle.module.url(forResource: "capabilities.v1", withExtension: "json") else {
+      throw CapabilityLoadingError.missingResource
+    }
+    return try JSONDecoder().decode(CapabilityRegistry.self, from: Data(contentsOf: url))
+  }
+}
+
+public enum CapabilityLoadingError: LocalizedError {
+  case missingResource
+
+  public var errorDescription: String? {
+    "The Rust-generated capability registry is missing from the app bundle."
+  }
+}
+
+public struct Capability: Codable, Identifiable, Sendable {
+  public let id: String
+  public let name: String
+  public let purpose: String
+  public let stage: CapabilityStage
+  public let surfaces: SurfaceMatrix
+  public let underlyingTools: [UnderlyingTool]
+  public let dataBoundary: String
+  public let qualification: Qualification
+  public let limitations: [String]
+  public let nextStep: String
+
+  enum CodingKeys: String, CodingKey {
+    case id, name, purpose, stage, surfaces, limitations, qualification
+    case underlyingTools = "underlying_tools"
+    case dataBoundary = "data_boundary"
+    case nextStep = "next_step"
+  }
+}
+
+public enum CapabilityStage: String, Codable, Sendable {
+  case current
+  case building
+  case future
+}
+
+public enum Availability: String, Codable, Sendable {
+  case available
+  case building
+  case planned
+  case unavailable
+}
+
+public enum Authority: String, Codable, Sendable {
+  case none
+  case read
+  case execute
+  case readExecute = "read_execute"
+}
+
+public enum Qualification: String, Codable, Sendable {
+  case qualified
+  case partial
+  case unqualified
+}
+
+public struct SurfaceProjection: Codable, Sendable {
+  public let availability: Availability
+  public let authority: Authority
+  public let entrypoints: [String]
+}
+
+public struct SurfaceMatrix: Codable, Sendable {
+  public let ui: SurfaceProjection
+  public let cli: SurfaceProjection
+  public let agent: SurfaceProjection
+}
+
+public struct UnderlyingTool: Codable, Sendable, Identifiable {
+  public let name: String
+  public let role: String
+  public let requirement: String
+
+  public var id: String { name }
+}

--- a/apps/macos/CodeVetterPackage/Sources/CodeVetterFeature/EvidenceScopeModels.swift
+++ b/apps/macos/CodeVetterPackage/Sources/CodeVetterFeature/EvidenceScopeModels.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+public enum EvidenceScopeConsumer: String, Codable, CaseIterable, Identifiable, Sendable {
+  case testing
+  case performance
+
+  public var id: String { rawValue }
+}
+
+public enum EvidenceScopeKind: String, Codable, CaseIterable, Identifiable, Sendable {
+  case flow
+  case change
+  case codebase
+
+  public var id: String { rawValue }
+
+  var cliFlag: String {
+    switch self {
+    case .flow: "--flow"
+    case .change: "--change"
+    case .codebase: "--codebase"
+    }
+  }
+}
+
+public struct EvidenceScopeRequest: Sendable {
+  public let repositoryPath: String
+  public let consumer: EvidenceScopeConsumer
+  public let kind: EvidenceScopeKind
+  public let value: String?
+
+  public init(
+    repositoryPath: String,
+    consumer: EvidenceScopeConsumer,
+    kind: EvidenceScopeKind,
+    value: String? = nil
+  ) {
+    self.repositoryPath = repositoryPath
+    self.consumer = consumer
+    self.kind = kind
+    self.value = value
+  }
+}
+
+public struct EvidenceScopeCandidate: Codable, Identifiable, Sendable {
+  public let id: String
+  public let adapter: String
+  public let target: String
+  public let name: String?
+  public let reason: String
+  public let sourcePaths: [String]
+  public let confidenceMilli: UInt16
+  public let testingSupported: Bool
+  public let performanceSupported: Bool
+
+  public var confidenceLabel: String {
+    String(format: "%.1f%%", Double(confidenceMilli) / 10.0)
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case id, adapter, target, name, reason
+    case sourcePaths = "source_paths"
+    case confidenceMilli = "confidence_milli"
+    case testingSupported = "testing_supported"
+    case performanceSupported = "performance_supported"
+  }
+}
+
+public struct EvidenceScopePlan: Codable, Sendable {
+  public let schemaVersion: UInt32
+  public let planID: String
+  public let repositoryRevision: String
+  public let dirty: Bool
+  public let kind: EvidenceScopeKind
+  public let originalInput: String?
+  public let consumer: EvidenceScopeConsumer
+  public let status: String
+  public let candidates: [EvidenceScopeCandidate]
+  public let uncoveredPaths: [String]
+  public let limitations: [String]
+
+  public var ready: Bool { status == "ready" && !candidates.isEmpty }
+
+  enum CodingKeys: String, CodingKey {
+    case dirty, kind, consumer, status, candidates, limitations
+    case schemaVersion = "schema_version"
+    case planID = "plan_id"
+    case repositoryRevision = "repository_revision"
+    case originalInput = "original_input"
+    case uncoveredPaths = "uncovered_paths"
+  }
+}
+
+public struct EvidenceScopeRunResult: Sendable {
+  public let plan: EvidenceScopePlan
+  public let rawJSON: String
+  public let processStatus: Int32
+}

--- a/apps/macos/CodeVetterPackage/Sources/CodeVetterFeature/EvidenceStyle.swift
+++ b/apps/macos/CodeVetterPackage/Sources/CodeVetterFeature/EvidenceStyle.swift
@@ -1,0 +1,77 @@
+import SwiftUI
+
+enum EvidenceStyle {
+  static let ink = Color(red: 0.035, green: 0.038, blue: 0.044)
+  static let amber = Color(red: 0.95, green: 0.64, blue: 0.19)
+  static let amberForegroundNSColor = dynamicNSColor(dark: 0xF2A330, light: 0x8A4C00)
+  static let amberForeground = Color(nsColor: amberForegroundNSColor)
+  static let amberSoft = Color(red: 1.0, green: 0.76, blue: 0.35)
+  static let successNSColor = dynamicNSColor(dark: 0x4DC77A, light: 0x1E6B3E)
+  static let success = Color(nsColor: successNSColor)
+  static let warningNSColor = dynamicNSColor(dark: 0xF2B040, light: 0x7A4A00)
+  static let warning = Color(nsColor: warningNSColor)
+  static let failureNSColor = dynamicNSColor(dark: 0xF05C70, light: 0xB4233B)
+  static let failure = Color(nsColor: failureNSColor)
+  static let panel = dynamicColor(dark: 0x030304, light: 0xFFFFFF)
+  static let canvas = dynamicColor(dark: 0x000000, light: 0xF7F6F3)
+  static let chrome = dynamicColor(dark: 0x000000, light: 0xF1F0ED)
+  static let surface = dynamicColor(dark: 0x050506, light: 0xFFFFFF)
+  static let inspector = dynamicColor(dark: 0x09090B, light: 0xF3F2EF)
+  static let separator = Color.primary.opacity(0.09)
+
+  private static func dynamicColor(dark: UInt32, light: UInt32) -> Color {
+    Color(nsColor: dynamicNSColor(dark: dark, light: light))
+  }
+
+  private static func dynamicNSColor(dark: UInt32, light: UInt32) -> NSColor {
+    NSColor(name: nil) { appearance in
+      let value = appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua ? dark : light
+      return NSColor(
+        srgbRed: CGFloat((value >> 16) & 0xFF) / 255,
+        green: CGFloat((value >> 8) & 0xFF) / 255,
+        blue: CGFloat(value & 0xFF) / 255,
+        alpha: 1
+      )
+    }
+  }
+}
+
+struct EvidencePanel<Content: View>: View {
+  let content: Content
+
+  init(@ViewBuilder content: () -> Content) {
+    self.content = content()
+  }
+
+  var body: some View {
+    content
+      .padding(18)
+      .background(EvidenceStyle.panel.opacity(0.78), in: RoundedRectangle(cornerRadius: 12))
+      .overlay {
+        RoundedRectangle(cornerRadius: 12)
+          .stroke(EvidenceStyle.separator, lineWidth: 1)
+      }
+  }
+}
+
+struct StatusPill: View {
+  let label: String
+  let color: Color
+
+  var body: some View {
+    HStack(spacing: 6) {
+      Circle().fill(color).frame(width: 6, height: 6)
+      Text(evidenceStatusLabel(label))
+    }
+    .font(.caption.weight(.medium))
+    .padding(.horizontal, 9)
+    .padding(.vertical, 5)
+    .background(color.opacity(0.12), in: Capsule())
+    .overlay { Capsule().stroke(color.opacity(0.22), lineWidth: 1) }
+    .accessibilityLabel(evidenceStatusLabel(label))
+  }
+}
+
+func evidenceStatusLabel(_ label: String) -> String {
+  label.replacingOccurrences(of: "_", with: " ")
+}

--- a/apps/macos/CodeVetterPackage/Sources/CodeVetterFeature/EvidenceViews.swift
+++ b/apps/macos/CodeVetterPackage/Sources/CodeVetterFeature/EvidenceViews.swift
@@ -1,0 +1,713 @@
+import SwiftUI
+import UniformTypeIdentifiers
+
+public struct EvidenceSidebarView: View {
+  @Bindable private var model: WorkbenchModel
+
+  public init(model: WorkbenchModel) {
+    self.model = model
+  }
+
+  public var body: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      HStack(spacing: 10) {
+        ZStack {
+          RoundedRectangle(cornerRadius: 8)
+            .fill(EvidenceStyle.amber.gradient)
+          Image(systemName: "checkmark.shield.fill")
+            .font(.system(size: 15, weight: .semibold))
+            .foregroundStyle(.black.opacity(0.82))
+        }
+        .frame(width: 30, height: 30)
+        VStack(alignment: .leading, spacing: 1) {
+          Text("CodeVetter").font(.system(size: 14, weight: .semibold))
+          Text("Evidence Workbench")
+            .font(.system(size: 10, weight: .medium))
+            .foregroundStyle(.secondary)
+        }
+      }
+      .padding(.horizontal, 14)
+      .padding(.top, 14)
+      .padding(.bottom, 18)
+
+      navigationGroup("Workspace", sections: [.usage, .repository])
+      navigationGroup("Verification", sections: [.review, .testing, .performance])
+        .padding(.top, 12)
+      navigationGroup("Evidence", sections: [.runs, .capabilities])
+        .padding(.top, 12)
+
+      Spacer()
+
+      VStack(alignment: .leading, spacing: 8) {
+        Label("Rust engine", systemImage: "shippingbox")
+          .font(.system(size: 11, weight: .semibold))
+        HStack(spacing: 6) {
+          Circle().fill(EvidenceStyle.success).frame(width: 6, height: 6)
+          Text("Contract loaded")
+            .font(.system(size: 11))
+            .foregroundStyle(.secondary)
+        }
+        Text(model.registry.schemaVersion)
+          .font(.system(size: 9, design: .monospaced))
+          .foregroundStyle(.tertiary)
+          .lineLimit(1)
+      }
+      .padding(12)
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .background(Color.primary.opacity(0.035), in: RoundedRectangle(cornerRadius: 9))
+      .padding(10)
+
+      navigationButton(.settings)
+        .padding(.horizontal, 8)
+        .padding(.bottom, 10)
+    }
+    .background(.ultraThinMaterial)
+  }
+
+  private func navigationGroup(_ title: String, sections: [WorkbenchSection]) -> some View {
+    VStack(alignment: .leading, spacing: 3) {
+      Text(title.uppercased())
+        .font(.system(size: 9, weight: .bold))
+        .foregroundStyle(.tertiary)
+        .padding(.horizontal, 11)
+        .padding(.bottom, 3)
+      ForEach(sections) { section in navigationButton(section) }
+    }
+    .padding(.horizontal, 8)
+  }
+
+  private func navigationButton(_ section: WorkbenchSection) -> some View {
+    Button {
+      model.section = section
+    } label: {
+      HStack(spacing: 10) {
+        Image(systemName: section.systemImage)
+          .font(.system(size: 13, weight: .medium))
+          .frame(width: 18)
+        Text(section.rawValue)
+          .font(.system(size: 13, weight: .medium))
+        Spacer()
+        if section == .runs {
+          Text("0")
+            .font(.system(size: 10, weight: .semibold, design: .rounded))
+            .foregroundStyle(.secondary)
+        }
+      }
+      .foregroundStyle(model.section == section ? .primary : .secondary)
+      .padding(.horizontal, 11)
+      .frame(height: 31)
+      .background {
+        RoundedRectangle(cornerRadius: 7)
+          .fill(model.section == section ? Color.primary.opacity(0.09) : .clear)
+      }
+    }
+    .buttonStyle(.plain)
+    .accessibilityLabel(section.rawValue)
+    .accessibilityValue(section == .runs ? "0 runs" : "")
+    .accessibilityAddTraits(model.section == section ? .isSelected : [])
+  }
+}
+
+public struct EvidenceWorkbenchView: View {
+  @Bindable private var model: WorkbenchModel
+
+  public init(model: WorkbenchModel) {
+    self.model = model
+  }
+
+  public var body: some View {
+    Group {
+      switch model.section {
+      case .review:
+        VerifyView(model: model)
+      case .capabilities:
+        CapabilityCatalogView(model: model)
+      case .usage:
+        EmptyWorkbenchView(
+          title: "Usage",
+          message:
+            "Local agent usage, cost, quota, model, and activity views will transfer here without changing their provider boundaries.",
+          icon: "chart.bar.xaxis"
+        )
+      case .runs:
+        EmptyWorkbenchView(
+          title: "Runs",
+          message: "Completed native receipts will appear here after the first verified run.",
+          icon: "clock.arrow.circlepath"
+        )
+      case .repository:
+        EmptyWorkbenchView(
+          title: "Repo Unpack",
+          message:
+            "Overview, Handoff, Rules, Analysis, Activity, Inventory, Graph, and Delta will transfer against the existing Rust evidence store.",
+          icon: "shippingbox"
+        )
+      case .testing:
+        EmptyWorkbenchView(
+          title: "Testing",
+          message:
+            "Direct previews, changed-capability verification, scenarios, watchers, and executable receipts remain part of the native product.",
+          icon: "testtube.2"
+        )
+      case .performance:
+        EmptyWorkbenchView(
+          title: "Performance",
+          message:
+            "Workload admission, measurement, diagnosis, paired optimization proof, cleanup, and receipts will migrate intact.",
+          icon: "gauge.with.dots.needle.67percent"
+        )
+      case .settings:
+        EmptyWorkbenchView(
+          title: "Settings",
+          message:
+            "Provider and runtime settings remain local and will migrate only after contract parity.",
+          icon: "gearshape"
+        )
+      }
+    }
+    .background(EvidenceStyle.canvas)
+  }
+}
+
+public struct EvidenceInspectorView: View {
+  @Bindable private var model: WorkbenchModel
+
+  public init(model: WorkbenchModel) {
+    self.model = model
+  }
+
+  public var body: some View {
+    ScrollView {
+      VStack(alignment: .leading, spacing: 18) {
+        if model.section == .capabilities, let capability = model.selectedCapability {
+          CapabilityInspector(capability: capability)
+        } else {
+          VerificationInspector(model: model)
+        }
+      }
+      .padding(18)
+    }
+    .background(Color(nsColor: .underPageBackgroundColor))
+  }
+}
+
+private struct VerifyView: View {
+  @Bindable var model: WorkbenchModel
+
+  var body: some View {
+    ScrollView {
+      VStack(alignment: .leading, spacing: 18) {
+        HStack(alignment: .top) {
+          VStack(alignment: .leading, spacing: 5) {
+            Text("REVIEW")
+              .font(.system(size: 9, weight: .bold))
+              .tracking(0.8)
+              .foregroundStyle(EvidenceStyle.amberForeground)
+            Text("Verify a change")
+              .font(.system(size: 24, weight: .semibold))
+            Text(
+              "Resolve the exact source, run executable checks, and keep the limitations attached."
+            )
+            .font(.system(size: 13))
+            .foregroundStyle(.secondary)
+          }
+          Spacer()
+          StatusPill(label: model.verificationState.rawValue, color: stateColor)
+        }
+
+        EvidencePanel {
+          VStack(alignment: .leading, spacing: 16) {
+            panelHeading(
+              "Change identity", caption: "Rust resolves these inputs before any claim is made.")
+            VStack(spacing: 12) {
+              LabeledContent("Repository") {
+                HStack(spacing: 8) {
+                  Text(
+                    model.repositoryPath.isEmpty ? "No repository selected" : model.repositoryPath
+                  )
+                  .font(.system(size: 12, design: .monospaced))
+                  .foregroundStyle(model.repositoryPath.isEmpty ? .secondary : .primary)
+                  .lineLimit(1)
+                  .truncationMode(.middle)
+                  .frame(maxWidth: .infinity, alignment: .leading)
+                  Button("Choose…") { model.choosingRepository = true }
+                    .controlSize(.small)
+                }
+              }
+              Divider()
+              LabeledContent("Change") {
+                TextField("main...HEAD", text: $model.change)
+                  .textFieldStyle(.roundedBorder)
+                  .font(.system(size: 12, design: .monospaced))
+              }
+              Divider()
+              LabeledContent("Task") {
+                TextField("Describe the behavior this change must satisfy", text: $model.task)
+                  .textFieldStyle(.roundedBorder)
+              }
+            }
+            .font(.system(size: 12))
+          }
+        }
+
+        EvidencePanel {
+          VStack(alignment: .leading, spacing: 16) {
+            panelHeading("Verification dossier", caption: model.statusMessage)
+            VerificationRail(model: model)
+            HStack(spacing: 10) {
+              Button {
+                model.plan()
+              } label: {
+                Label("Plan verification", systemImage: "list.bullet.clipboard")
+              }
+              .buttonStyle(.borderedProminent)
+              .tint(EvidenceStyle.amber)
+              .foregroundStyle(.black.opacity(0.84))
+              .disabled(!model.canStart)
+              .keyboardShortcut(.return, modifiers: [.command])
+
+              Button {
+                model.execute()
+              } label: {
+                Label("Execute", systemImage: "play.fill")
+              }
+              .buttonStyle(.bordered)
+              .disabled(!model.canStart)
+
+              if model.isBusy {
+                Button("Cancel", role: .destructive) { model.cancel() }
+              }
+              Spacer()
+              Text("Rust-owned receipt")
+                .font(.system(size: 10, weight: .medium))
+                .foregroundStyle(.tertiary)
+            }
+          }
+        }
+
+        if let receipt = model.receipt {
+          ReceiptSummary(receipt: receipt)
+        }
+      }
+      .padding(24)
+      .frame(maxWidth: 940, alignment: .leading)
+    }
+    .fileImporter(
+      isPresented: $model.choosingRepository,
+      allowedContentTypes: [.folder],
+      allowsMultipleSelection: false
+    ) { result in
+      guard case .success(let urls) = result, let url = urls.first else { return }
+      model.selectRepository(url)
+    }
+  }
+
+  private var stateColor: Color {
+    switch model.verificationState {
+    case .completed, .planned: EvidenceStyle.success
+    case .planning, .running: EvidenceStyle.amber
+    case .limited: EvidenceStyle.warning
+    case .failed: EvidenceStyle.failure
+    case .ready, .cancelled: .secondary
+    }
+  }
+}
+
+private struct VerificationRail: View {
+  let model: WorkbenchModel
+
+  private let stages = [
+    ("1", "Resolve", "Exact repository and revision"),
+    ("2", "Correctness", "Discovered or explicit checks"),
+    ("3", "Performance", "Bounded workload evidence"),
+    ("4", "Review", "Model findings with runtime context"),
+    ("5", "Verdict", "Measured outcome and limitations"),
+  ]
+
+  var body: some View {
+    ViewThatFits(in: .horizontal) {
+      horizontalRail
+        .fixedSize(horizontal: true, vertical: false)
+      compactRail
+    }
+  }
+
+  private var horizontalRail: some View {
+    HStack(alignment: .top, spacing: 0) {
+      ForEach(Array(stages.enumerated()), id: \.offset) { index, stage in
+        VStack(spacing: 7) {
+          ZStack {
+            Circle()
+              .fill(index == activeIndex ? EvidenceStyle.amber : Color.primary.opacity(0.08))
+            Text(stage.0)
+              .font(.system(size: 10, weight: .bold, design: .rounded))
+              .foregroundStyle(index == activeIndex ? .black : .secondary)
+          }
+          .frame(width: 24, height: 24)
+          Text(stage.1)
+            .font(.system(size: 11, weight: .semibold))
+          Text(stage.2)
+            .font(.system(size: 9))
+            .foregroundStyle(.secondary)
+            .multilineTextAlignment(.center)
+            .lineLimit(2)
+            .frame(width: 92)
+        }
+        if index < stages.count - 1 {
+          Rectangle()
+            .fill(Color.primary.opacity(0.09))
+            .frame(height: 1)
+            .padding(.top, 12)
+            .frame(width: 18)
+        }
+      }
+    }
+  }
+
+  private var compactRail: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      ForEach(Array(stages.enumerated()), id: \.offset) { index, stage in
+        HStack(spacing: 11) {
+          ZStack {
+            Circle()
+              .fill(index == activeIndex ? EvidenceStyle.amber : Color.primary.opacity(0.08))
+            Text(stage.0)
+              .font(.system(size: 10, weight: .bold, design: .rounded))
+              .foregroundStyle(index == activeIndex ? .black : .secondary)
+          }
+          .frame(width: 24, height: 24)
+          VStack(alignment: .leading, spacing: 2) {
+            Text(stage.1)
+              .font(.system(size: 11, weight: .semibold))
+            Text(stage.2)
+              .font(.system(size: 10))
+              .foregroundStyle(.secondary)
+          }
+          Spacer()
+          if index < activeIndex {
+            Image(systemName: "checkmark.circle.fill")
+              .foregroundStyle(EvidenceStyle.success)
+          } else if index == activeIndex {
+            Text("CURRENT")
+              .font(.system(size: 8, weight: .bold))
+              .foregroundStyle(EvidenceStyle.amberForeground)
+          }
+        }
+        .padding(.vertical, 7)
+        if index < stages.count - 1 {
+          Divider().padding(.leading, 35)
+        }
+      }
+    }
+  }
+
+  private var activeIndex: Int {
+    switch model.verificationState {
+    case .ready, .planning: 0
+    case .planned: 1
+    case .running: 2
+    case .completed, .limited, .failed: 4
+    case .cancelled: 0
+    }
+  }
+}
+
+private struct ReceiptSummary: View {
+  let receipt: VerificationReceipt
+
+  var body: some View {
+    EvidencePanel {
+      VStack(alignment: .leading, spacing: 14) {
+        panelHeading("Canonical receipt", caption: receipt.schemaVersion)
+        HStack(spacing: 16) {
+          receiptMetric("Outcome", receipt.status ?? receipt.verdict ?? "completed")
+          receiptMetric("Changed files", "\(receipt.source.changedPaths.count)")
+          receiptMetric("Head", String(receipt.source.headSha.prefix(10)))
+        }
+        if !receipt.limitations.isEmpty {
+          Divider()
+          Label("Limitations", systemImage: "exclamationmark.triangle")
+            .font(.system(size: 11, weight: .semibold))
+          ForEach(receipt.limitations, id: \.self) { limitation in
+            Text("• \(limitation)")
+              .font(.system(size: 11))
+              .foregroundStyle(.secondary)
+          }
+        }
+      }
+    }
+  }
+
+  private func receiptMetric(_ label: String, _ value: String) -> some View {
+    VStack(alignment: .leading, spacing: 4) {
+      Text(label.uppercased())
+        .font(.system(size: 9, weight: .semibold))
+        .foregroundStyle(.tertiary)
+      Text(value.replacingOccurrences(of: "_", with: " "))
+        .font(.system(size: 12, weight: .semibold, design: .monospaced))
+        .lineLimit(1)
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+  }
+}
+
+private struct CapabilityCatalogView: View {
+  @Bindable var model: WorkbenchModel
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 16) {
+      HStack(alignment: .top) {
+        VStack(alignment: .leading, spacing: 5) {
+          Text("Capabilities")
+            .font(.system(size: 24, weight: .semibold))
+          Text("One Rust-owned glossary for the UI, CLI, and AI agent surfaces.")
+            .font(.system(size: 13))
+            .foregroundStyle(.secondary)
+        }
+        Spacer()
+        Text(model.registry.schemaVersion)
+          .font(.system(size: 10, design: .monospaced))
+          .foregroundStyle(.secondary)
+          .padding(.horizontal, 9)
+          .padding(.vertical, 5)
+          .background(Color.primary.opacity(0.06), in: Capsule())
+      }
+
+      Grid(horizontalSpacing: 12, verticalSpacing: 0) {
+        GridRow {
+          header("Capability", alignment: .leading)
+          header("Stage")
+          header("UI")
+          header("CLI")
+          header("Agent")
+        }
+        Divider().gridCellColumns(5)
+        ForEach(model.registry.capabilities) { capability in
+          GridRow {
+            Button {
+              model.selectedCapabilityID = capability.id
+            } label: {
+              VStack(alignment: .leading, spacing: 3) {
+                Text(capability.name)
+                  .font(.system(size: 12, weight: .semibold))
+                Text(capability.id)
+                  .font(.system(size: 9, design: .monospaced))
+                  .foregroundStyle(.tertiary)
+              }
+              .frame(maxWidth: .infinity, alignment: .leading)
+              .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            stageLabel(capability.stage)
+            availabilityLabel(capability.surfaces.ui.availability)
+            availabilityLabel(capability.surfaces.cli.availability)
+            availabilityLabel(capability.surfaces.agent.availability)
+          }
+          .padding(.vertical, 10)
+          .background(
+            model.selectedCapabilityID == capability.id
+              ? EvidenceStyle.amber.opacity(0.07)
+              : .clear
+          )
+          Divider().gridCellColumns(5)
+        }
+      }
+      .padding(12)
+      .background(EvidenceStyle.panel.opacity(0.78), in: RoundedRectangle(cornerRadius: 12))
+      .overlay { RoundedRectangle(cornerRadius: 12).stroke(EvidenceStyle.separator) }
+      Spacer()
+    }
+    .padding(24)
+  }
+
+  private func header(_ text: String, alignment: Alignment = .center) -> some View {
+    Text(text.uppercased())
+      .font(.system(size: 9, weight: .bold))
+      .foregroundStyle(.tertiary)
+      .frame(maxWidth: .infinity, alignment: alignment)
+      .padding(.vertical, 8)
+  }
+
+  private func stageLabel(_ stage: CapabilityStage) -> some View {
+    Text(stage.rawValue.capitalized)
+      .font(.system(size: 10, weight: .medium))
+      .foregroundStyle(stage == .current ? EvidenceStyle.success : .secondary)
+      .frame(maxWidth: .infinity)
+  }
+
+  private func availabilityLabel(_ availability: Availability) -> some View {
+    Image(
+      systemName: availability == .available ? "checkmark.circle.fill" : symbol(for: availability)
+    )
+    .foregroundStyle(color(for: availability))
+    .frame(maxWidth: .infinity)
+    .accessibilityLabel(availability.rawValue)
+  }
+
+  private func symbol(for availability: Availability) -> String {
+    switch availability {
+    case .available: "checkmark.circle.fill"
+    case .building: "hammer.circle.fill"
+    case .planned: "clock"
+    case .unavailable: "minus.circle"
+    }
+  }
+
+  private func color(for availability: Availability) -> Color {
+    switch availability {
+    case .available: EvidenceStyle.success
+    case .building: EvidenceStyle.amber
+    case .planned, .unavailable: .secondary
+    }
+  }
+}
+
+private struct VerificationInspector: View {
+  let model: WorkbenchModel
+
+  var body: some View {
+    Text("EVIDENCE")
+      .font(.system(size: 10, weight: .bold))
+      .foregroundStyle(.tertiary)
+    if let receipt = model.receipt {
+      inspectorPair("Schema", receipt.schemaVersion)
+      inspectorPair("Source", receipt.source.input)
+      inspectorPair("Base", String(receipt.source.baseSha.prefix(12)))
+      inspectorPair("Head", String(receipt.source.headSha.prefix(12)))
+      Divider()
+      Text("RAW RECEIPT")
+        .font(.system(size: 10, weight: .bold))
+        .foregroundStyle(.tertiary)
+      Text(model.receiptJSON)
+        .textSelection(.enabled)
+        .font(.system(size: 10, design: .monospaced))
+        .foregroundStyle(.secondary)
+    } else {
+      Text("PROOF STANDARD")
+        .font(.system(size: 10, weight: .bold))
+        .foregroundStyle(.tertiary)
+      Text("A verdict earns its place here.")
+        .font(.system(size: 17, weight: .semibold))
+      Text("CodeVetter keeps the claim attached to what actually ran.")
+        .font(.system(size: 12))
+        .foregroundStyle(.secondary)
+      Divider()
+      inspectorRequirement(
+        "Exact change identity", "Repository, base, head, and changed paths are resolved first.",
+        icon: "point.topleft.down.to.point.bottomright.curvepath")
+      inspectorRequirement(
+        "Executable evidence", "Checks and artifacts come from the supervised Rust engine.",
+        icon: "terminal")
+      inspectorRequirement(
+        "Bounded verdict", "Known limitations remain visible beside the outcome.",
+        icon: "scope")
+      Divider()
+      Label("The receipt stays pinned while you inspect the workbench.", systemImage: "pin")
+        .font(.system(size: 10))
+        .foregroundStyle(.tertiary)
+    }
+  }
+}
+
+private func inspectorRequirement(_ title: String, _ detail: String, icon: String) -> some View {
+  HStack(alignment: .top, spacing: 10) {
+    Image(systemName: icon)
+      .font(.system(size: 12, weight: .semibold))
+      .foregroundStyle(EvidenceStyle.amberForeground)
+      .frame(width: 18, height: 18)
+    VStack(alignment: .leading, spacing: 3) {
+      Text(title)
+        .font(.system(size: 11, weight: .semibold))
+      Text(detail)
+        .font(.system(size: 10))
+        .foregroundStyle(.secondary)
+        .fixedSize(horizontal: false, vertical: true)
+    }
+  }
+}
+
+private struct CapabilityInspector: View {
+  let capability: Capability
+
+  var body: some View {
+    Text("CAPABILITY")
+      .font(.system(size: 10, weight: .bold))
+      .foregroundStyle(.tertiary)
+    Text(capability.name)
+      .font(.system(size: 17, weight: .semibold))
+    Text(capability.purpose)
+      .font(.system(size: 12))
+      .foregroundStyle(.secondary)
+    Divider()
+    inspectorPair("Qualification", capability.qualification.rawValue)
+    inspectorPair("Data boundary", capability.dataBoundary)
+    Text("UNDERLYING TOOLS")
+      .font(.system(size: 10, weight: .bold))
+      .foregroundStyle(.tertiary)
+    ForEach(capability.underlyingTools) { tool in
+      VStack(alignment: .leading, spacing: 3) {
+        Text(tool.name).font(.system(size: 11, weight: .semibold))
+        Text(tool.role).font(.system(size: 10)).foregroundStyle(.secondary)
+        Text(tool.requirement.uppercased())
+          .font(.system(size: 8, weight: .bold))
+          .foregroundStyle(.tertiary)
+      }
+    }
+    if !capability.limitations.isEmpty {
+      Divider()
+      Text("LIMITATIONS")
+        .font(.system(size: 10, weight: .bold))
+        .foregroundStyle(.tertiary)
+      ForEach(capability.limitations, id: \.self) { limitation in
+        Text("• \(limitation)")
+          .font(.system(size: 10))
+          .foregroundStyle(.secondary)
+      }
+    }
+    Divider()
+    Text("NEXT")
+      .font(.system(size: 10, weight: .bold))
+      .foregroundStyle(.tertiary)
+    Text(capability.nextStep)
+      .font(.system(size: 11, weight: .medium))
+  }
+}
+
+private struct EmptyWorkbenchView: View {
+  let title: String
+  let message: String
+  let icon: String
+
+  var body: some View {
+    VStack(spacing: 12) {
+      Image(systemName: icon)
+        .font(.system(size: 34, weight: .light))
+        .foregroundStyle(.tertiary)
+      Text(title).font(.system(size: 22, weight: .semibold))
+      Text(message)
+        .font(.system(size: 13))
+        .foregroundStyle(.secondary)
+        .multilineTextAlignment(.center)
+        .frame(maxWidth: 420)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+  }
+}
+
+private func panelHeading(_ title: String, caption: String) -> some View {
+  VStack(alignment: .leading, spacing: 4) {
+    Text(title).font(.system(size: 13, weight: .semibold))
+    Text(caption).font(.system(size: 11)).foregroundStyle(.secondary)
+  }
+}
+
+private func inspectorPair(_ label: String, _ value: String) -> some View {
+  VStack(alignment: .leading, spacing: 3) {
+    Text(label.uppercased())
+      .font(.system(size: 9, weight: .bold))
+      .foregroundStyle(.tertiary)
+    Text(value.replacingOccurrences(of: "_", with: " "))
+      .font(.system(size: 11, design: label == "Data boundary" ? .default : .monospaced))
+      .textSelection(.enabled)
+  }
+}

--- a/apps/macos/CodeVetterPackage/Sources/CodeVetterFeature/NativeUpdaterConfiguration.swift
+++ b/apps/macos/CodeVetterPackage/Sources/CodeVetterFeature/NativeUpdaterConfiguration.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+public struct NativeUpdaterConfiguration: Equatable, Sendable {
+  public let feedURL: URL?
+  public let publicEdKey: String?
+  public let productionBundle: Bool
+
+  public var ready: Bool {
+    feedURL?.scheme?.lowercased() == "https"
+      && !(publicEdKey?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
+      && productionBundle
+  }
+
+  public var status: String {
+    if !productionBundle { return "Preview builds never install production updates." }
+    if feedURL?.scheme?.lowercased() != "https" {
+      return "A secure Sparkle appcast is not configured."
+    }
+    if publicEdKey?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true {
+      return "The Sparkle EdDSA public key is not configured."
+    }
+    return "Signed Sparkle updates are available."
+  }
+
+  public init(bundle: Bundle = .main) {
+    let feed = bundle.object(forInfoDictionaryKey: "SUFeedURL") as? String
+    feedURL = feed.flatMap(URL.init(string:))
+    publicEdKey = bundle.object(forInfoDictionaryKey: "SUPublicEDKey") as? String
+    productionBundle = bundle.bundleIdentifier == "com.codevetter.desktop"
+  }
+
+  public init(feedURL: URL?, publicEdKey: String?, productionBundle: Bool) {
+    self.feedURL = feedURL
+    self.publicEdKey = publicEdKey
+    self.productionBundle = productionBundle
+  }
+}

--- a/apps/macos/CodeVetterPackage/Sources/CodeVetterFeature/OpsStatusModels.swift
+++ b/apps/macos/CodeVetterPackage/Sources/CodeVetterFeature/OpsStatusModels.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+public struct OpsBillingStatus: Codable, Sendable {
+  public let anthropicConfigured: Bool
+  public let openaiConfigured: Bool
+
+  enum CodingKeys: String, CodingKey {
+    case anthropicConfigured = "anthropic_configured"
+    case openaiConfigured = "openai_configured"
+  }
+}
+
+public struct OpsWebhookStatus: Codable, Sendable {
+  public let configured: Bool
+  public let flavor: String
+}
+
+public struct OpsObservabilityRow: Codable, Identifiable, Sendable {
+  public let taskType: String
+  public let sessionCount: Int64
+  public let successCount: Int64
+  public let failureCount: Int64
+  public let successRatePercent: Double
+  public let medianDurationSeconds: Double?
+  public let p95DurationSeconds: Double?
+
+  public var id: String { taskType }
+
+  enum CodingKeys: String, CodingKey {
+    case taskType = "task_type"
+    case sessionCount = "session_count"
+    case successCount = "success_count"
+    case failureCount = "failure_count"
+    case successRatePercent = "success_rate_pct"
+    case medianDurationSeconds = "median_duration_seconds"
+    case p95DurationSeconds = "p95_duration_seconds"
+  }
+}
+
+public struct OpsStatusReceipt: Codable, Sendable {
+  public let schemaVersion: String
+  public let generatedAt: String
+  public let databaseAvailable: Bool
+  public let windowDays: Int
+  public let billing: OpsBillingStatus
+  public let webhook: OpsWebhookStatus
+  public let observability: [OpsObservabilityRow]
+  public let excludedSensitiveKeys: [String]
+  public let limitations: [String]
+
+  enum CodingKeys: String, CodingKey {
+    case billing, webhook, observability, limitations
+    case schemaVersion = "schema_version"
+    case generatedAt = "generated_at"
+    case databaseAvailable = "database_available"
+    case windowDays = "window_days"
+    case excludedSensitiveKeys = "excluded_sensitive_keys"
+  }
+}

--- a/apps/macos/CodeVetterPackage/Sources/CodeVetterFeature/RepositoryAccessStore.swift
+++ b/apps/macos/CodeVetterPackage/Sources/CodeVetterFeature/RepositoryAccessStore.swift
@@ -1,0 +1,127 @@
+import Foundation
+
+/// Retains the repository chosen through the native folder picker across app launches.
+///
+/// The bookmark is the authority when it can be resolved. The path is only a recovery
+/// fallback for non-sandboxed builds and for older bookmarks that macOS can no longer
+/// resolve. Access remains active for the lifetime of this store so bundled CLI
+/// processes inherit the selected-folder grant.
+@MainActor
+public final class RepositoryAccessStore {
+  public static let standard = RepositoryAccessStore(defaults: .standard)
+
+  private enum Key {
+    static let bookmark = "native.lastRepositoryBookmark"
+    static let path = "native.lastRepositoryPath"
+  }
+
+  private let defaults: UserDefaults
+  private var activeURL: URL?
+  private var activeSecurityScope = false
+
+  public init(defaults: UserDefaults) {
+    self.defaults = defaults
+  }
+
+  public func restore() -> URL? {
+    if let data = defaults.data(forKey: Key.bookmark),
+      let restored = resolveBookmark(data),
+      isDirectory(restored.url)
+    {
+      activate(restored.url)
+      if restored.isStale {
+        persistBookmark(for: restored.url)
+      }
+      return restored.url
+    }
+
+    guard let path = defaults.string(forKey: Key.path), !path.isEmpty else { return nil }
+    let url = canonicalURL(URL(fileURLWithPath: path, isDirectory: true))
+    guard isDirectory(url) else {
+      forget()
+      return nil
+    }
+    activate(url)
+    persistBookmark(for: url)
+    return url
+  }
+
+  @discardableResult
+  public func remember(_ url: URL) -> URL? {
+    let resolved = canonicalURL(url)
+    guard isDirectory(resolved) else { return nil }
+    activate(resolved)
+    defaults.set(resolved.path(percentEncoded: false), forKey: Key.path)
+    persistBookmark(for: resolved)
+    return resolved
+  }
+
+  public func forget() {
+    releaseActiveAccess()
+    defaults.removeObject(forKey: Key.bookmark)
+    defaults.removeObject(forKey: Key.path)
+  }
+
+  private func resolveBookmark(_ data: Data) -> (url: URL, isStale: Bool)? {
+    var isStale = false
+    if let url = try? URL(
+      resolvingBookmarkData: data,
+      options: [.withSecurityScope, .withoutUI],
+      relativeTo: nil,
+      bookmarkDataIsStale: &isStale
+    ) {
+      return (canonicalURL(url), isStale)
+    }
+
+    isStale = false
+    guard
+      let url = try? URL(
+        resolvingBookmarkData: data,
+        options: [.withoutUI],
+        relativeTo: nil,
+        bookmarkDataIsStale: &isStale
+      )
+    else { return nil }
+    return (canonicalURL(url), isStale)
+  }
+
+  private func persistBookmark(for url: URL) {
+    let data =
+      (try? url.bookmarkData(
+        options: [.withSecurityScope],
+        includingResourceValuesForKeys: [.isDirectoryKey],
+        relativeTo: nil
+      ))
+      ?? (try? url.bookmarkData(
+        options: [.minimalBookmark],
+        includingResourceValuesForKeys: [.isDirectoryKey],
+        relativeTo: nil
+      ))
+    if let data {
+      defaults.set(data, forKey: Key.bookmark)
+    }
+  }
+
+  private func activate(_ url: URL) {
+    if activeURL == url { return }
+    releaseActiveAccess()
+    activeSecurityScope = url.startAccessingSecurityScopedResource()
+    activeURL = url
+  }
+
+  private func releaseActiveAccess() {
+    if activeSecurityScope {
+      activeURL?.stopAccessingSecurityScopedResource()
+    }
+    activeURL = nil
+    activeSecurityScope = false
+  }
+
+  private func canonicalURL(_ url: URL) -> URL {
+    url.resolvingSymlinksInPath().standardizedFileURL
+  }
+
+  private func isDirectory(_ url: URL) -> Bool {
+    (try? url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true
+  }
+}

--- a/apps/macos/CodeVetterPackage/Sources/CodeVetterFeature/RepositoryQueryWorker.swift
+++ b/apps/macos/CodeVetterPackage/Sources/CodeVetterFeature/RepositoryQueryWorker.swift
@@ -1,0 +1,395 @@
+import Darwin
+import Foundation
+
+private let repositoryQueryWorkerRequestSchema =
+  "codevetter.repo-query-worker-request/v2"
+private let repositoryQueryWorkerResponseSchema =
+  "codevetter.repo-query-worker-response/v1"
+private let repositoryQueryPreparationSchema =
+  "codevetter.repo-query-preparation/v1"
+private let maximumRepositoryQueryWorkerResponseBytes = 2 * 1_024 * 1_024
+
+private enum RepositoryQueryWorkerOperation: String, Encodable {
+  case prepare
+  case query
+}
+
+private struct RepositoryQueryWorkerRequest: Encodable {
+  let schemaVersion: String
+  let requestID: String
+  let operation: RepositoryQueryWorkerOperation
+  let repoPath: String
+  let domain: RepositoryQueryDomain
+  let mode: RepositoryQueryMode
+  let query: String?
+  let target: String?
+  let direction: RepositoryGraphDirection?
+  let depth: Int?
+  let historySelector: RepositoryHistorySelectorKind?
+  let limit: Int?
+
+  enum CodingKeys: String, CodingKey {
+    case operation, domain, mode, query, target, direction, depth, limit
+    case schemaVersion = "schema_version"
+    case requestID = "request_id"
+    case repoPath = "repo_path"
+    case historySelector = "history_selector"
+  }
+}
+
+private struct RepositoryQueryPreparation: Decodable {
+  let schemaVersion: String
+  let authority: String
+  let repoPath: String
+  let domain: RepositoryQueryDomain
+  let status: String
+
+  enum CodingKeys: String, CodingKey {
+    case authority, domain, status
+    case schemaVersion = "schema_version"
+    case repoPath = "repo_path"
+  }
+}
+
+private struct RepositoryQueryWorkerResponse: Decodable {
+  let schemaVersion: String
+  let requestID: String
+  let status: String
+  let receipt: RepositoryQueryReceipt?
+  let preparation: RepositoryQueryPreparation?
+  let error: String?
+
+  enum CodingKeys: String, CodingKey {
+    case status, receipt, preparation, error
+    case schemaVersion = "schema_version"
+    case requestID = "request_id"
+  }
+}
+
+enum RepositoryQueryWorkerFailure: Error {
+  case transport(String)
+  case remote(String)
+}
+
+/// Owns one read-only Rust query process for the native app lifetime.
+///
+/// Requests are serialized so stdout remains a bounded JSON-lines protocol.
+/// Cancellation terminates only this scoped worker; the next request starts a
+/// fresh process and never accepts a partial receipt.
+final class RepositoryQueryWorker: @unchecked Sendable {
+  private let executableURL: URL
+  private let queue = DispatchQueue(label: "com.codevetter.repository-query-worker")
+  private let lock = NSLock()
+  private var process: Process?
+  private var inputHandle: FileHandle?
+  private var outputHandle: FileHandle?
+  private var errorPipe: Pipe?
+  private var errorData = Data()
+  private var outputBuffer = Data()
+  private var activeRequestID: String?
+  private var cancelledRequestIDs: Set<String> = []
+
+  init(executableURL: URL) {
+    self.executableURL = executableURL
+  }
+
+  deinit {
+    stopWorker()
+  }
+
+  func prepare(repositoryPath: String, domain: RepositoryQueryDomain) async throws -> Bool {
+    let requestID = UUID().uuidString.lowercased()
+    let request = RepositoryQueryWorkerRequest(
+      schemaVersion: repositoryQueryWorkerRequestSchema,
+      requestID: requestID,
+      operation: .prepare,
+      repoPath: repositoryPath,
+      domain: domain,
+      mode: .search,
+      query: nil,
+      target: nil,
+      direction: nil,
+      depth: nil,
+      historySelector: nil,
+      limit: nil
+    )
+    let response = try await execute(request, requestID: requestID)
+    guard let preparation = response.preparation,
+      response.receipt == nil,
+      preparation.schemaVersion == repositoryQueryPreparationSchema,
+      preparation.authority == "read_only_projection",
+      preparation.repoPath
+        == URL(fileURLWithPath: repositoryPath).resolvingSymlinksInPath().path,
+      preparation.domain == domain,
+      ["ready", "unavailable"].contains(preparation.status)
+    else {
+      throw RepositoryQueryWorkerFailure.transport(
+        "The Rust worker returned an inconsistent preparation receipt.")
+    }
+    return preparation.status == "ready"
+  }
+
+  func query(
+    repositoryPath: String,
+    domain: RepositoryQueryDomain,
+    mode: RepositoryQueryMode,
+    query: String,
+    target: String?,
+    direction: RepositoryGraphDirection?,
+    depth: Int?,
+    historySelector: RepositoryHistorySelectorKind?,
+    limit: Int
+  ) async throws -> RepositoryQueryReceipt {
+    let requestID = UUID().uuidString.lowercased()
+    let request = RepositoryQueryWorkerRequest(
+      schemaVersion: repositoryQueryWorkerRequestSchema,
+      requestID: requestID,
+      operation: .query,
+      repoPath: repositoryPath,
+      domain: domain,
+      mode: mode,
+      query: query,
+      target: target,
+      direction: direction,
+      depth: depth,
+      historySelector: historySelector,
+      limit: limit
+    )
+    let response = try await execute(request, requestID: requestID)
+    guard let receipt = response.receipt, response.preparation == nil else {
+      throw RepositoryQueryWorkerFailure.transport(
+        "The Rust worker omitted the canonical repository query receipt.")
+    }
+    return receipt
+  }
+
+  func cancelAll() {
+    lock.lock()
+    if let activeRequestID {
+      cancelledRequestIDs.insert(activeRequestID)
+    }
+    let activeProcess = process
+    let activeInput = inputHandle
+    lock.unlock()
+    interruptWorker(process: activeProcess, input: activeInput)
+  }
+
+  private func execute(
+    _ request: RepositoryQueryWorkerRequest,
+    requestID: String
+  ) async throws -> RepositoryQueryWorkerResponse {
+    try await withTaskCancellationHandler {
+      try await withCheckedThrowingContinuation { continuation in
+        queue.async { [self] in
+          guard begin(requestID) else {
+            finish(requestID)
+            continuation.resume(throwing: CancellationError())
+            return
+          }
+          do {
+            let response = try executeSynchronously(request)
+            let wasCancelled = isCancelled(requestID)
+            finish(requestID)
+            if wasCancelled {
+              throw CancellationError()
+            }
+            continuation.resume(returning: response)
+          } catch {
+            let wasCancelled = isCancelled(requestID)
+            finish(requestID)
+            if wasCancelled || error is CancellationError {
+              resetWorker(terminate: true)
+              continuation.resume(throwing: CancellationError())
+            } else {
+              continuation.resume(throwing: error)
+            }
+          }
+        }
+      }
+    } onCancel: {
+      self.cancel(requestID)
+    }
+  }
+
+  private func executeSynchronously(
+    _ request: RepositoryQueryWorkerRequest
+  ) throws -> RepositoryQueryWorkerResponse {
+    let handles = try ensureWorker()
+    do {
+      var encoded = try JSONEncoder().encode(request)
+      encoded.append(0x0A)
+      try handles.input.write(contentsOf: encoded)
+      let line = try readResponseLine(from: handles.output)
+      let response = try JSONDecoder().decode(RepositoryQueryWorkerResponse.self, from: line)
+      guard response.schemaVersion == repositoryQueryWorkerResponseSchema,
+        response.requestID == request.requestID
+      else {
+        throw RepositoryQueryWorkerFailure.transport(
+          "The Rust worker response did not match the supervised request.")
+      }
+      guard response.status == "ok" else {
+        throw RepositoryQueryWorkerFailure.remote(
+          response.error ?? "The Rust query worker rejected the request.")
+      }
+      return response
+    } catch let error as RepositoryQueryWorkerFailure {
+      if case .transport = error {
+        resetWorker(terminate: true)
+      }
+      throw error
+    } catch {
+      resetWorker(terminate: true)
+      throw RepositoryQueryWorkerFailure.transport(error.localizedDescription)
+    }
+  }
+
+  private func ensureWorker() throws -> (input: FileHandle, output: FileHandle) {
+    lock.lock()
+    if let process, process.isRunning, let inputHandle, let outputHandle {
+      lock.unlock()
+      return (inputHandle, outputHandle)
+    }
+    lock.unlock()
+
+    resetWorker(terminate: false)
+    let process = Process()
+    let inputPipe = Pipe()
+    let outputPipe = Pipe()
+    let errorPipe = Pipe()
+    process.executableURL = executableURL
+    process.arguments = ["unpack", "--operation", "query-worker", "--json"]
+    process.standardInput = inputPipe
+    process.standardOutput = outputPipe
+    process.standardError = errorPipe
+    errorPipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
+      let data = handle.availableData
+      guard !data.isEmpty, let self else { return }
+      self.lock.lock()
+      self.errorData.append(data)
+      self.lock.unlock()
+    }
+    do {
+      try process.run()
+    } catch {
+      errorPipe.fileHandleForReading.readabilityHandler = nil
+      throw RepositoryQueryWorkerFailure.transport(error.localizedDescription)
+    }
+    lock.lock()
+    self.process = process
+    inputHandle = inputPipe.fileHandleForWriting
+    outputHandle = outputPipe.fileHandleForReading
+    self.errorPipe = errorPipe
+    errorData.removeAll(keepingCapacity: true)
+    lock.unlock()
+    return (inputPipe.fileHandleForWriting, outputPipe.fileHandleForReading)
+  }
+
+  private func readResponseLine(from handle: FileHandle) throws -> Data {
+    while true {
+      if let newline = outputBuffer.firstIndex(of: 0x0A) {
+        let line = outputBuffer[..<newline]
+        outputBuffer.removeSubrange(...newline)
+        guard !line.isEmpty else {
+          throw RepositoryQueryWorkerFailure.transport("The Rust worker returned an empty line.")
+        }
+        return Data(line)
+      }
+      guard outputBuffer.count <= maximumRepositoryQueryWorkerResponseBytes else {
+        throw RepositoryQueryWorkerFailure.transport(
+          "The Rust worker response exceeded the bounded receipt size.")
+      }
+      let chunk = handle.availableData
+      guard !chunk.isEmpty else {
+        throw RepositoryQueryWorkerFailure.transport(workerExitMessage())
+      }
+      outputBuffer.append(chunk)
+    }
+  }
+
+  private func workerExitMessage() -> String {
+    lock.lock()
+    let message = String(decoding: errorData, as: UTF8.self)
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+    lock.unlock()
+    return message.isEmpty
+      ? "The Rust query worker closed before returning a receipt."
+      : message
+  }
+
+  private func begin(_ requestID: String) -> Bool {
+    lock.lock()
+    defer { lock.unlock() }
+    guard !cancelledRequestIDs.contains(requestID) else { return false }
+    activeRequestID = requestID
+    return true
+  }
+
+  private func finish(_ requestID: String) {
+    lock.lock()
+    cancelledRequestIDs.remove(requestID)
+    if activeRequestID == requestID {
+      activeRequestID = nil
+    }
+    lock.unlock()
+  }
+
+  private func isCancelled(_ requestID: String) -> Bool {
+    lock.lock()
+    defer { lock.unlock() }
+    return cancelledRequestIDs.contains(requestID)
+  }
+
+  private func cancel(_ requestID: String) {
+    lock.lock()
+    cancelledRequestIDs.insert(requestID)
+    let activeProcess = activeRequestID == requestID ? process : nil
+    let activeInput = activeRequestID == requestID ? inputHandle : nil
+    lock.unlock()
+    interruptWorker(process: activeProcess, input: activeInput)
+  }
+
+  private func interruptWorker(process: Process?, input: FileHandle?) {
+    // Closing stdin releases workers blocked in a read even when their shell
+    // does not act on Foundation's SIGTERM until that read returns.
+    try? input?.close()
+    terminateWorker(process)
+  }
+
+  private func stopWorker() {
+    resetWorker(terminate: true)
+  }
+
+  private func resetWorker(terminate: Bool) {
+    lock.lock()
+    let currentProcess = process
+    let currentInput = inputHandle
+    let currentErrorPipe = errorPipe
+    process = nil
+    inputHandle = nil
+    outputHandle = nil
+    errorPipe = nil
+    lock.unlock()
+    currentErrorPipe?.fileHandleForReading.readabilityHandler = nil
+    try? currentInput?.close()
+    if terminate {
+      terminateWorker(currentProcess)
+    }
+    outputBuffer.removeAll(keepingCapacity: true)
+  }
+
+  private func terminateWorker(_ process: Process?) {
+    guard let process, process.isRunning else { return }
+    process.terminate()
+
+    // A shell blocked in a pipe read can defer SIGTERM indefinitely. Give the
+    // exclusively owned read-only worker a short graceful window, then bound
+    // cancellation with SIGKILL so the UI and the next request cannot hang.
+    let deadline = Date().addingTimeInterval(0.2)
+    while process.isRunning && Date() < deadline {
+      Thread.sleep(forTimeInterval: 0.01)
+    }
+    if process.isRunning {
+      _ = Darwin.kill(process.processIdentifier, SIGKILL)
+    }
+  }
+}

--- a/apps/macos/CodeVetterPackage/Sources/CodeVetterFeature/Resources/capabilities.v1.json
+++ b/apps/macos/CodeVetterPackage/Sources/CodeVetterFeature/Resources/capabilities.v1.json
@@ -1,0 +1,928 @@
+{
+  "schema_version": "codevetter.capabilities.v1",
+  "authority": "codevetter-rust-core",
+  "capabilities": [
+    {
+      "id": "verification.local_check",
+      "name": "Local verification",
+      "purpose": "Bind one exact task and change to executable correctness, performance, review, and receipt evidence.",
+      "stage": "current",
+      "surfaces": {
+        "ui": {
+          "availability": "available",
+          "authority": "read_execute",
+          "entrypoints": [
+            "Tauri Review",
+            "Native Review (acceptance binding, plan, execute, findings, proof map, intent diagnostic, recorded-QA artifacts, isolated fix/recheck, source, X-Ray, export)"
+          ]
+        },
+        "cli": {
+          "availability": "available",
+          "authority": "read_execute",
+          "entrypoints": [
+            "codevetter check",
+            "codevetter fix-packet",
+            "codevetter fix",
+            "codevetter xray"
+          ]
+        },
+        "agent": {
+          "availability": "available",
+          "authority": "read_execute",
+          "entrypoints": [
+            "MCP verification_get_receipt (read-only persisted receipt)",
+            "codevetter fix through an explicit local CLI consent boundary"
+          ]
+        }
+      },
+      "underlying_tools": [
+        {
+          "name": "CodeVetter Rust core",
+          "role": "Owns planning, execution order, verdicts, and receipts",
+          "requirement": "bundled"
+        },
+        {
+          "name": "Configured coding-agent CLI",
+          "role": "Produces the model review stage",
+          "requirement": "optional local tool"
+        }
+      ],
+      "data_boundary": "Selected local repository; evidence stays on the Mac unless the configured agent provider is invoked.",
+      "qualification": "partial",
+      "limitations": [
+        "The Tauri-independent verification-command/v1 service correlates native/CLI commands, ordered progress/v2 events, request-scoped verification-cancel/v1 termination, and terminal receipts with one bounded request id.",
+        "Cancellation is supervised at the process boundary but is not yet a canonical engine event.",
+        "An unavailable runtime collector yields an explicit limitation rather than a passing claim.",
+        "Native source opening uses the recorded repository-relative path; line positioning depends on the user's default editor.",
+        "Fix execution is deliberately limited to one retained detached worktree. It never commits, merges, pushes, or modifies the selected checkout; discard requires a separate confirmation.",
+        "The repository-scoped MCP server can read one persisted canonical local-check receipt by bounded run id, but it cannot start or cancel verification. Agent execution remains an explicit local CLI consent boundary."
+      ],
+      "next_step": "Qualify a real isolated fix/recheck plus saved-flow post-fix rerun without duplicating execution authority in Review."
+    },
+    {
+      "id": "verification.runtime_preview",
+      "name": "Runtime preview verification",
+      "purpose": "Exercise changed browser behavior against an exact preview and preserve executable evidence.",
+      "stage": "current",
+      "surfaces": {
+        "ui": {
+          "availability": "available",
+          "authority": "read_execute",
+          "entrypoints": [
+            "Tauri Testing",
+            "Native Testing (secret-safe journey workspace + scope discovery + direct preview + warm + differential + scenarios + PR watcher)"
+          ]
+        },
+        "cli": {
+          "availability": "available",
+          "authority": "read_execute",
+          "entrypoints": [
+            "codevetter scope --consumer testing",
+            "codevetter trex",
+            "codevetter qa",
+            "codevetter warm",
+            "codevetter differential",
+            "codevetter scenario",
+            "codevetter watcher"
+          ]
+        },
+        "agent": {
+          "availability": "available",
+          "authority": "read",
+          "entrypoints": [
+            "MCP resolve_evidence_scope",
+            "MCP qa_workspace_inspect",
+            "MCP prepare_review verification_targets"
+          ]
+        }
+      },
+      "underlying_tools": [
+        {
+          "name": "Playwright",
+          "role": "Runs browser journeys and captures runtime evidence",
+          "requirement": "project or bundled runtime"
+        },
+        {
+          "name": "CodeVetter Rust QA workspace",
+          "role": "Owns secret-safe saved workflow projection, repository spec discovery, explicit target handoff, and deterministic post-fix comparison setup",
+          "requirement": "bundled"
+        }
+      ],
+      "data_boundary": "Selected repository and explicitly supplied preview URL. Watcher polls may contact GitHub, execute project code and a configured agent, and post commit statuses only after foreground confirmation.",
+      "qualification": "partial",
+      "limitations": [
+        "A preview must already exist for direct preview verification; warm, differential, and scenario workflows instead require one repository-owned verify script and supported lockfile.",
+        "Fixture execution is contract evidence, not production-change proof.",
+        "Native and CLI consume one codevetter.qa-workspace/v1 receipt. It imports only non-secret legacy fields into a separate native preference, discovers repository Playwright specs without execution, passes the selected route and goal into the canonical T-REX receipt, and never restores preview network consent. The scoped MCP projection is read-only.",
+        "Native and CLI scenario authoring share the incumbent Rust bridge: free/local generation creates only expiring candidates; validation and dry-run are non-persistent; acceptance is hash-bound and destination-selective. Differential evidence never creates pass evidence. Native PR watcher scheduling exists only for the current app lifetime; every foreground poll is explicitly confirmed and remains alive until new head-SHA receipts persist. The watcher fetches the immutable GitHub PR ref without changing the checkout, uses the repository-declared Node package manager, and resolves status authentication ephemerally from existing local authority. MCP target discovery remains read-only and never starts these runtimes.",
+        "One repository-owned evidence-scope fixture now passes the authoritative Rust resolver, CLI projection, native supervised runner, and real read-only MCP protocol without semantic drift.",
+        "A bounded live PR qualification proved exact-head materialization, pnpm frozen installation, repository-owned lint, conservative NEEDS_REVIEW classification, retained receipt identity, and a GitHub commit status without exposing a token."
+      ],
+      "next_step": "Qualify one real saved-flow post-fix rerun and complete owner visual acceptance while keeping MCP inspection read-only."
+    },
+    {
+      "id": "verification.performance",
+      "name": "Performance verification",
+      "purpose": "Compare bounded workloads and prevent unsupported optimization claims.",
+      "stage": "current",
+      "surfaces": {
+        "ui": {
+          "availability": "available",
+          "authority": "read_execute",
+          "entrypoints": [
+            "Tauri Performance",
+            "Native Performance (scope discovery + exact workload)"
+          ]
+        },
+        "cli": {
+          "availability": "available",
+          "authority": "read_execute",
+          "entrypoints": [
+            "codevetter scope --consumer performance",
+            "codevetter performance",
+            "codevetter check --perf-adapter"
+          ]
+        },
+        "agent": {
+          "availability": "available",
+          "authority": "read",
+          "entrypoints": [
+            "MCP resolve_evidence_scope",
+            "MCP prepare_review verification_targets"
+          ]
+        }
+      },
+      "underlying_tools": [
+        {
+          "name": "CodeVetter performance capsule",
+          "role": "Supervises samples, warmups, timeouts, and paired evidence",
+          "requirement": "bundled"
+        }
+      ],
+      "data_boundary": "Explicit local workload and optional clean baseline checkout.",
+      "qualification": "partial",
+      "limitations": [
+        "Results are workload-specific.",
+        "A missing clean baseline blocks paired-improvement claims.",
+        "Native intent/change/codebase scope resolution, digest-validated recorded-run inspection, the diagnosis-to-paired campaign handoff, and periodic owned-process-tree RSS/process evidence are available. Sampling can miss peaks between 75 ms observations.",
+        "The shared evidence-scope fixture passes Rust, CLI, native, and read-only MCP projections; only UI and CLI retain workload-execution authority.",
+        "Native release launch, steady app RSS, bridge latency, 1,000-event progress throughput, cancellation, worker crash recovery, and five large-receipt decode/render surfaces pass explicit gates."
+      ],
+      "next_step": "Refresh launch, settled RSS, responsiveness, energy, and long-session evidence on the exact current package with owner-approved foreground qualification."
+    },
+    {
+      "id": "evidence.local_usage",
+      "name": "Local agent usage",
+      "purpose": "Inspect local token, cache, cost, model, and session evidence without conflating it with cloud quota telemetry.",
+      "stage": "current",
+      "surfaces": {
+        "ui": {
+          "availability": "available",
+          "authority": "read",
+          "entrypoints": [
+            "Tauri Usage",
+            "Native Usage (ccusage plus separate indexed Devin history)"
+          ]
+        },
+        "cli": {
+          "availability": "available",
+          "authority": "read",
+          "entrypoints": [
+            "codevetter usage"
+          ]
+        },
+        "agent": {
+          "availability": "planned",
+          "authority": "none",
+          "entrypoints": []
+        }
+      },
+      "underlying_tools": [
+        {
+          "name": "ccusage 20.0.20",
+          "role": "Normalizes offline Claude, Codex, and Grok local usage logs",
+          "requirement": "bundled pinned sidecar"
+        },
+        {
+          "name": "CodeVetter Rust core",
+          "role": "Owns provider boundaries, ccusage normalization, separate SQLite Devin history, caching, and stale/unavailable states",
+          "requirement": "bundled"
+        }
+      ],
+      "data_boundary": "Local agent logs, optional read-only imported Codex roots, and indexed Devin sessions from the existing SQLite database; no provider credential or network access.",
+      "qualification": "partial",
+      "limitations": [
+        "Indexed Devin sessions, generated/cache tokens, cost, and model rows follow 1w, 30d, 90d, and all-time windows through a separate Rust projection and are never included in ccusage totals.",
+        "Live provider quotas remain separate telemetry and are never inferred from local spend.",
+        "Native 1w, 30d, 90d, and all-time selection keeps ccusage chart, totals, models, and sessions aligned while the separate Devin desk follows the same selected window."
+      ],
+      "next_step": "Migrate live provider telemetry as a credential-safe separate projection, then expose the bounded report through scoped MCP."
+    },
+    {
+      "id": "usage.history_roots",
+      "name": "Additional Codex history roots",
+      "purpose": "Restore Codex sessions stored outside the active CODEX_HOME without reading or deleting transcript content during configuration.",
+      "stage": "current",
+      "surfaces": {
+        "ui": {
+          "availability": "available",
+          "authority": "read_execute",
+          "entrypoints": [
+            "Tauri Usage settings",
+            "Native Usage settings"
+          ]
+        },
+        "cli": {
+          "availability": "available",
+          "authority": "read_execute",
+          "entrypoints": [
+            "codevetter history-roots"
+          ]
+        },
+        "agent": {
+          "availability": "unavailable",
+          "authority": "none",
+          "entrypoints": []
+        }
+      },
+      "underlying_tools": [
+        {
+          "name": "CodeVetter Rust core",
+          "role": "Owns path normalization, Codex-home validation, deduplication, the 16-root bound, SQLite preference persistence, and the versioned receipt",
+          "requirement": "bundled"
+        }
+      ],
+      "data_boundary": "Absolute local directory identities and availability metadata only; configuration never reads transcript content and removal never deletes provider files.",
+      "qualification": "qualified",
+      "limitations": [
+        "The active CODEX_HOME remains automatic and is not duplicated in the additional-root receipt.",
+        "A selected sessions or archived_sessions directory is normalized to its containing Codex home.",
+        "Reconciliation remains a separate explicit Usage action.",
+        "Agent and MCP surfaces receive no local history-root authority."
+      ],
+      "next_step": "Keep local history-root mutation out of agent authority and preserve the bounded receipt as usage importers evolve."
+    },
+    {
+      "id": "configuration.native_settings",
+      "name": "Native non-secret settings",
+      "purpose": "Read and save declared local preferences without projecting credentials or provider tokens into Swift.",
+      "stage": "building",
+      "surfaces": {
+        "ui": {
+          "availability": "building",
+          "authority": "read_execute",
+          "entrypoints": [
+            "Native Settings",
+            "Native first-run onboarding"
+          ]
+        },
+        "cli": {
+          "availability": "available",
+          "authority": "read_execute",
+          "entrypoints": [
+            "codevetter settings",
+            "codevetter onboarding"
+          ]
+        },
+        "agent": {
+          "availability": "unavailable",
+          "authority": "none",
+          "entrypoints": []
+        }
+      },
+      "underlying_tools": [
+        {
+          "name": "CodeVetter Rust core",
+          "role": "Owns the allowlist, validation, SQLite persistence, and versioned receipt",
+          "requirement": "bundled"
+        }
+      ],
+      "data_boundary": "Twenty-eight declared non-secret local preferences plus the shared onboarding completion flag and default adapter; github_token and all undeclared values are excluded from every receipt.",
+      "qualification": "partial",
+      "limitations": [
+        "Integration credentials remain in their incumbent owner until secure native storage is separately qualified.",
+        "Native onboarding reuses the incumbent completion flag, checks executable presence without inspecting authentication, and changes only the declared default adapter plus completion state.",
+        "Ops read-only aggregate status now has a bounded shared contract; credential writes, live provider refresh, and webhook operations remain with the incumbent owner.",
+        "About now reports native version and bundle identity, and Sparkle is locally packaged but remains disabled until production signing, appcast, EdDSA, and installed-upgrade gates pass."
+      ],
+      "next_step": "Prove secure native credential ownership and production updater behavior separately without widening the non-secret settings receipt."
+    },
+    {
+      "id": "operations.local_status",
+      "name": "Local operations status",
+      "purpose": "Inspect bounded local billing readiness, webhook readiness, and aggregate agent-run evidence without exposing credentials or contacting providers.",
+      "stage": "building",
+      "surfaces": {
+        "ui": {
+          "availability": "available",
+          "authority": "read",
+          "entrypoints": [
+            "Native Settings / Ops"
+          ]
+        },
+        "cli": {
+          "availability": "available",
+          "authority": "read",
+          "entrypoints": [
+            "codevetter ops"
+          ]
+        },
+        "agent": {
+          "availability": "unavailable",
+          "authority": "none",
+          "entrypoints": []
+        }
+      },
+      "underlying_tools": [
+        {
+          "name": "CodeVetter Rust core and SQLite",
+          "role": "Own the fixed time windows, configuration-presence projection, aggregate observability query, secret exclusion, and versioned receipt",
+          "requirement": "bundled"
+        }
+      ],
+      "data_boundary": "Local aggregate counts, rates, durations, and configuration-presence booleans for 7, 30, or 90 days. Credentials, webhook URLs, absolute paths, and provider responses never enter the receipt.",
+      "qualification": "partial",
+      "limitations": [
+        "This surface never refreshes live provider billing or sends a webhook.",
+        "Credential and endpoint writes remain in the incumbent settings surface.",
+        "Indexed-session success remains an explicitly labelled aggregate proxy because the stored source has no failure signal.",
+        "Agent and MCP surfaces receive no operations authority."
+      ],
+      "next_step": "Transfer credential storage and live provider or webhook operations only after a separately reviewed secure-native contract is qualified."
+    },
+    {
+      "id": "presentation.agent_island",
+      "name": "Agent Island",
+      "purpose": "Configure the optional native agent-status presentation without exposing provider content, credentials, or action authority.",
+      "stage": "building",
+      "surfaces": {
+        "ui": {
+          "availability": "building",
+          "authority": "read_execute",
+          "entrypoints": [
+            "Tauri Agent Island runtime",
+            "Native Agent Island settings"
+          ]
+        },
+        "cli": {
+          "availability": "available",
+          "authority": "read_execute",
+          "entrypoints": [
+            "codevetter settings"
+          ]
+        },
+        "agent": {
+          "availability": "unavailable",
+          "authority": "none",
+          "entrypoints": []
+        }
+      },
+      "underlying_tools": [
+        {
+          "name": "CodeVetter Rust core",
+          "role": "Owns the twelve-setting allowlist, validation, SQLite persistence, and helper runtime authority",
+          "requirement": "bundled"
+        },
+        {
+          "name": "AppKit and SwiftUI Agent Island helper",
+          "role": "Owns non-activating presentation and local system speech only",
+          "requirement": "bundled"
+        }
+      ],
+      "data_boundary": "Twelve non-secret presentation and speech preferences. Live session snapshots, prompts, output, commands, paths, provider responses, and credentials never enter the settings receipt.",
+      "qualification": "partial",
+      "limitations": [
+        "The feature remains off by default.",
+        "Native UI, CLI, and the retained helper share the exact persisted preference keys, defaults, and options.",
+        "The new Evidence Workbench stores configuration only; it does not yet launch the helper or action live agent requests.",
+        "Agent and MCP surfaces receive no Agent Island authority."
+      ],
+      "next_step": "Integrate and requalify the supervised helper in the new native host before claiming live runtime parity."
+    },
+    {
+      "id": "evidence.agent_memories",
+      "name": "Local agent memories",
+      "purpose": "Inspect bounded local agent instruction and memory sources without granting edit, deletion, credential, or agent authority.",
+      "stage": "current",
+      "surfaces": {
+        "ui": {
+          "availability": "available",
+          "authority": "read",
+          "entrypoints": [
+            "Tauri Memories",
+            "Native Memories"
+          ]
+        },
+        "cli": {
+          "availability": "available",
+          "authority": "read",
+          "entrypoints": [
+            "codevetter memories"
+          ]
+        },
+        "agent": {
+          "availability": "unavailable",
+          "authority": "none",
+          "entrypoints": []
+        }
+      },
+      "underlying_tools": [
+        {
+          "name": "CodeVetter Rust core",
+          "role": "Owns source discovery, opaque identity, canonical path admission, redaction, byte and character bounds, and Git diff supervision",
+          "requirement": "bundled"
+        }
+      ],
+      "data_boundary": "Explicitly selected local agent memory content. Receipts expose display paths rather than absolute paths and apply line-based secret redaction before content leaves Rust.",
+      "qualification": "qualified",
+      "limitations": [
+        "The source catalog is capped at 128 entries; one document is capped at 512 KiB and 120,000 output characters.",
+        "Redaction is heuristic, so displayed memory remains private operator data.",
+        "The native UI and CLI can list, read, search, copy, and inspect a redacted Git diff; neither can edit or delete a source.",
+        "MCP and agent surfaces receive no memory content or read authority."
+      ],
+      "next_step": "Preserve the read-only boundary while adding explicit source-format fixtures as new agent tools are supported."
+    },
+    {
+      "id": "maintenance.session_retention",
+      "name": "Session archive retention",
+      "purpose": "Preview and explicitly maintain CodeVetter indexed session rows without deleting provider transcripts or source sessions.",
+      "stage": "current",
+      "surfaces": {
+        "ui": {
+          "availability": "available",
+          "authority": "read_execute",
+          "entrypoints": [
+            "Tauri Usage settings",
+            "Native Usage settings"
+          ]
+        },
+        "cli": {
+          "availability": "available",
+          "authority": "read_execute",
+          "entrypoints": [
+            "codevetter retention"
+          ]
+        },
+        "agent": {
+          "availability": "unavailable",
+          "authority": "none",
+          "entrypoints": []
+        }
+      },
+      "underlying_tools": [
+        {
+          "name": "CodeVetter Rust core",
+          "role": "Owns policy validation, protected-reference discovery, stable plan identity, fail-closed apply, checkpoint, and VACUUM",
+          "requirement": "bundled"
+        }
+      ],
+      "data_boundary": "Local CodeVetter archive and FTS rows only; provider transcripts, source sessions, and protected references are retained.",
+      "qualification": "qualified",
+      "limitations": [
+        "Preview persists a plan receipt but deletes no archive rows.",
+        "Apply and VACUUM require explicit UI or CLI authority and are intentionally not exposed to agents."
+      ],
+      "next_step": "Keep destructive maintenance out of agent authority; add separate read-only recovery diagnostics when the history-root transfer is implemented."
+    },
+    {
+      "id": "configuration.review_rubrics",
+      "name": "Review rubric packs",
+      "purpose": "Keep the exact review standards, active selection, prompt context, and usage attribution consistent across product and agent surfaces.",
+      "stage": "current",
+      "surfaces": {
+        "ui": {
+          "availability": "available",
+          "authority": "read_execute",
+          "entrypoints": [
+            "Tauri Rubrics",
+            "Native Rubrics"
+          ]
+        },
+        "cli": {
+          "availability": "available",
+          "authority": "read_execute",
+          "entrypoints": [
+            "codevetter rubrics",
+            "codevetter check"
+          ]
+        },
+        "agent": {
+          "availability": "available",
+          "authority": "read_execute",
+          "entrypoints": [
+            "codevetter check",
+            "codevetter rubrics"
+          ]
+        }
+      },
+      "underlying_tools": [
+        {
+          "name": "CodeVetter Rust core",
+          "role": "Owns built-in definitions, validation, active selection, custom packs, usage attribution, and exact prompt rendering",
+          "requirement": "bundled"
+        }
+      ],
+      "data_boundary": "Non-secret rubric definitions and local review-attribution counts; no provider credentials or review evidence content.",
+      "qualification": "partial",
+      "limitations": [
+        "The incumbent Tauri shell attempts the bounded WebView-local migration on every startup until Rust owns a canonical preference; opening Rubrics also retries and reports sync errors.",
+        "Built-in packs are immutable; custom packs can be created or replaced within declared bounds."
+      ],
+      "next_step": "Qualify the startup bridge against an installed upgrade with custom packs before retiring the Tauri rubric owner."
+    },
+    {
+      "id": "machine.repository_mcp",
+      "name": "Repository-scoped MCP",
+      "purpose": "Expose bounded local history, graph, archaeology, and review-preparation context to agents without granting file-write or provider authority.",
+      "stage": "current",
+      "surfaces": {
+        "ui": {
+          "availability": "available",
+          "authority": "read_execute",
+          "entrypoints": [
+            "Tauri Agent MCP",
+            "Native Agent MCP"
+          ]
+        },
+        "cli": {
+          "availability": "available",
+          "authority": "read_execute",
+          "entrypoints": [
+            "codevetter mcp"
+          ]
+        },
+        "agent": {
+          "availability": "available",
+          "authority": "read",
+          "entrypoints": [
+            "codevetter-mcp stdio server"
+          ]
+        }
+      },
+      "underlying_tools": [
+        {
+          "name": "CodeVetter MCP server",
+          "role": "Serves repository-scoped resources and tools over local stdio",
+          "requirement": "bundled companion executable"
+        },
+        {
+          "name": "CodeVetter Rust core",
+          "role": "Owns scope enablement, redaction, limits, audit metadata, and client configuration",
+          "requirement": "bundled"
+        }
+      ],
+      "data_boundary": "One explicitly selected, history-indexed local repository; operational audit rows never store arguments, prompts, queries, credentials, or evidence content.",
+      "qualification": "partial",
+      "limitations": [
+        "Enabling requires an existing release-history index.",
+        "The server uses local stdio only and cannot write files, refresh indexes, call providers, or listen on the network.",
+        "The native local package gate bundles and smokes codevetter-mcp beside the app; Developer ID and notarized archive proof remain release gates."
+      ],
+      "next_step": "Add scoped MCP projections for remaining non-local-check receipt families and repeat companion qualification in the notarized production archive."
+    },
+    {
+      "id": "evidence.tool_collectors",
+      "name": "External evidence collectors",
+      "purpose": "Attach narrowly scoped security and coverage receipts without treating tool presence as proof.",
+      "stage": "current",
+      "surfaces": {
+        "ui": {
+          "availability": "planned",
+          "authority": "none",
+          "entrypoints": []
+        },
+        "cli": {
+          "availability": "available",
+          "authority": "read_execute",
+          "entrypoints": [
+            "codevetter collect"
+          ]
+        },
+        "agent": {
+          "availability": "unavailable",
+          "authority": "none",
+          "entrypoints": []
+        }
+      },
+      "underlying_tools": [
+        {
+          "name": "Gitleaks",
+          "role": "Scans the selected change for secret exposure",
+          "requirement": "optional local tool"
+        },
+        {
+          "name": "cargo-audit",
+          "role": "Checks Rust advisories using available local data",
+          "requirement": "optional local tool"
+        },
+        {
+          "name": "cargo-llvm-cov",
+          "role": "Captures Rust coverage evidence",
+          "requirement": "optional local tool"
+        }
+      ],
+      "data_boundary": "Explicit change range in the selected local repository; collectors receive only their declared inputs.",
+      "qualification": "partial",
+      "limitations": [
+        "The native glossary reports declared collectors and limitations but does not execute them.",
+        "Collectors are not installed or network-enabled automatically.",
+        "Unavailable offline data keeps the claim closed."
+      ],
+      "next_step": "Add bounded collector receipt inspection to the native UI and scoped MCP without granting either surface collector-execution authority."
+    },
+    {
+      "id": "repository.snapshot_scan",
+      "name": "Deterministic repository snapshot",
+      "purpose": "Create and inspect one local, bounded source, history, health, and topology snapshot without invoking a model.",
+      "stage": "current",
+      "surfaces": {
+        "ui": {
+          "availability": "available",
+          "authority": "read_execute",
+          "entrypoints": [
+            "Tauri Repo Unpack",
+            "Native Repo Unpack (scan + bounded inspectors)"
+          ]
+        },
+        "cli": {
+          "availability": "available",
+          "authority": "read_execute",
+          "entrypoints": [
+            "codevetter unpack --operation scan",
+            "codevetter unpack --operation inspect"
+          ]
+        },
+        "agent": {
+          "availability": "available",
+          "authority": "read",
+          "entrypoints": [
+            "MCP graph and history tools over an explicitly enabled stored index"
+          ]
+        }
+      },
+      "underlying_tools": [
+        {
+          "name": "CodeVetter Rust core",
+          "role": "Owns the deterministic scan, bounded projection, persistence, and receipt",
+          "requirement": "bundled"
+        },
+        {
+          "name": "Git",
+          "role": "Supplies local revision and bounded history evidence when available",
+          "requirement": "optional local tool"
+        },
+        {
+          "name": "rusqlite",
+          "role": "Persists the canonical local snapshot",
+          "requirement": "bundled"
+        }
+      ],
+      "data_boundary": "One explicitly selected local directory and the local SQLite evidence store; the scan does not call a provider or require network access.",
+      "qualification": "partial",
+      "limitations": [
+        "The client receipt omits the raw full-file list while the bounded canonical snapshot remains local.",
+        "Topology, history, and deterministic health are navigation evidence, not executable verification.",
+        "Native model synthesis execution and cleanup remain migration gaps."
+      ],
+      "next_step": "Migrate the remaining synthesis and cleanup workflows while keeping every Rust receipt authoritative."
+    },
+    {
+      "id": "repository.structural_graph",
+      "name": "Structural repository graph",
+      "purpose": "Navigate source-backed symbols, relationships, impact, and history without presenting topology as runtime proof.",
+      "stage": "current",
+      "surfaces": {
+        "ui": {
+          "availability": "available",
+          "authority": "read",
+          "entrypoints": [
+            "Tauri Repo Unpack",
+            "Native Repo Unpack (bounded snapshot + canonical query desk)"
+          ]
+        },
+        "cli": {
+          "availability": "available",
+          "authority": "read",
+          "entrypoints": [
+            "codevetter unpack --operation query --query-domain graph --query-mode search|explain|impact|path",
+            "codevetter-graph"
+          ]
+        },
+        "agent": {
+          "availability": "available",
+          "authority": "read",
+          "entrypoints": [
+            "graph_query",
+            "graph_impact",
+            "graph_path"
+          ]
+        }
+      },
+      "underlying_tools": [
+        {
+          "name": "Tree-sitter",
+          "role": "Extracts syntax-aware source identities across the qualified language set",
+          "requirement": "bundled"
+        }
+      ],
+      "data_boundary": "Selected local repository and its local SQLite evidence store.",
+      "qualification": "qualified",
+      "limitations": [
+        "Graph relationships are navigation evidence, not executable verification.",
+        "Native search, node explanation, impact, and directed path stay bounded and fail closed when the canonical structural index is unavailable.",
+        "Native retains one read-only search projection per worker, upgrades it in place with compact traversal edges only when required, hydrates bounded result evidence, rechecks live Git freshness and latest snapshot identity on every query, and falls back to the exact supervised one-shot CLI contract when the worker transport is unavailable."
+      ],
+      "next_step": "Add source-opening and richer graph filtering without moving ranking or traversal semantics into Swift."
+    },
+    {
+      "id": "repository.history",
+      "name": "Evidence-backed repository history",
+      "purpose": "Explain bounded historical state and lineage using stable evidence identities and explicit gaps.",
+      "stage": "current",
+      "surfaces": {
+        "ui": {
+          "availability": "available",
+          "authority": "read",
+          "entrypoints": [
+            "Tauri Repo Unpack",
+            "Native Repo Unpack (bounded snapshot + canonical query desk)"
+          ]
+        },
+        "cli": {
+          "availability": "available",
+          "authority": "read",
+          "entrypoints": [
+            "codevetter unpack --operation query --query-domain history --query-mode search|trace"
+          ]
+        },
+        "agent": {
+          "availability": "available",
+          "authority": "read",
+          "entrypoints": [
+            "history_search",
+            "history_explain",
+            "history_trace"
+          ]
+        }
+      },
+      "underlying_tools": [
+        {
+          "name": "Git",
+          "role": "Supplies exact local revision and tag identity",
+          "requirement": "required local tool"
+        }
+      ],
+      "data_boundary": "Authorized repository scope and read-only local SQLite evidence.",
+      "qualification": "qualified",
+      "limitations": [
+        "Explanations remain bounded by indexed evidence and disclose missing causal proof.",
+        "Native history search and causal trace share the canonical Rust index, preserve evidenced versus qualified-lead links, and fail closed when temporal coverage is unavailable.",
+        "Repeated native history queries reuse the same scoped read-only worker and preserve the exact one-shot CLI fallback."
+      ],
+      "next_step": "Add native source lineage without duplicating temporal semantics in Swift."
+    },
+    {
+      "id": "native.evidence_workbench",
+      "name": "Native Evidence Workbench",
+      "purpose": "Provide a fast, accessible macOS operating surface over the canonical Rust verification loop.",
+      "stage": "building",
+      "surfaces": {
+        "ui": {
+          "availability": "building",
+          "authority": "read_execute",
+          "entrypoints": [
+            "apps/macos"
+          ]
+        },
+        "cli": {
+          "availability": "unavailable",
+          "authority": "none",
+          "entrypoints": []
+        },
+        "agent": {
+          "availability": "unavailable",
+          "authority": "none",
+          "entrypoints": []
+        }
+      },
+      "underlying_tools": [
+        {
+          "name": "AppKit",
+          "role": "Owns windows, menus, split views, keyboard behavior, and lifecycle",
+          "requirement": "Apple platform"
+        },
+        {
+          "name": "SwiftUI",
+          "role": "Composes feature, inspector, and settings views",
+          "requirement": "Apple platform"
+        },
+        {
+          "name": "CodeVetter Rust core",
+          "role": "Owns verification execution, persistence, verdicts, and canonical receipts",
+          "requirement": "bundled CLI and MCP companions"
+        },
+        {
+          "name": "Sparkle 2.9.6",
+          "role": "Owns signed update discovery, installation, and relaunch after production configuration",
+          "requirement": "exact Swift package; disabled in preview"
+        },
+        {
+          "name": "XcodeBuildMCP 2.7.0",
+          "role": "Provides reproducible project build and test automation",
+          "requirement": "development only"
+        }
+      ],
+      "data_boundary": "User-selected local repositories; no ambient credential authority. Sparkle remains inactive unless a production HTTPS appcast and EdDSA public key are present.",
+      "qualification": "partial",
+      "limitations": [
+        "The native client does not replace Tauri until feature, output, performance, accessibility, visual, installed-upgrade, and owner gates pass.",
+        "The local package is hardened, non-sandboxed, and ad-hoc signed; Developer ID signing, notarization, production updater inputs, and rollback proof remain open."
+      ],
+      "next_step": "Close retained feature and owner-interaction gaps, refresh exact-package performance with owner-approved foreground qualification, then qualify a notarized installed upgrade before the owner retirement decision."
+    },
+    {
+      "id": "evidence.local_runs",
+      "name": "Verification run ledger",
+      "purpose": "Inspect one bounded chronology of local-check, preview, T-Rex PR, synthetic QA, warm, differential, and audience evidence without rewriting originating receipts.",
+      "stage": "building",
+      "surfaces": {
+        "ui": {
+          "availability": "building",
+          "authority": "read",
+          "entrypoints": [
+            "Native Runs (building)"
+          ]
+        },
+        "cli": {
+          "availability": "available",
+          "authority": "read",
+          "entrypoints": [
+            "codevetter runs"
+          ]
+        },
+        "agent": {
+          "availability": "unavailable",
+          "authority": "none",
+          "entrypoints": []
+        }
+      },
+      "underlying_tools": [
+        {
+          "name": "CodeVetter Rust core",
+          "role": "Owns receipt schemas and persistence",
+          "requirement": "bundled"
+        },
+        {
+          "name": "rusqlite",
+          "role": "Stores complete canonical receipts in the existing local database",
+          "requirement": "bundled"
+        }
+      ],
+      "data_boundary": "Local SQLite database; list results are bounded to at most 100 receipts.",
+      "qualification": "partial",
+      "limitations": [
+        "The ledger is read-only; watcher, QA, and audience workflow controls remain on their originating surfaces until those workspaces migrate.",
+        "The Swift host-render gate excludes window-server frame pacing and interactive scrolling.",
+        "Foreground XCUITest and owner interaction acceptance remain open."
+      ],
+      "next_step": "Complete foreground UI automation and owner interaction acceptance, then use the ledger as shared evidence infrastructure for Testing and Performance."
+    },
+    {
+      "id": "runtime.hardened_isolation",
+      "name": "Hardened execution isolation",
+      "purpose": "Run untrusted project checks with stronger process, filesystem, resource, and network containment.",
+      "stage": "future",
+      "surfaces": {
+        "ui": {
+          "availability": "planned",
+          "authority": "none",
+          "entrypoints": []
+        },
+        "cli": {
+          "availability": "planned",
+          "authority": "none",
+          "entrypoints": []
+        },
+        "agent": {
+          "availability": "planned",
+          "authority": "none",
+          "entrypoints": []
+        }
+      },
+      "underlying_tools": [
+        {
+          "name": "Apple Containerization or measured alternative",
+          "role": "Candidate containment boundary",
+          "requirement": "not selected"
+        }
+      ],
+      "data_boundary": "Not yet defined; no isolation claim is made.",
+      "qualification": "unqualified",
+      "limitations": [
+        "No production isolation backend has passed the runtime and compatibility gates."
+      ],
+      "next_step": "Benchmark candidates against real CodeVetter workloads before selecting a dependency."
+    }
+  ]
+}

--- a/apps/macos/CodeVetterPackage/Sources/CodeVetterFeature/SettingsModels.swift
+++ b/apps/macos/CodeVetterPackage/Sources/CodeVetterFeature/SettingsModels.swift
@@ -1,0 +1,477 @@
+import Foundation
+
+public enum OnboardingOperation: String, Codable, Sendable {
+  case inspect
+  case complete
+}
+
+public struct OnboardingToolStatus: Codable, Identifiable, Sendable {
+  public let id: String
+  public let label: String
+  public let available: Bool
+  public let role: String
+  public let authentication: String
+}
+
+public struct OnboardingReceipt: Codable, Sendable {
+  public let schemaVersion: String
+  public let generatedAt: String
+  public let operation: OnboardingOperation
+  public let completed: Bool
+  public let completionSource: String
+  public let defaultAdapter: String
+  public let tools: [OnboardingToolStatus]
+  public let limitations: [String]
+
+  enum CodingKeys: String, CodingKey {
+    case operation, completed, tools, limitations
+    case schemaVersion = "schema_version"
+    case generatedAt = "generated_at"
+    case completionSource = "completion_source"
+    case defaultAdapter = "default_adapter"
+  }
+}
+
+public enum NativeSettingKind: String, Codable, Sendable {
+  case toggle
+  case choice
+  case text
+}
+
+public struct NativeSettingOption: Codable, Identifiable, Sendable {
+  public let value: String
+  public let label: String
+  public var id: String { value }
+}
+
+public struct NativeSettingValue: Codable, Identifiable, Sendable {
+  public let key: String
+  public let section: String
+  public let label: String
+  public let description: String
+  public let kind: NativeSettingKind
+  public let value: String
+  public let defaultValue: String
+  public let options: [NativeSettingOption]
+  public var id: String { key }
+
+  enum CodingKeys: String, CodingKey {
+    case key, section, label, description, kind, value, options
+    case defaultValue = "default_value"
+  }
+}
+
+public struct NativeSettingsReceipt: Codable, Sendable {
+  public let schemaVersion: String
+  public let generatedAt: String
+  public let databaseAvailable: Bool
+  public let savedKey: String?
+  public let settings: [NativeSettingValue]
+  public let excludedSensitiveKeys: [String]
+
+  enum CodingKeys: String, CodingKey {
+    case settings
+    case schemaVersion = "schema_version"
+    case generatedAt = "generated_at"
+    case databaseAvailable = "database_available"
+    case savedKey = "saved_key"
+    case excludedSensitiveKeys = "excluded_sensitive_keys"
+  }
+}
+
+public enum HistoryRootsOperation: String, Codable, Equatable, Sendable {
+  case read
+  case add
+  case remove
+}
+
+public struct HistoryRoot: Codable, Identifiable, Sendable {
+  public let path: String
+  public let displayPath: String
+  public let exists: Bool
+  public let sessionsAvailable: Bool
+  public let archivedSessionsAvailable: Bool
+
+  public var id: String { path }
+
+  enum CodingKeys: String, CodingKey {
+    case path, exists
+    case displayPath = "display_path"
+    case sessionsAvailable = "sessions_available"
+    case archivedSessionsAvailable = "archived_sessions_available"
+  }
+}
+
+public struct HistoryRootsReceipt: Codable, Sendable {
+  public let schemaVersion: String
+  public let generatedAt: String
+  public let operation: HistoryRootsOperation
+  public let databaseAvailable: Bool
+  public let changedRoot: String?
+  public let roots: [HistoryRoot]
+  public let limitations: [String]
+
+  enum CodingKeys: String, CodingKey {
+    case operation, roots, limitations
+    case schemaVersion = "schema_version"
+    case generatedAt = "generated_at"
+    case databaseAvailable = "database_available"
+    case changedRoot = "changed_root"
+  }
+}
+
+public enum SessionRetentionOperation: String, Codable, Equatable, Sendable {
+  case plan
+  case apply
+  case checkpoint
+}
+
+public struct SessionRetentionPolicy: Codable, Sendable {
+  public let maxAgeDays: Int64?
+  public let maxArchiveBytes: Int64?
+
+  enum CodingKeys: String, CodingKey {
+    case maxAgeDays = "maxAgeDays"
+    case maxArchiveBytes = "maxArchiveBytes"
+  }
+}
+
+public struct SessionRetentionEntry: Codable, Identifiable, Sendable {
+  public let sessionID: String
+  public let rows: Int64
+  public let estimatedBytes: Int64
+  public let lastActivity: String
+  public let reasons: [String]
+
+  public var id: String { sessionID }
+
+  enum CodingKeys: String, CodingKey {
+    case rows, reasons
+    case sessionID = "sessionId"
+    case estimatedBytes = "estimatedBytes"
+    case lastActivity = "lastActivity"
+  }
+}
+
+public struct SessionRetentionPlan: Codable, Identifiable, Sendable {
+  public let id: String
+  public let planIdentity: String
+  public let archiveFingerprint: String
+  public let policy: SessionRetentionPolicy
+  public let archiveRows: Int64
+  public let archiveBytes: Int64
+  public let candidateRows: Int64
+  public let candidateBytes: Int64
+  public let candidates: [SessionRetentionEntry]
+  public let protected: [SessionRetentionEntry]
+  public let projectedRows: Int64
+  public let projectedBytes: Int64
+  public let createdAt: String
+}
+
+public struct SessionRetentionReceipt: Codable, Sendable {
+  public let schemaVersion: String
+  public let generatedAt: String
+  public let operation: SessionRetentionOperation
+  public let plan: SessionRetentionPlan?
+  public let result: PerformanceJSONValue?
+
+  enum CodingKeys: String, CodingKey {
+    case operation, plan, result
+    case schemaVersion = "schema_version"
+    case generatedAt = "generated_at"
+  }
+}
+
+public enum RubricSettingsOperation: String, Codable, Equatable, Sendable {
+  case read
+  case select
+  case upsert
+}
+
+public struct RubricPackInput: Sendable {
+  public let id: String
+  public let name: String
+  public let focus: String
+  public let checks: [String]
+}
+
+public struct RubricPackReceipt: Codable, Identifiable, Sendable {
+  public let id: String
+  public let name: String
+  public let focus: String
+  public let checks: [String]
+  public let builtIn: Bool
+  public let active: Bool
+  public let reviewCount: Int64
+  public let totalFindings: Int64
+  public let promptPreview: String
+
+  enum CodingKeys: String, CodingKey {
+    case id, name, focus, checks, active
+    case builtIn = "built_in"
+    case reviewCount = "review_count"
+    case totalFindings = "total_findings"
+    case promptPreview = "prompt_preview"
+  }
+}
+
+public struct RubricSettingsReceipt: Codable, Sendable {
+  public let schemaVersion: String
+  public let generatedAt: String
+  public let operation: RubricSettingsOperation
+  public let activePackID: String?
+  public let customRules: [String]
+  public let packs: [RubricPackReceipt]
+  public let savedPackID: String?
+  public let migratedLegacyConfig: Bool
+
+  enum CodingKeys: String, CodingKey {
+    case operation, packs
+    case schemaVersion = "schema_version"
+    case generatedAt = "generated_at"
+    case activePackID = "active_pack_id"
+    case customRules = "custom_rules"
+    case savedPackID = "saved_pack_id"
+    case migratedLegacyConfig = "migrated_legacy_config"
+  }
+}
+
+public enum MemoryReceiptOperation: String, Codable, Equatable, Sendable {
+  case list
+  case read
+  case diff
+}
+
+public struct MemorySourceReceipt: Codable, Identifiable, Sendable {
+  public let id: String
+  public let tool: String
+  public let label: String
+  public let displayPath: String
+  public let exists: Bool
+  public let readable: Bool
+  public let fileSizeBytes: UInt64?
+  public let modifiedAt: String?
+  public let sourceKind: String
+  public let preview: String
+  public let note: String
+
+  enum CodingKeys: String, CodingKey {
+    case id, tool, label, exists, readable, preview, note
+    case displayPath = "display_path"
+    case fileSizeBytes = "file_size_bytes"
+    case modifiedAt = "modified_at"
+    case sourceKind = "source_kind"
+  }
+}
+
+public struct MemoryDocumentReceipt: Codable, Sendable {
+  public let sourceID: String
+  public let content: String
+  public let truncated: Bool
+  public let extractionNote: String
+
+  enum CodingKeys: String, CodingKey {
+    case content, truncated
+    case sourceID = "source_id"
+    case extractionNote = "extraction_note"
+  }
+}
+
+public struct MemoryDiffReceipt: Codable, Sendable {
+  public let sourceID: String
+  public let hasChanges: Bool
+  public let status: String
+  public let diff: String
+
+  enum CodingKeys: String, CodingKey {
+    case status, diff
+    case sourceID = "source_id"
+    case hasChanges = "has_changes"
+  }
+}
+
+public struct MemoryReceiptLimits: Codable, Sendable {
+  public let maxSources: Int
+  public let maxReadBytes: UInt64
+  public let maxOutputChars: Int
+  public let sourcesTruncated: Bool
+
+  enum CodingKeys: String, CodingKey {
+    case maxSources = "max_sources"
+    case maxReadBytes = "max_read_bytes"
+    case maxOutputChars = "max_output_chars"
+    case sourcesTruncated = "sources_truncated"
+  }
+}
+
+public struct MemoryReceipt: Codable, Sendable {
+  public let schemaVersion: String
+  public let generatedAt: String
+  public let operation: MemoryReceiptOperation
+  public let selectedSourceID: String?
+  public let candidateLocationsChecked: Int
+  public let sourcesTotal: Int
+  public let sources: [MemorySourceReceipt]
+  public let document: MemoryDocumentReceipt?
+  public let diff: MemoryDiffReceipt?
+  public let limits: MemoryReceiptLimits
+  public let limitations: [String]
+
+  enum CodingKeys: String, CodingKey {
+    case operation, sources, document, diff, limits, limitations
+    case schemaVersion = "schema_version"
+    case generatedAt = "generated_at"
+    case selectedSourceID = "selected_source_id"
+    case candidateLocationsChecked = "candidate_locations_checked"
+    case sourcesTotal = "sources_total"
+  }
+}
+
+public enum NativeSettingsSection: String, CaseIterable, Identifiable, Sendable {
+  case general
+  case appearance
+  case integrations
+  case agents
+  case agentIsland = "agent_island"
+  case mcp
+  case notifications
+  case usage
+  case rubrics
+  case ops
+  case memories
+  case about
+
+  public var id: String { rawValue }
+
+  public var label: String {
+    switch self {
+    case .general: "General"
+    case .appearance: "Appearance"
+    case .integrations: "Integrations"
+    case .agents: "Agents"
+    case .agentIsland: "Agent Island"
+    case .mcp: "Agent MCP"
+    case .notifications: "Notifications"
+    case .usage: "Usage"
+    case .rubrics: "Rubrics"
+    case .ops: "Ops"
+    case .memories: "Memories"
+    case .about: "About"
+    }
+  }
+
+  public var systemImage: String {
+    switch self {
+    case .general: "slider.horizontal.3"
+    case .appearance: "circle.lefthalf.filled"
+    case .integrations: "point.3.connected.trianglepath.dotted"
+    case .agents: "terminal"
+    case .agentIsland: "rectangle.topthird.inset.filled"
+    case .mcp: "arrow.trianglehead.branch"
+    case .notifications: "bell"
+    case .usage: "chart.bar"
+    case .rubrics: "checklist"
+    case .ops: "bolt"
+    case .memories: "memorychip"
+    case .about: "info.circle"
+    }
+  }
+}
+
+public enum McpSettingsOperation: String, Codable, Equatable, Sendable {
+  case read
+  case enable
+  case disable
+  case clearAudit = "clear_audit"
+
+  public var cliFlag: String? {
+    switch self {
+    case .read: nil
+    case .enable: "--enable"
+    case .disable: "--disable"
+    case .clearAudit: "--clear-audit"
+    }
+  }
+}
+
+public struct McpAuditEntry: Codable, Identifiable, Sendable {
+  public let id: Int64
+  public let repoID: String
+  public let serverSession: String
+  public let operation: String
+  public let status: String
+  public let durationMS: UInt64
+  public let resultCount: Int
+  public let responseBytes: Int
+  public let createdAt: String
+
+  enum CodingKeys: String, CodingKey {
+    case id, operation, status
+    case repoID = "repo_id"
+    case serverSession = "server_session"
+    case durationMS = "duration_ms"
+    case resultCount = "result_count"
+    case responseBytes = "response_bytes"
+    case createdAt = "created_at"
+  }
+}
+
+public struct McpRepositorySettings: Codable, Sendable {
+  public let repoID: String?
+  public let enabled: Bool
+  public let indexed: Bool
+  public let indexedHead: String?
+  public let currentHead: String?
+  public let stale: Bool
+  public let serverPath: String
+  public let clientConfig: PerformanceJSONValue?
+  public let resourceKinds: [String]
+  public let toolNames: [String]
+  public let redactionRules: [String]
+  public let limits: PerformanceJSONValue
+  public let recentAudit: [McpAuditEntry]
+
+  enum CodingKeys: String, CodingKey {
+    case enabled, indexed, stale, limits
+    case repoID = "repo_id"
+    case indexedHead = "indexed_head"
+    case currentHead = "current_head"
+    case serverPath = "server_path"
+    case clientConfig = "client_config"
+    case resourceKinds = "resource_kinds"
+    case toolNames = "tool_names"
+    case redactionRules = "redaction_rules"
+    case recentAudit = "recent_audit"
+  }
+
+  public var clientConfigJSON: String? {
+    guard let clientConfig,
+      let data = try? JSONEncoder.prettySorted.encode(clientConfig)
+    else { return nil }
+    return String(data: data, encoding: .utf8)
+  }
+}
+
+public struct McpSettingsReceipt: Codable, Sendable {
+  public let schemaVersion: String
+  public let generatedAt: String
+  public let operation: McpSettingsOperation
+  public let clearedAuditRows: Int
+  public let settings: McpRepositorySettings
+
+  enum CodingKeys: String, CodingKey {
+    case operation, settings
+    case schemaVersion = "schema_version"
+    case generatedAt = "generated_at"
+    case clearedAuditRows = "cleared_audit_rows"
+  }
+}
+
+extension JSONEncoder {
+  fileprivate static var prettySorted: JSONEncoder {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+    return encoder
+  }
+}

--- a/apps/macos/CodeVetterPackage/Sources/CodeVetterFeature/UsageModels.swift
+++ b/apps/macos/CodeVetterPackage/Sources/CodeVetterFeature/UsageModels.swift
@@ -1,0 +1,372 @@
+import Foundation
+
+public enum LocalUsageStatus: String, Codable, Sendable {
+  case ready
+  case stale
+  case unavailable
+}
+
+public enum UsageScale: String, CaseIterable, Identifiable, Sendable {
+  case day = "Day"
+  case week = "Week"
+  case month = "Month"
+
+  public var id: String { rawValue }
+}
+
+public enum UsageWindow: String, CaseIterable, Identifiable, Sendable {
+  case oneWeek = "1w"
+  case thirtyDays = "30d"
+  case ninetyDays = "90d"
+  case allTime = "All"
+
+  public var id: String { rawValue }
+
+  fileprivate var dayCount: Int? {
+    switch self {
+    case .oneWeek: 7
+    case .thirtyDays: 30
+    case .ninetyDays: 90
+    case .allTime: nil
+    }
+  }
+
+  public var description: String {
+    switch self {
+    case .oneWeek: "last week"
+    case .thirtyDays: "last 30 days"
+    case .ninetyDays: "last 90 days"
+    case .allTime: "all time"
+    }
+  }
+
+  var receiptKey: String {
+    switch self {
+    case .oneWeek: "1w"
+    case .thirtyDays: "30d"
+    case .ninetyDays: "90d"
+    case .allTime: "all"
+    }
+  }
+}
+
+public struct LocalUsageTotals: Codable, Equatable, Sendable {
+  public let inputTokens: UInt64
+  public let cacheCreationTokens: UInt64
+  public let cacheReadTokens: UInt64
+  public let outputTokens: UInt64
+  public let totalTokens: UInt64
+  public let costUSD: Double
+
+  enum CodingKeys: String, CodingKey {
+    case inputTokens = "input_tokens"
+    case cacheCreationTokens = "cache_creation_tokens"
+    case cacheReadTokens = "cache_read_tokens"
+    case outputTokens = "output_tokens"
+    case totalTokens = "total_tokens"
+    case costUSD = "cost_usd"
+  }
+
+  public static let zero = LocalUsageTotals(
+    inputTokens: 0,
+    cacheCreationTokens: 0,
+    cacheReadTokens: 0,
+    outputTokens: 0,
+    totalTokens: 0,
+    costUSD: 0
+  )
+
+  public init(
+    inputTokens: UInt64,
+    cacheCreationTokens: UInt64,
+    cacheReadTokens: UInt64,
+    outputTokens: UInt64,
+    totalTokens: UInt64,
+    costUSD: Double
+  ) {
+    self.inputTokens = inputTokens
+    self.cacheCreationTokens = cacheCreationTokens
+    self.cacheReadTokens = cacheReadTokens
+    self.outputTokens = outputTokens
+    self.totalTokens = totalTokens
+    self.costUSD = costUSD
+  }
+
+  public var generatedTokens: UInt64 {
+    inputTokens &+ cacheCreationTokens &+ outputTokens
+  }
+
+  public func adding(_ other: LocalUsageTotals) -> LocalUsageTotals {
+    LocalUsageTotals(
+      inputTokens: inputTokens &+ other.inputTokens,
+      cacheCreationTokens: cacheCreationTokens &+ other.cacheCreationTokens,
+      cacheReadTokens: cacheReadTokens &+ other.cacheReadTokens,
+      outputTokens: outputTokens &+ other.outputTokens,
+      totalTokens: totalTokens &+ other.totalTokens,
+      costUSD: costUSD + other.costUSD
+    )
+  }
+}
+
+public struct LocalUsageModel: Codable, Identifiable, Sendable {
+  public let model: String
+  public let totals: LocalUsageTotals
+  public let fallback: Bool
+  public let priced: Bool
+
+  public var id: String { model }
+}
+
+public struct LocalUsageAgent: Codable, Identifiable, Sendable {
+  public let agent: String
+  public let totals: LocalUsageTotals
+  public let models: [LocalUsageModel]
+
+  public var id: String { agent }
+}
+
+public struct LocalUsagePeriod: Codable, Identifiable, Sendable {
+  public let period: String
+  public let totals: LocalUsageTotals
+  public let agents: [LocalUsageAgent]
+  public let models: [LocalUsageModel]
+
+  public var id: String { period }
+
+  public func totals(for selectedAgents: Set<String>) -> LocalUsageTotals {
+    guard !selectedAgents.isEmpty else { return totals }
+    return agents.lazy
+      .filter { selectedAgents.contains($0.agent) }
+      .reduce(.zero) { $0.adding($1.totals) }
+  }
+}
+
+public struct LocalUsageSession: Codable, Identifiable, Sendable {
+  public let sessionID: String
+  public let agent: String
+  public let lastActivity: String?
+  public let reasoningOutputTokens: UInt64
+  public let totals: LocalUsageTotals
+  public let models: [LocalUsageModel]
+
+  public var id: String { "\(agent)\u{0}\(sessionID)" }
+
+  enum CodingKeys: String, CodingKey {
+    case agent, totals, models
+    case sessionID = "session_id"
+    case lastActivity = "last_activity"
+    case reasoningOutputTokens = "reasoning_output_tokens"
+  }
+}
+
+public struct LocalUsageProvenance: Codable, Sendable {
+  public let engine: String
+  public let version: String
+  public let generatedAt: String
+  public let timezone: String
+  public let window: String
+  public let detectedAgents: [String]
+  public let excludedAgents: [String]
+  public let codexRoots: [String]
+  public let sourceFingerprint: String
+  public let pricingComplete: Bool
+  public let fallbackModels: [String]
+  public let unpricedModels: [String]
+
+  enum CodingKeys: String, CodingKey {
+    case engine, version, window
+    case generatedAt = "generated_at"
+    case detectedAgents = "detected_agents"
+    case excludedAgents = "excluded_agents"
+    case codexRoots = "codex_roots"
+    case sourceFingerprint = "source_fingerprint"
+    case pricingComplete = "pricing_complete"
+    case fallbackModels = "fallback_models"
+    case unpricedModels = "unpriced_models"
+    case timezone
+  }
+}
+
+public struct LocalUsageFailure: Codable, Sendable {
+  public let category: String
+  public let message: String
+}
+
+public struct DevinUsageModel: Codable, Identifiable, Sendable {
+  public let model: String
+  public let sessions: Int64
+  public let generatedTokens: Int64
+  public let cacheReadTokens: Int64
+  public let costUSD: Double
+
+  public var id: String { model }
+
+  enum CodingKeys: String, CodingKey {
+    case model, sessions
+    case generatedTokens = "generated_tokens"
+    case cacheReadTokens = "cache_read_tokens"
+    case costUSD = "cost_usd"
+  }
+}
+
+public struct DevinUsageWindow: Codable, Identifiable, Sendable {
+  public let window: String
+  public let since: String?
+  public let sessions: Int64
+  public let generatedTokens: Int64
+  public let cacheReadTokens: Int64
+  public let costUSD: Double
+  public let models: [DevinUsageModel]
+
+  public var id: String { window }
+
+  enum CodingKeys: String, CodingKey {
+    case window, since, sessions, models
+    case generatedTokens = "generated_tokens"
+    case cacheReadTokens = "cache_read_tokens"
+    case costUSD = "cost_usd"
+  }
+}
+
+public struct DevinUsageSummary: Codable, Sendable {
+  public let status: String
+  public let source: String
+  public let sessions: Int64
+  public let generatedTokens: Int64
+  public let cacheReadTokens: Int64
+  public let outputTokens: Int64
+  public let costUSD: Double
+  public let models: [DevinUsageModel]
+  public let windows: [DevinUsageWindow]?
+  public let limitations: [String]
+
+  enum CodingKeys: String, CodingKey {
+    case status, source, sessions, models, windows, limitations
+    case generatedTokens = "generated_tokens"
+    case cacheReadTokens = "cache_read_tokens"
+    case outputTokens = "output_tokens"
+    case costUSD = "cost_usd"
+  }
+
+  public func projection(for window: UsageWindow) -> DevinUsageWindow {
+    if let projection = windows?.first(where: { $0.window == window.receiptKey }) {
+      return projection
+    }
+    return DevinUsageWindow(
+      window: "all",
+      since: nil,
+      sessions: sessions,
+      generatedTokens: generatedTokens,
+      cacheReadTokens: cacheReadTokens,
+      costUSD: costUSD,
+      models: models
+    )
+  }
+}
+
+public struct LocalUsageReport: Codable, Sendable {
+  public let status: LocalUsageStatus
+  public let stale: Bool
+  public let error: LocalUsageFailure?
+  public let provenance: LocalUsageProvenance
+  public let daily: [LocalUsagePeriod]
+  public let weekly: [LocalUsagePeriod]
+  public let monthly: [LocalUsagePeriod]
+  public let sessions: [LocalUsageSession]
+  public let totals: LocalUsageTotals
+  public let devin: DevinUsageSummary?
+
+  public func periods(for scale: UsageScale) -> [LocalUsagePeriod] {
+    switch scale {
+    case .day: daily
+    case .week: weekly
+    case .month: monthly
+    }
+  }
+
+  public func periods(
+    for scale: UsageScale,
+    window: UsageWindow,
+    referenceDate: Date = Date()
+  ) -> [LocalUsagePeriod] {
+    guard let cutoff = usageWindowCutoff(window, referenceDate: referenceDate) else {
+      return periods(for: scale)
+    }
+    return periods(for: scale).filter { period in
+      guard let interval = usagePeriodInterval(period.period, scale: scale) else { return false }
+      return interval.start <= referenceDate && interval.end >= cutoff
+    }
+  }
+
+  public func totals(
+    for selectedAgents: Set<String>,
+    window: UsageWindow,
+    referenceDate: Date = Date()
+  ) -> LocalUsageTotals {
+    periods(for: .day, window: window, referenceDate: referenceDate)
+      .reduce(.zero) { $0.adding($1.totals(for: selectedAgents)) }
+  }
+
+  public func sessions(
+    for selectedAgents: Set<String>,
+    window: UsageWindow,
+    referenceDate: Date = Date()
+  ) -> [LocalUsageSession] {
+    let agentSessions = sessions.filter { selectedAgents.contains($0.agent) }
+    guard let cutoff = usageWindowCutoff(window, referenceDate: referenceDate) else {
+      return agentSessions
+    }
+    return agentSessions.filter { session in
+      guard let raw = session.lastActivity, let activity = usageTimestamp(raw) else { return false }
+      return activity >= cutoff && activity <= referenceDate
+    }
+  }
+}
+
+private func usageCalendar() -> Calendar {
+  var calendar = Calendar(identifier: .gregorian)
+  calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+  return calendar
+}
+
+private func usageWindowCutoff(_ window: UsageWindow, referenceDate: Date) -> Date? {
+  guard let dayCount = window.dayCount else { return nil }
+  let calendar = usageCalendar()
+  let today = calendar.startOfDay(for: referenceDate)
+  return calendar.date(byAdding: .day, value: -(dayCount - 1), to: today)
+}
+
+private func usagePeriodInterval(_ raw: String, scale: UsageScale) -> DateInterval? {
+  let parts = raw.split(separator: "-").compactMap { Int($0) }
+  let calendar = usageCalendar()
+  let components: DateComponents
+  switch scale {
+  case .day, .week:
+    guard parts.count == 3 else { return nil }
+    components = DateComponents(year: parts[0], month: parts[1], day: parts[2])
+  case .month:
+    guard parts.count == 2 else { return nil }
+    components = DateComponents(year: parts[0], month: parts[1], day: 1)
+  }
+  guard let start = calendar.date(from: components) else { return nil }
+  let end: Date
+  switch scale {
+  case .day:
+    end = calendar.date(byAdding: .day, value: 1, to: start)!.addingTimeInterval(-1)
+  case .week:
+    end = calendar.date(byAdding: .day, value: 7, to: start)!.addingTimeInterval(-1)
+  case .month:
+    end = calendar.date(byAdding: .month, value: 1, to: start)!.addingTimeInterval(-1)
+  }
+  return DateInterval(start: start, end: end)
+}
+
+private func usageTimestamp(_ raw: String) -> Date? {
+  ISO8601DateFormatter().date(from: raw)
+}
+
+public struct LocalUsageRunResult: Sendable {
+  public let report: LocalUsageReport
+  public let rawJSON: String
+  public let processStatus: Int32
+}

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
       "@tailwindcss/vite>vite": "7.3.6",
       "astro>esbuild": "0.28.1",
       "brace-expansion": "5.0.9",
+      "browserslist": "4.28.7",
       "js-yaml": "4.3.1",
       "nanoid": "3.3.18",
       "postcss": "8.5.26",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   '@tailwindcss/vite>vite': 7.3.6
   astro>esbuild: 0.28.1
   brace-expansion: 5.0.9
+  browserslist: 4.28.7
   js-yaml: 4.3.1
   nanoid: 3.3.18
   postcss: 8.5.26
@@ -2366,8 +2367,8 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  baseline-browser-mapping@2.10.21:
-    resolution: {integrity: sha512-Q+rUQ7Uz8AHM7DEaNdwvfFCTq7a43lNTzuS94eiWqwyxfV/wJv+oUivef51T91mmRY4d4A1u9rcSvkeufCVXlA==}
+  baseline-browser-mapping@2.11.20:
+    resolution: {integrity: sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -2389,8 +2390,8 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
-  browserslist@4.28.2:
-    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+  browserslist@4.28.7:
+    resolution: {integrity: sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -2410,6 +2411,9 @@ packages:
 
   caniuse-lite@1.0.30001790:
     resolution: {integrity: sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw==}
+
+  caniuse-lite@1.0.30001810:
+    resolution: {integrity: sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -2610,8 +2614,8 @@ packages:
     resolution: {integrity: sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==}
     engines: {node: '>=4'}
 
-  electron-to-chromium@1.5.344:
-    resolution: {integrity: sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==}
+  electron-to-chromium@1.5.420:
+    resolution: {integrity: sha512-2yD6XreGusOfNV+dUcvipJEXc3n/n7fgr7996aszTG+YY5E4mqM4tOq/3uhP129cazL9YHbVWSpc79ePotWtPA==}
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
@@ -3289,8 +3293,9 @@ packages:
   node-mock-http@1.0.4:
     resolution: {integrity: sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==}
 
-  node-releases@2.0.38:
-    resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
+  node-releases@2.0.54:
+    resolution: {integrity: sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==}
+    engines: {node: '>=18'}
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -4006,7 +4011,7 @@ packages:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
     peerDependencies:
-      browserslist: '>= 4.21.0'
+      browserslist: 4.28.7
 
   use-callback-ref@1.3.3:
     resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
@@ -4422,7 +4427,7 @@ snapshots:
     dependencies:
       '@babel/compat-data': 7.29.0
       '@babel/helper-validator-option': 7.27.1
-      browserslist: 4.28.2
+      browserslist: 4.28.7
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -5992,7 +5997,7 @@ snapshots:
 
   autoprefixer@10.5.0(postcss@8.5.26):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.7
       caniuse-lite: 1.0.30001790
       fraction.js: 5.3.4
       picocolors: 1.1.1
@@ -6007,7 +6012,7 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  baseline-browser-mapping@2.10.21: {}
+  baseline-browser-mapping@2.11.20: {}
 
   binary-extensions@2.3.0: {}
 
@@ -6023,13 +6028,13 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  browserslist@4.28.2:
+  browserslist@4.28.7:
     dependencies:
-      baseline-browser-mapping: 2.10.21
-      caniuse-lite: 1.0.30001790
-      electron-to-chromium: 1.5.344
-      node-releases: 2.0.38
-      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+      baseline-browser-mapping: 2.11.20
+      caniuse-lite: 1.0.30001810
+      electron-to-chromium: 1.5.420
+      node-releases: 2.0.54
+      update-browserslist-db: 1.2.3(browserslist@4.28.7)
 
   c8@11.0.0:
     dependencies:
@@ -6048,6 +6053,8 @@ snapshots:
   camelcase-css@2.0.1: {}
 
   caniuse-lite@1.0.30001790: {}
+
+  caniuse-lite@1.0.30001810: {}
 
   ccount@2.0.1: {}
 
@@ -6226,7 +6233,7 @@ snapshots:
 
   dset@3.1.4: {}
 
-  electron-to-chromium@1.5.344: {}
+  electron-to-chromium@1.5.420: {}
 
   emoji-regex@10.6.0: {}
 
@@ -6921,7 +6928,7 @@ snapshots:
 
   node-mock-http@1.0.4: {}
 
-  node-releases@2.0.38: {}
+  node-releases@2.0.54: {}
 
   normalize-path@3.0.0: {}
 
@@ -7665,9 +7672,9 @@ snapshots:
 
   until-async@3.0.2: {}
 
-  update-browserslist-db@1.2.3(browserslist@4.28.2):
+  update-browserslist-db@1.2.3(browserslist@4.28.7):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.7
       escalade: 3.2.0
       picocolors: 1.1.1
 


### PR DESCRIPTION
Part 1/40 of the dependency-ordered native macOS evidence-workbench stack.

Base: `main`
Head: `stack/01-native-models`

This layer stays within the repository's 40-file, 4,000-addition, and 6,000-gross-line limits. Merge only in stack order.
The top tree is byte-identical to the snapshot qualified in draft PR #203; protected signing, notarization, release, and Tauri cutover remain owner-approval gates.
Tracks #193, #194, #199, #200, #201, and #202 without auto-closing them before the full stack lands.