### PR TITLE
[stack 02/40] Native settings and performance views

### DIFF
--- a/apps/macos/CodeVetterPackage/Sources/CodeVetterFeature/PremiumCommandPaletteView.swift
+++ b/apps/macos/CodeVetterPackage/Sources/CodeVetterFeature/PremiumCommandPaletteView.swift
@@ -1,0 +1,157 @@
+import SwiftUI
+
+struct PremiumCommandPaletteView: View {
+  @Bindable var model: WorkbenchModel
+  @Environment(\.dismiss) private var dismiss
+  @FocusState private var searchFocused: Bool
+  @State private var query = ""
+  @State private var selectedIndex = 0
+
+  private var matches: [WorkbenchSection] {
+    let needle = query.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !needle.isEmpty else { return WorkbenchSection.allCases }
+    return WorkbenchSection.allCases.filter {
+      $0.rawValue.localizedCaseInsensitiveContains(needle)
+    }
+  }
+
+  var body: some View {
+    VStack(spacing: 0) {
+      HStack(spacing: 11) {
+        Image(systemName: "command")
+          .font(.system(size: 13, weight: .semibold))
+          .foregroundStyle(EvidenceStyle.amberForeground)
+        TextField("Search workspaces", text: $query)
+          .textFieldStyle(.plain)
+          .font(.system(size: 15, weight: .medium))
+          .focused($searchFocused)
+          .accessibilityLabel("Search CodeVetter workspaces")
+          .accessibilityIdentifier("command-palette-search")
+          .onSubmit { activateSelection() }
+          .onKeyPress(.downArrow) {
+            moveSelection(by: 1)
+            return .handled
+          }
+          .onKeyPress(.upArrow) {
+            moveSelection(by: -1)
+            return .handled
+          }
+        Text("ESC")
+          .font(.system(size: 8, weight: .bold, design: .monospaced))
+          .foregroundStyle(.tertiary)
+          .padding(.horizontal, 7)
+          .padding(.vertical, 5)
+          .background(EvidenceStyle.inspector, in: RoundedRectangle(cornerRadius: 6))
+          .accessibilityHidden(true)
+      }
+      .padding(.horizontal, 18)
+      .frame(height: 58)
+
+      Rectangle().fill(EvidenceStyle.separator).frame(height: 1)
+
+      ScrollView {
+        LazyVStack(spacing: 4) {
+          if matches.isEmpty {
+            ContentUnavailableView(
+              "No matching workspace",
+              systemImage: "magnifyingglass",
+              description: Text("Try Usage, Review, Testing, Performance, Runs, or Settings.")
+            )
+            .frame(minHeight: 220)
+          } else {
+            ForEach(Array(matches.enumerated()), id: \.element.id) { index, section in
+              Button {
+                activate(section)
+              } label: {
+                HStack(spacing: 12) {
+                  Image(systemName: section.systemImage)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(
+                      index == selectedIndex
+                        ? EvidenceStyle.amberForeground
+                        : .secondary
+                    )
+                    .frame(width: 20)
+                  VStack(alignment: .leading, spacing: 3) {
+                    Text(section.rawValue).font(.system(size: 13, weight: .semibold))
+                    Text(sectionPurpose(section))
+                      .font(.system(size: 9))
+                      .foregroundStyle(.secondary)
+                  }
+                  Spacer()
+                  Text("⌘\(index + 1)")
+                    .font(.system(size: 9, weight: .medium, design: .monospaced))
+                    .foregroundStyle(.tertiary)
+                }
+                .padding(.horizontal, 13)
+                .frame(height: 44)
+                .background(
+                  index == selectedIndex ? EvidenceStyle.amber.opacity(0.09) : Color.clear,
+                  in: RoundedRectangle(cornerRadius: 9)
+                )
+                .overlay {
+                  RoundedRectangle(cornerRadius: 9).stroke(
+                    index == selectedIndex ? EvidenceStyle.amber.opacity(0.3) : Color.clear)
+                }
+              }
+              .buttonStyle(.plain)
+              .accessibilityLabel("Open \(section.rawValue)")
+              .accessibilityValue(index == selectedIndex ? "Selected suggestion" : "")
+              .onHover { hovering in
+                if hovering { selectedIndex = index }
+              }
+            }
+          }
+        }
+        .padding(10)
+      }
+
+      Rectangle().fill(EvidenceStyle.separator).frame(height: 1)
+      HStack {
+        Label("Navigate", systemImage: "arrow.up.arrow.down")
+        Label("Open", systemImage: "return")
+        Spacer()
+        Text("One workbench · one Rust evidence model")
+      }
+      .font(.system(size: 8, weight: .medium))
+      .foregroundStyle(.tertiary)
+      .padding(.horizontal, 18)
+      .frame(height: 38)
+    }
+    .frame(width: 520, height: 520)
+    .background(EvidenceStyle.canvas)
+    .accessibilityElement(children: .contain)
+    .accessibilityIdentifier("command-palette")
+    .onAppear { searchFocused = true }
+    .onChange(of: query) { _, _ in selectedIndex = 0 }
+    .onExitCommand { dismiss() }
+  }
+
+  private func moveSelection(by offset: Int) {
+    guard !matches.isEmpty else { return }
+    selectedIndex = min(max(selectedIndex + offset, 0), matches.count - 1)
+  }
+
+  private func activateSelection() {
+    guard matches.indices.contains(selectedIndex) else { return }
+    activate(matches[selectedIndex])
+  }
+
+  private func activate(_ section: WorkbenchSection) {
+    model.section = section
+    dismiss()
+  }
+
+  private func sectionPurpose(_ section: WorkbenchSection) -> String {
+    switch section {
+    case .usage: "Inspect local provider usage without inventing quota truth"
+    case .repository: "Read bounded repository structure and stored snapshots"
+    case .review: "Plan and inspect execution-backed change verification"
+    case .testing: "Exercise changed behavior and preserve runtime evidence"
+    case .performance: "Measure one exact workload and compare one change"
+    case .runs: "Inspect canonical Rust-persisted verification receipts"
+    case .capabilities: "See UI, CLI, and agent authority from one registry"
+    case .settings: "Manage local behavior without exposing credentials"
+    }
+  }
+}

--- a/apps/macos/CodeVetterPackage/Sources/CodeVetterFeature/PremiumDifferentialVerificationView.swift
+++ b/apps/macos/CodeVetterPackage/Sources/CodeVetterFeature/PremiumDifferentialVerificationView.swift
@@ -1,0 +1,312 @@
+import SwiftUI
+
+struct PremiumDifferentialVerificationView: View {
+  @Bindable var model: WorkbenchModel
+  @Environment(\.dismiss) private var dismiss
+
+  var body: some View {
+    VStack(spacing: 0) {
+      HStack(spacing: 14) {
+        VStack(alignment: .leading, spacing: 4) {
+          Text("DIFFERENTIAL / PAIRED EVIDENCE")
+            .font(.system(size: 9, weight: .bold, design: .monospaced))
+            .tracking(1.1).foregroundStyle(EvidenceStyle.amberForeground)
+          Text("Compare behavior, not just code.")
+            .font(.system(size: 21, weight: .semibold)).tracking(-0.3)
+          Text("Exact reference · exact candidate · same scenarios · zero model calls")
+            .font(.system(size: 9, design: .monospaced)).foregroundStyle(.secondary)
+        }
+        Spacer()
+        StatusPill(label: model.differentialState.rawValue, color: stateColor)
+        Button("Done") { dismiss() }.buttonStyle(.bordered)
+      }
+      .padding(.horizontal, 24).frame(height: 88).background(EvidenceStyle.chrome)
+      Rectangle().fill(EvidenceStyle.separator).frame(height: 1)
+      if let receipt = model.differentialReceipt {
+        receiptDesk(receipt)
+      } else {
+        setupDesk
+      }
+    }
+    .background(EvidenceStyle.canvas)
+    .accessibilityElement(children: .contain)
+    .accessibilityIdentifier("differential-verification-workspace")
+  }
+
+  private var setupDesk: some View {
+    VStack(spacing: 0) {
+      HStack(spacing: 0) {
+        ScrollView {
+          VStack(alignment: .leading, spacing: 22) {
+            PremiumFieldLabel("COMPARISON PAIR")
+            PremiumInput(
+              label: "REFERENCE REVISION", icon: "arrow.uturn.backward",
+              placeholder: "main", text: $model.differentialReference)
+            VStack(alignment: .leading, spacing: 8) {
+              PremiumFieldLabel("CANDIDATE SOURCE")
+              Picker("Candidate source", selection: $model.differentialCandidateKind) {
+                ForEach(DifferentialCandidateKind.allCases) { kind in
+                  Text(kind.rawValue.capitalized).tag(kind)
+                }
+              }
+              .pickerStyle(.segmented).labelsHidden().tint(EvidenceStyle.amber)
+            }
+            if model.differentialCandidateKind == .commit
+              || model.differentialCandidateKind == .range
+            {
+              PremiumInput(
+                label: model.differentialCandidateKind == .commit
+                  ? "CANDIDATE COMMIT" : "CANDIDATE RANGE",
+                icon: "point.topleft.down.to.point.bottomright.curvepath",
+                placeholder: model.differentialCandidateKind == .commit
+                  ? "HEAD" : "main...HEAD",
+                text: $model.differentialCandidateRevision)
+            }
+
+            VStack(alignment: .leading, spacing: 10) {
+              PremiumFieldLabel("PARITY CONTRACT")
+              row("Scenario set", "Shared and bounded")
+              row("Observation policy", "Identical on both sides")
+              row("Timing", "Parity-gated")
+              row("Pass authority", "Never created by differential")
+              row("Model calls", "0")
+            }
+
+            if let issue = model.differentialIssue ?? model.differentialInputIssue {
+              Label(issue, systemImage: "exclamationmark.triangle.fill")
+                .font(.system(size: 10, weight: .medium))
+                .foregroundStyle(
+                  model.differentialIssue == nil ? EvidenceStyle.warning : EvidenceStyle.failure
+                )
+                .padding(14).frame(maxWidth: .infinity, alignment: .leading)
+                .background(
+                  EvidenceStyle.warning.opacity(0.07), in: RoundedRectangle(cornerRadius: 12))
+            }
+          }
+          .padding(28).frame(maxWidth: 620, alignment: .leading)
+        }
+        Rectangle().fill(EvidenceStyle.separator).frame(width: 1)
+        preparationInspector.frame(width: 330)
+      }
+      Rectangle().fill(EvidenceStyle.separator).frame(height: 1)
+      actionBar
+    }
+  }
+
+  private var preparationInspector: some View {
+    ScrollView {
+      VStack(alignment: .leading, spacing: 18) {
+        PremiumFieldLabel("PREPARATION RECEIPT")
+        if let prepared = model.differentialPrepared {
+          Label(
+            prepared.status == "ready" ? "Pair ready" : "Pair incomparable",
+            systemImage: prepared.status == "ready"
+              ? "checkmark.seal.fill" : "questionmark.diamond.fill"
+          )
+          .font(.system(size: 13, weight: .semibold))
+          .foregroundStyle(
+            prepared.status == "ready" ? EvidenceStyle.success : EvidenceStyle.warning)
+          datum("RUN", prepared.runID)
+          datum("REFERENCE", prepared.referenceSHA.map { String($0.prefix(14)) } ?? "unresolved")
+          datum("CANDIDATE", prepared.candidateKind.rawValue)
+          datum("SCENARIOS", "\(prepared.scenarioCount)")
+          datum("SOURCE CACHE", "\(prepared.sourceCacheHits)/2")
+          datum("DEPENDENCIES", prepared.dependencyCacheHit ? "cache hit" : "prepared")
+          datum("PREPARED", bytes(prepared.preparedBytes))
+          datum("MODEL CALLS", "\(prepared.modelCallCount)")
+          if !prepared.reasonCodes.isEmpty {
+            Divider()
+            PremiumFieldLabel("REASON CODES")
+            ForEach(prepared.reasonCodes, id: \.self) { reason in
+              Text(reason).font(.system(size: 9, design: .monospaced)).foregroundStyle(.secondary)
+            }
+          }
+        } else {
+          Label("Not prepared", systemImage: "square.dashed")
+            .font(.system(size: 13, weight: .semibold))
+          Text(
+            "Preparation materializes and validates the exact pair before comparison can execute."
+          )
+          .font(.system(size: 10)).foregroundStyle(.secondary)
+          .fixedSize(horizontal: false, vertical: true)
+        }
+        Divider()
+        Label("codevetter differential", systemImage: "terminal.fill")
+          .font(.system(size: 10, weight: .semibold, design: .monospaced))
+          .foregroundStyle(EvidenceStyle.success)
+        Text(
+          "Swift renders the contract. Rust owns source materialization, parity, comparison, cleanup, persistence, and classification."
+        )
+        .font(.system(size: 9)).foregroundStyle(.secondary)
+        .fixedSize(horizontal: false, vertical: true)
+      }
+      .padding(24)
+    }
+    .background(EvidenceStyle.inspector)
+  }
+
+  private var actionBar: some View {
+    HStack(spacing: 12) {
+      if model.differentialState == .planning || model.differentialState == .running {
+        ProgressView().controlSize(.small).tint(EvidenceStyle.amber)
+      }
+      Text(model.differentialStatusMessage)
+        .font(.system(size: 10, weight: .medium)).foregroundStyle(.secondary).lineLimit(2)
+      Spacer()
+      if model.differentialState == .planning || model.differentialState == .running {
+        Button("Cancel", role: .destructive) { model.cancelDifferentialVerification() }
+          .buttonStyle(.bordered)
+      } else {
+        Button("Prepare pair") { model.prepareDifferential() }
+          .buttonStyle(.bordered).disabled(!model.canPrepareDifferential)
+        Button("Run comparison") { model.runDifferentialVerification() }
+          .buttonStyle(PremiumPrimaryButtonStyle()).disabled(!model.canRunDifferential)
+      }
+    }
+    .padding(.horizontal, 22).frame(minHeight: 68).background(EvidenceStyle.chrome)
+  }
+
+  private func receiptDesk(_ receipt: StoredDifferentialRun) -> some View {
+    let summary = receipt.summary
+    return VStack(spacing: 0) {
+      HStack(spacing: 14) {
+        VStack(alignment: .leading, spacing: 4) {
+          Text("COMPARISON RECORDED")
+            .font(.system(size: 9, weight: .bold, design: .monospaced))
+            .tracking(1).foregroundStyle(classificationColor(summary.classification))
+          Text(model.differentialStatusMessage).font(.system(size: 16, weight: .semibold))
+          Text(
+            "\(summary.scenarioCount) scenarios · \(summary.deltaCount) deltas · \(summary.blockingDeltaCount) blocking"
+          )
+          .font(.system(size: 9, design: .monospaced)).foregroundStyle(.secondary)
+        }
+        Spacer()
+        StatusPill(
+          label: summary.classification, color: classificationColor(summary.classification))
+        Button("Open in Runs") {
+          model.showingDifferentialVerifier = false
+          model.section = .runs
+          model.loadRuns()
+        }.buttonStyle(.bordered)
+        Button("New pair") { model.resetDifferentialVerification() }.buttonStyle(.bordered)
+      }
+      .padding(.horizontal, 22).frame(height: 76).background(EvidenceStyle.chrome)
+      .overlay(alignment: .bottom) { Rectangle().fill(EvidenceStyle.separator).frame(height: 1) }
+
+      HStack(spacing: 0) {
+        VStack(alignment: .leading, spacing: 16) {
+          PremiumFieldLabel("EXACT PAIR")
+          datum("REFERENCE", summary.referenceSHA.map { String($0.prefix(16)) } ?? "unresolved")
+          datum("CANDIDATE", summary.candidateKind.rawValue)
+          datum("IDENTITY", summary.candidateIdentity.map { String($0.prefix(16)) } ?? "unresolved")
+          datum("DURATION", "\(Int(summary.durationMS)) ms")
+          datum("CLEANUP", summary.cleanupComplete ? "complete" : "incomplete")
+          datum("MODEL CALLS", "\(summary.modelCallCount)")
+          Divider()
+          Text("Differential evidence never creates pass evidence.")
+            .font(.system(size: 9, weight: .semibold)).foregroundStyle(EvidenceStyle.warning)
+            .fixedSize(horizontal: false, vertical: true)
+          Spacer()
+          Label("Rust validated + persisted", systemImage: "checkmark.seal.fill")
+            .font(.system(size: 10, weight: .semibold)).foregroundStyle(EvidenceStyle.success)
+        }
+        .padding(22).frame(width: 260, alignment: .topLeading).background(EvidenceStyle.chrome)
+        Rectangle().fill(EvidenceStyle.separator).frame(width: 1)
+        ScrollView {
+          LazyVStack(alignment: .leading, spacing: 14) {
+            HStack(spacing: 10) {
+              metric("SCENARIOS", "\(summary.scenarioCount)")
+              metric("DELTAS", "\(summary.deltaCount)")
+              metric("BLOCKING", "\(summary.blockingDeltaCount)")
+            }
+            PremiumFieldLabel("DELTA PREVIEWS")
+            if summary.deltaPreviews.isEmpty {
+              Label("No behavioral deltas recorded", systemImage: "equal.circle.fill")
+                .font(.system(size: 11, weight: .semibold)).foregroundStyle(EvidenceStyle.success)
+                .padding(15).frame(maxWidth: .infinity, alignment: .leading)
+                .background(
+                  EvidenceStyle.success.opacity(0.07), in: RoundedRectangle(cornerRadius: 12))
+            }
+            ForEach(summary.deltaPreviews) { delta in
+              VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                  Label(
+                    delta.kind,
+                    systemImage: delta.blocking ? "xmark.octagon.fill" : "arrow.left.arrow.right"
+                  )
+                  .font(.system(size: 11, weight: .semibold))
+                  .foregroundStyle(delta.blocking ? EvidenceStyle.failure : EvidenceStyle.warning)
+                  Spacer()
+                  Text(delta.direction).font(.system(size: 9, design: .monospaced)).foregroundStyle(
+                    .secondary)
+                }
+                Text(delta.scenarioID).font(.system(size: 10, design: .monospaced))
+                Text(delta.policyID).font(.system(size: 8, design: .monospaced)).foregroundStyle(
+                  .tertiary)
+              }
+              .padding(14).background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 12))
+              .overlay { RoundedRectangle(cornerRadius: 12).stroke(EvidenceStyle.separator) }
+            }
+            if !summary.reasonCodes.isEmpty {
+              PremiumFieldLabel("REASON CODES")
+              ForEach(summary.reasonCodes, id: \.self) { reason in
+                Text(reason).font(.system(size: 9, design: .monospaced)).foregroundStyle(.secondary)
+              }
+            }
+          }.padding(18)
+        }
+      }
+    }
+  }
+
+  private func row(_ label: String, _ value: String) -> some View {
+    HStack {
+      Text(label).font(.system(size: 10, weight: .semibold))
+      Spacer()
+      Text(value).font(.system(size: 9, design: .monospaced)).foregroundStyle(.secondary)
+    }
+    .padding(12).background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 10))
+  }
+
+  private func datum(_ label: String, _ value: String) -> some View {
+    VStack(alignment: .leading, spacing: 4) {
+      PremiumFieldLabel(label)
+      Text(value).font(.system(size: 9, weight: .medium, design: .monospaced)).foregroundStyle(
+        .secondary
+      ).textSelection(.enabled).lineLimit(2)
+    }
+  }
+
+  private func metric(_ label: String, _ value: String) -> some View {
+    VStack(alignment: .leading, spacing: 5) {
+      PremiumFieldLabel(label)
+      Text(value).font(.system(size: 18, weight: .semibold, design: .monospaced))
+    }
+    .padding(13).frame(maxWidth: .infinity, alignment: .leading)
+    .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 11))
+    .overlay { RoundedRectangle(cornerRadius: 11).stroke(EvidenceStyle.separator) }
+  }
+
+  private var stateColor: Color {
+    switch model.differentialState {
+    case .running, .planning: EvidenceStyle.amber
+    case .completed, .planned: EvidenceStyle.success
+    case .limited: EvidenceStyle.warning
+    case .failed: EvidenceStyle.failure
+    case .ready, .cancelled: .secondary
+    }
+  }
+
+  private func classificationColor(_ value: String) -> Color {
+    switch value {
+    case "regressed": EvidenceStyle.failure
+    case "improved": EvidenceStyle.success
+    case "unchanged": .secondary
+    default: EvidenceStyle.warning
+    }
+  }
+
+  private func bytes(_ value: UInt64) -> String {
+    ByteCountFormatter.string(fromByteCount: Int64(clamping: value), countStyle: .memory)
+  }
+}

--- a/apps/macos/CodeVetterPackage/Sources/CodeVetterFeature/PremiumOnboardingView.swift
+++ b/apps/macos/CodeVetterPackage/Sources/CodeVetterFeature/PremiumOnboardingView.swift
@@ -1,0 +1,351 @@
+import SwiftUI
+
+struct PremiumOnboardingView: View {
+  @Bindable var model: WorkbenchModel
+
+  private let steps = ["Purpose", "Readiness", "Agent", "Workbench"]
+
+  var body: some View {
+    VStack(spacing: 0) {
+      header
+      Rectangle().fill(EvidenceStyle.separator).frame(height: 1)
+      content
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+      Rectangle().fill(EvidenceStyle.separator).frame(height: 1)
+      footer
+    }
+    .frame(width: 760, height: 600)
+    .background(EvidenceStyle.canvas)
+    .accessibilityElement(children: .contain)
+    .accessibilityIdentifier("native-onboarding")
+  }
+
+  private var header: some View {
+    HStack(spacing: 18) {
+      HStack(spacing: 10) {
+        ZStack {
+          RoundedRectangle(cornerRadius: 9).fill(EvidenceStyle.amber)
+          Image(systemName: "checkmark.shield.fill")
+            .font(.system(size: 15, weight: .bold))
+            .foregroundStyle(EvidenceStyle.ink)
+        }
+        .frame(width: 36, height: 36)
+        VStack(alignment: .leading, spacing: 2) {
+          Text("CODEVETTER")
+            .font(.system(size: 9, weight: .bold, design: .monospaced))
+            .tracking(1.1)
+            .foregroundStyle(EvidenceStyle.amberForeground)
+          Text("Evidence Workbench").font(.system(size: 13, weight: .semibold))
+        }
+      }
+      Spacer()
+      HStack(spacing: 5) {
+        ForEach(Array(steps.enumerated()), id: \.offset) { index, label in
+          VStack(alignment: .leading, spacing: 5) {
+            Text(label.uppercased())
+              .font(.system(size: 7, weight: .bold, design: .monospaced))
+              .foregroundStyle(index == model.onboardingStep ? Color.primary : Color.secondary)
+            Capsule()
+              .fill(index <= model.onboardingStep ? EvidenceStyle.amber : EvidenceStyle.separator)
+              .frame(width: 64, height: 2)
+          }
+        }
+      }
+      .accessibilityElement(children: .ignore)
+      .accessibilityLabel(
+        "Step \(model.onboardingStep + 1) of \(steps.count), \(steps[model.onboardingStep])")
+    }
+    .padding(.horizontal, 24)
+    .frame(height: 76)
+    .background(EvidenceStyle.chrome)
+  }
+
+  @ViewBuilder
+  private var content: some View {
+    switch model.onboardingStep {
+    case 0: purposeStep
+    case 1: readinessStep
+    case 2: agentStep
+    default: workbenchStep
+    }
+  }
+
+  private var purposeStep: some View {
+    HStack(spacing: 38) {
+      VStack(alignment: .leading, spacing: 18) {
+        PremiumFieldLabel("THE STANDARD")
+        Text("Judge code by\nwhat it proves.")
+          .font(.system(size: 36, weight: .semibold))
+          .tracking(-0.8)
+        Text(
+          "CodeVetter binds an exact change to executable checks, runtime evidence, and a measurable verdict. Model opinions remain leads—not proof."
+        )
+        .font(.system(size: 13))
+        .foregroundStyle(.secondary)
+        .fixedSize(horizontal: false, vertical: true)
+        HStack(spacing: 7) {
+          StatusPill(label: "Local first", color: EvidenceStyle.success)
+          StatusPill(label: "Rust authority", color: EvidenceStyle.amber)
+          StatusPill(label: "Fail closed", color: EvidenceStyle.warning)
+        }
+      }
+      .frame(maxWidth: 410, alignment: .leading)
+      ZStack {
+        RoundedRectangle(cornerRadius: 24)
+          .fill(EvidenceStyle.surface)
+          .overlay { RoundedRectangle(cornerRadius: 24).stroke(EvidenceStyle.separator) }
+        VStack(spacing: 15) {
+          proofNode("TASK", "Exact intent", "scope")
+          Image(systemName: "arrow.down").foregroundStyle(EvidenceStyle.amberForeground)
+          proofNode("EXECUTE", "Repository checks", "terminal")
+          Image(systemName: "arrow.down").foregroundStyle(EvidenceStyle.amberForeground)
+          proofNode("VERDICT", "Evidence bounded", "checkmark.seal")
+        }
+      }
+      .frame(width: 225, height: 340)
+    }
+    .padding(38)
+  }
+
+  private var readinessStep: some View {
+    VStack(alignment: .leading, spacing: 18) {
+      PremiumFieldLabel("LOCAL TOOL READINESS")
+      Text("Know what is available. Assume nothing.")
+        .font(.system(size: 27, weight: .semibold))
+      Text(
+        "The Rust receipt checks executable presence only. Authentication and credential contents are deliberately not inspected."
+      )
+      .font(.system(size: 11))
+      .foregroundStyle(.secondary)
+      VStack(spacing: 0) {
+        ForEach(Array((model.onboardingReceipt?.tools ?? []).enumerated()), id: \.element.id) {
+          index, tool in
+          HStack(spacing: 14) {
+            Image(systemName: tool.available ? "checkmark.circle.fill" : "minus.circle")
+              .font(.system(size: 16))
+              .foregroundStyle(tool.available ? EvidenceStyle.success : Color.secondary)
+              .frame(width: 24)
+            VStack(alignment: .leading, spacing: 3) {
+              Text(tool.label).font(.system(size: 12, weight: .semibold))
+              Text(tool.role).font(.system(size: 9)).foregroundStyle(.secondary)
+            }
+            Spacer()
+            StatusPill(
+              label: tool.available ? "Available" : "Not found",
+              color: tool.available ? EvidenceStyle.success : Color.secondary)
+          }
+          .padding(.horizontal, 18)
+          .frame(height: 70)
+          .accessibilityElement(children: .combine)
+          if index < (model.onboardingReceipt?.tools.count ?? 0) - 1 {
+            Rectangle().fill(EvidenceStyle.separator).frame(height: 1)
+          }
+        }
+      }
+      .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 14))
+      .overlay { RoundedRectangle(cornerRadius: 14).stroke(EvidenceStyle.separator) }
+      Label(
+        "Missing tools do not become green checks. You can finish setup and install them later.",
+        systemImage: "lock.shield"
+      )
+      .font(.system(size: 9))
+      .foregroundStyle(.secondary)
+    }
+    .padding(38)
+  }
+
+  private var agentStep: some View {
+    VStack(alignment: .leading, spacing: 20) {
+      PremiumFieldLabel("DEFAULT REVIEW AGENT")
+      Text("Choose the worker. Keep proof independent.")
+        .font(.system(size: 27, weight: .semibold))
+      Text(
+        "This selects the default local agent adapter. It does not grant repository, network, or credential authority."
+      )
+      .font(.system(size: 11))
+      .foregroundStyle(.secondary)
+      HStack(spacing: 14) {
+        agentChoice(
+          id: "codex", title: "Codex", subtitle: "Use the local Codex CLI",
+          symbol: "chevron.left.forwardslash.chevron.right")
+        agentChoice(
+          id: "claude-code", title: "Claude Code", subtitle: "Use the local Claude CLI",
+          symbol: "sparkles")
+      }
+      HStack(spacing: 10) {
+        Image(systemName: "equal.circle.fill").foregroundStyle(EvidenceStyle.amberForeground)
+        Text("Both adapters produce leads. Rust-owned execution evidence determines confidence.")
+          .font(.system(size: 10, weight: .medium))
+      }
+      .padding(14)
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .background(EvidenceStyle.amber.opacity(0.07), in: RoundedRectangle(cornerRadius: 11))
+      .overlay { RoundedRectangle(cornerRadius: 11).stroke(EvidenceStyle.amber.opacity(0.22)) }
+      Spacer()
+    }
+    .padding(38)
+  }
+
+  private var workbenchStep: some View {
+    VStack(alignment: .leading, spacing: 18) {
+      PremiumFieldLabel("ONE PRODUCT · THREE INTERFACES")
+      Text("Start with the change. End with proof.")
+        .font(.system(size: 27, weight: .semibold))
+      HStack(spacing: 12) {
+        tourCard(
+          "APP", "Operate", "Review, Testing, Performance, and evidence inspection", "macwindow")
+        tourCard(
+          "CLI", "Automate", "The same versioned commands and canonical receipts", "terminal")
+        tourCard(
+          "AGENTS", "Integrate", "Scoped MCP reads and explicit execution boundaries",
+          "point.3.connected.trianglepath.dotted")
+      }
+      VStack(spacing: 0) {
+        workbenchRow("1", "Select an exact repository and change")
+        Rectangle().fill(EvidenceStyle.separator).frame(height: 1)
+        workbenchRow("2", "Plan correctness, runtime, and performance evidence")
+        Rectangle().fill(EvidenceStyle.separator).frame(height: 1)
+        workbenchRow("3", "Execute deliberately and inspect every limitation")
+      }
+      .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 12))
+      .overlay { RoundedRectangle(cornerRadius: 12).stroke(EvidenceStyle.separator) }
+    }
+    .padding(38)
+  }
+
+  private var footer: some View {
+    HStack(spacing: 10) {
+      if let issue = model.onboardingIssue {
+        Label(issue, systemImage: "exclamationmark.triangle.fill")
+          .font(.system(size: 9))
+          .foregroundStyle(EvidenceStyle.warning)
+          .lineLimit(2)
+      } else {
+        Text("No credential values enter the onboarding receipt.")
+          .font(.system(size: 8, design: .monospaced))
+          .foregroundStyle(.secondary)
+      }
+      Spacer()
+      if model.onboardingStep == 0 {
+        Button("Not now") { model.dismissOnboarding() }
+          .buttonStyle(.bordered)
+          .disabled(model.onboardingLoading)
+      } else {
+        Button("Back") { model.onboardingStep -= 1 }
+          .buttonStyle(.bordered)
+          .keyboardShortcut(.leftArrow, modifiers: [.command])
+          .disabled(model.onboardingLoading)
+      }
+      Button(model.onboardingStep == steps.count - 1 ? "Enter Workbench" : "Continue") {
+        if model.onboardingStep == steps.count - 1 {
+          model.completeNativeOnboarding()
+        } else {
+          model.onboardingStep += 1
+        }
+      }
+      .buttonStyle(.borderedProminent)
+      .tint(EvidenceStyle.amber)
+      .keyboardShortcut(.return, modifiers: [])
+      .disabled(model.onboardingLoading)
+      .accessibilityIdentifier(
+        model.onboardingStep == steps.count - 1 ? "onboarding-finish" : "onboarding-continue")
+      if model.onboardingLoading {
+        ProgressView().controlSize(.small).tint(EvidenceStyle.amber)
+      }
+    }
+    .padding(.horizontal, 24)
+    .frame(height: 70)
+    .background(EvidenceStyle.chrome)
+  }
+
+  private func proofNode(_ eyebrow: String, _ title: String, _ symbol: String) -> some View {
+    HStack(spacing: 12) {
+      Image(systemName: symbol).foregroundStyle(EvidenceStyle.amberForeground).frame(width: 24)
+      VStack(alignment: .leading, spacing: 2) {
+        Text(eyebrow).font(.system(size: 7, weight: .bold, design: .monospaced)).foregroundStyle(
+          .secondary)
+        Text(title).font(.system(size: 11, weight: .semibold))
+      }
+      Spacer()
+    }
+    .padding(14)
+    .frame(width: 176)
+    .background(EvidenceStyle.inspector, in: RoundedRectangle(cornerRadius: 11))
+    .overlay { RoundedRectangle(cornerRadius: 11).stroke(EvidenceStyle.separator) }
+  }
+
+  private func agentChoice(id: String, title: String, subtitle: String, symbol: String) -> some View
+  {
+    let selected = model.onboardingDefaultAdapter == id
+    return Button {
+      model.onboardingDefaultAdapter = id
+    } label: {
+      VStack(alignment: .leading, spacing: 15) {
+        HStack {
+          Image(systemName: symbol)
+            .font(.system(size: 18))
+            .foregroundStyle(EvidenceStyle.amberForeground)
+          Spacer()
+          Image(systemName: selected ? "checkmark.circle.fill" : "circle")
+            .foregroundStyle(selected ? EvidenceStyle.amberForeground : Color.secondary)
+        }
+        Text(title).font(.system(size: 15, weight: .semibold))
+        Text(subtitle).font(.system(size: 9)).foregroundStyle(.secondary)
+        StatusPill(
+          label: toolAvailable(for: id) ? "CLI available" : "CLI not found",
+          color: toolAvailable(for: id) ? EvidenceStyle.success : Color.secondary)
+      }
+      .padding(18)
+      .frame(maxWidth: .infinity, minHeight: 170, alignment: .topLeading)
+      .background(
+        selected ? EvidenceStyle.amber.opacity(0.09) : EvidenceStyle.surface,
+        in: RoundedRectangle(cornerRadius: 14)
+      )
+      .overlay {
+        RoundedRectangle(cornerRadius: 14).stroke(
+          selected ? EvidenceStyle.amber.opacity(0.55) : EvidenceStyle.separator)
+      }
+    }
+    .buttonStyle(.plain)
+    .accessibilityLabel("\(title), \(selected ? "selected" : "not selected")")
+    .accessibilityAddTraits(selected ? .isSelected : [])
+  }
+
+  private func toolAvailable(for adapter: String) -> Bool {
+    let id = adapter == "codex" ? "codex" : "claude"
+    return model.onboardingReceipt?.tools.first { $0.id == id }?.available ?? false
+  }
+
+  private func tourCard(_ eyebrow: String, _ title: String, _ detail: String, _ symbol: String)
+    -> some View
+  {
+    VStack(alignment: .leading, spacing: 10) {
+      Image(systemName: symbol)
+        .font(.system(size: 18))
+        .foregroundStyle(EvidenceStyle.amberForeground)
+      Text(eyebrow).font(.system(size: 7, weight: .bold, design: .monospaced)).foregroundStyle(
+        .secondary)
+      Text(title).font(.system(size: 14, weight: .semibold))
+      Text(detail).font(.system(size: 9)).foregroundStyle(.secondary).fixedSize(
+        horizontal: false, vertical: true)
+    }
+    .padding(16)
+    .frame(maxWidth: .infinity, minHeight: 145, alignment: .topLeading)
+    .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 13))
+    .overlay { RoundedRectangle(cornerRadius: 13).stroke(EvidenceStyle.separator) }
+  }
+
+  private func workbenchRow(_ number: String, _ label: String) -> some View {
+    HStack(spacing: 13) {
+      Text(number)
+        .font(.system(size: 9, weight: .bold, design: .monospaced))
+        .foregroundStyle(EvidenceStyle.ink)
+        .frame(width: 23, height: 23)
+        .background(EvidenceStyle.amber, in: Circle())
+      Text(label).font(.system(size: 10, weight: .medium))
+      Spacer()
+    }
+    .padding(.horizontal, 15)
+    .frame(height: 43)
+  }
+}

--- a/apps/macos/CodeVetterPackage/Sources/CodeVetterFeature/PremiumPerformanceView.swift
+++ b/apps/macos/CodeVetterPackage/Sources/CodeVetterFeature/PremiumPerformanceView.swift
@@ -1,0 +1,971 @@
+import SwiftUI
+import UniformTypeIdentifiers
+
+private let performanceEvidencePreviewLimit = 5
+
+private enum PerformanceDetailMode: String, CaseIterable, Identifiable {
+  case evidence = "Evidence"
+  case json = "JSON"
+
+  var id: String { rawValue }
+}
+
+struct PremiumPerformanceView: View {
+  @Bindable var model: WorkbenchModel
+  @State private var detailMode: PerformanceDetailMode = .evidence
+
+  var body: some View {
+    HStack(spacing: 0) {
+      workloadControls.frame(width: 350)
+      Rectangle().fill(EvidenceStyle.separator).frame(width: 1)
+      evidenceWorkspace
+    }
+    .background(EvidenceStyle.canvas)
+    .fileImporter(
+      isPresented: $model.choosingRepository,
+      allowedContentTypes: [.folder],
+      allowsMultipleSelection: false
+    ) { result in
+      guard case .success(let urls) = result, let url = urls.first else { return }
+      model.selectRepository(url)
+    }
+    .fileImporter(
+      isPresented: $model.choosingPerformanceBaseline,
+      allowedContentTypes: [.folder],
+      allowsMultipleSelection: false
+    ) { result in
+      guard case .success(let urls) = result, let url = urls.first else { return }
+      model.performanceBaselineRepositoryPath = url.path(percentEncoded: false)
+    }
+    .accessibilityElement(children: .contain)
+    .accessibilityIdentifier("performance-workspace")
+  }
+
+  private var workloadControls: some View {
+    VStack(spacing: 0) {
+      ScrollView {
+        VStack(alignment: .leading, spacing: 21) {
+          VStack(alignment: .leading, spacing: 6) {
+            Text("PERFORMANCE / EXACT WORKLOAD")
+              .font(.system(size: 9, weight: .bold, design: .monospaced))
+              .tracking(1.15)
+              .foregroundStyle(EvidenceStyle.amberForeground)
+            Text("Measure what changed.")
+              .font(.system(size: 25, weight: .semibold))
+              .tracking(-0.4)
+            Text("Admit one local workload, capture observed evidence, then compare one change.")
+              .font(.system(size: 11))
+              .foregroundStyle(.secondary)
+              .fixedSize(horizontal: false, vertical: true)
+          }
+
+          VStack(alignment: .leading, spacing: 14) {
+            PremiumFieldLabel("REPOSITORY")
+            Button {
+              model.choosingRepository = true
+            } label: {
+              HStack(spacing: 10) {
+                Image(systemName: "folder.fill").foregroundStyle(EvidenceStyle.amberForeground)
+                Text(repositoryLabel)
+                  .font(.system(size: 11, weight: .medium, design: .monospaced))
+                  .foregroundStyle(model.repositoryPath.isEmpty ? .secondary : .primary)
+                  .lineLimit(1)
+                  .truncationMode(.middle)
+                Spacer()
+                Text("Choose…").font(.system(size: 9, weight: .semibold)).foregroundStyle(
+                  .secondary)
+              }
+              .padding(.horizontal, 13)
+              .frame(height: 43)
+              .premiumField()
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Choose performance repository")
+
+            VStack(alignment: .leading, spacing: 9) {
+              HStack {
+                PremiumFieldLabel("RECORDED RUN")
+                Spacer()
+                Text("DIGEST VERIFIED")
+                  .font(.system(size: 8, weight: .bold, design: .monospaced))
+                  .foregroundStyle(EvidenceStyle.success)
+              }
+              HStack(spacing: 8) {
+                Image(systemName: "archivebox").foregroundStyle(EvidenceStyle.amberForeground)
+                TextField("performance-run-7", text: $model.performanceRecordedRunID)
+                  .textFieldStyle(.plain)
+                  .font(.system(size: 10, design: .monospaced))
+                  .accessibilityLabel("Recorded performance run ID")
+                Button("Inspect") { model.inspectPerformanceRun() }
+                  .buttonStyle(.borderless)
+                  .disabled(!model.canInspectPerformanceRun)
+              }
+              .padding(.horizontal, 11)
+              .frame(height: 38)
+              .premiumField()
+              if !model.performanceRecordedRunID.isEmpty,
+                let issue = model.performanceInspectionInputIssue
+              {
+                Text(issue).font(.system(size: 9)).foregroundStyle(.tertiary)
+              }
+            }
+            .padding(12)
+            .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 11))
+            .overlay { RoundedRectangle(cornerRadius: 11).stroke(EvidenceStyle.separator) }
+
+            PremiumScopePlanner(
+              title: "Workload discovery",
+              subtitle:
+                "Turn one flow, exact change, or bounded portfolio into closed workload candidates.",
+              kind: $model.performanceScopeKind,
+              value: $model.performanceScopeValue,
+              plan: model.performanceDiscoveryPlan,
+              loading: model.performanceScopeLoading,
+              issue: model.performanceScopeIssue ?? model.performanceScopeInputIssue,
+              canResolve: model.canResolvePerformanceScope,
+              selectedCandidateID: selectedPerformanceCandidateID,
+              compact: true,
+              accessibilityID: "performance-scope-planner",
+              onResolve: model.resolvePerformanceScope,
+              onSelect: model.applyPerformanceScopeCandidate
+            )
+
+            VStack(alignment: .leading, spacing: 7) {
+              PremiumFieldLabel("ADAPTER")
+              Picker("Performance adapter", selection: $model.performanceAdapter) {
+                ForEach(PerformanceAdapter.allCases) { adapter in
+                  Text(adapter.label).tag(adapter)
+                }
+              }
+              .labelsHidden()
+              .pickerStyle(.menu)
+              .tint(EvidenceStyle.amber)
+              .frame(maxWidth: .infinity, alignment: .leading)
+              .padding(.horizontal, 9)
+              .frame(height: 39)
+              .premiumField()
+            }
+
+            PerformanceTextField(
+              label: "RELATIVE TARGET",
+              icon: "scope",
+              placeholder: "src/cart/cart.test.ts",
+              text: $model.performanceTarget
+            )
+            PerformanceTextField(
+              label: "EXACT TEST OR BENCHMARK · OPTIONAL",
+              icon: "line.3.horizontal.decrease",
+              placeholder: "updates totals",
+              text: $model.performanceName
+            )
+
+            HStack(spacing: 8) {
+              PerformanceNumberField(
+                label: "SAMPLES",
+                value: $model.performanceSamples,
+                range: 2...10
+              )
+              PerformanceNumberField(
+                label: "WARMUPS",
+                value: $model.performanceWarmups,
+                range: 0...5
+              )
+              PerformanceNumberField(
+                label: "TIMEOUT",
+                value: Binding(
+                  get: { max(1, model.performanceTimeoutMS / 1_000) },
+                  set: { model.performanceTimeoutMS = $0 * 1_000 }
+                ),
+                range: 1...120,
+                suffix: "s"
+              )
+            }
+          }
+
+          VStack(alignment: .leading, spacing: 9) {
+            Label("Local · zero egress", systemImage: "network.slash")
+            Label("Rust-owned admission", systemImage: "checkmark.shield")
+            Label("Bounded process cleanup", systemImage: "wind")
+          }
+          .font(.system(size: 10, weight: .medium))
+          .foregroundStyle(.secondary)
+          .padding(13)
+          .frame(maxWidth: .infinity, alignment: .leading)
+          .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 11))
+          .overlay { RoundedRectangle(cornerRadius: 11).stroke(EvidenceStyle.separator) }
+        }
+        .padding(22)
+      }
+
+      Rectangle().fill(EvidenceStyle.separator).frame(height: 1)
+      performanceActionBar
+    }
+    .background(EvidenceStyle.chrome)
+  }
+
+  private var selectedPerformanceCandidateID: String? {
+    model.performanceDiscoveryPlan?.candidates.first(where: {
+      $0.adapter == model.performanceAdapter.rawValue
+        && $0.target == model.performanceTarget
+        && ($0.name ?? "") == model.performanceName
+    })?.id
+  }
+
+  private var performanceActionBar: some View {
+    VStack(alignment: .leading, spacing: 10) {
+      HStack(spacing: 8) {
+        if model.performanceState == .planning || model.performanceState == .running {
+          ProgressView().controlSize(.small).tint(EvidenceStyle.amber)
+        }
+        Text(model.performanceStatusMessage)
+          .font(.system(size: 9, weight: .medium))
+          .foregroundStyle(.secondary)
+          .lineLimit(2)
+      }
+      HStack(spacing: 8) {
+        if model.performanceState == .planning || model.performanceState == .running {
+          Button("Cancel", role: .destructive) { model.cancelPerformance() }
+            .buttonStyle(.bordered)
+        } else {
+          Button("Plan") { model.planPerformance() }
+            .buttonStyle(.bordered)
+            .disabled(!model.canPlanPerformance)
+          Button("Capture evidence") { model.diagnosePerformance() }
+            .buttonStyle(PremiumPrimaryButtonStyle())
+            .disabled(!model.canDiagnosePerformance)
+        }
+        Spacer()
+        StatusPill(label: model.performanceState.rawValue, color: performanceStateColor)
+      }
+      if let issue = currentInputIssue {
+        Text(issue).font(.system(size: 9)).foregroundStyle(.tertiary).lineLimit(2)
+      }
+    }
+    .padding(14)
+    .frame(minHeight: 94)
+  }
+
+  private var evidenceWorkspace: some View {
+    VStack(spacing: 0) {
+      HStack {
+        VStack(alignment: .leading, spacing: 3) {
+          Text(
+            isInspectingRecordedRun ? "RECORDED RUN INSPECTION" : "PERFORMANCE EVIDENCE LANE"
+          )
+          .font(.system(size: 9, weight: .bold, design: .monospaced))
+          .tracking(1.1)
+          .foregroundStyle(EvidenceStyle.amberForeground)
+          Text(
+            isInspectingRecordedRun
+              ? "Read the stored receipt. Verify its digest. Preserve its limits."
+              : "Measure one flow. Change one thing. Prove it."
+          )
+          .font(.system(size: 17, weight: .semibold))
+        }
+        Spacer()
+        if hasPerformanceReceipt {
+          HStack(spacing: 2) {
+            ForEach(PerformanceDetailMode.allCases) { mode in
+              Button {
+                detailMode = mode
+              } label: {
+                Text(mode.rawValue)
+                  .font(.system(size: 10, weight: .semibold))
+                  .foregroundStyle(detailMode == mode ? EvidenceStyle.ink : Color.secondary)
+                  .padding(.horizontal, 13)
+                  .frame(height: 28)
+                  .background(
+                    detailMode == mode ? EvidenceStyle.amber : Color.clear,
+                    in: RoundedRectangle(cornerRadius: 7)
+                  )
+              }
+              .buttonStyle(.plain)
+              .accessibilityAddTraits(detailMode == mode ? .isSelected : [])
+            }
+          }
+          .padding(2)
+          .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 9))
+          .overlay { RoundedRectangle(cornerRadius: 9).stroke(EvidenceStyle.separator) }
+          .accessibilityElement(children: .contain)
+          .accessibilityLabel("Performance receipt detail")
+        }
+        Button("Reset") { model.resetPerformance() }
+          .buttonStyle(.borderless)
+          .disabled(!hasPerformanceReceipt)
+      }
+      .padding(.horizontal, 22)
+      .frame(height: 72)
+      .background(EvidenceStyle.chrome)
+
+      if !isInspectingRecordedRun {
+        PerformanceEvidenceLane(model: model)
+        Rectangle().fill(EvidenceStyle.separator).frame(height: 1)
+      }
+
+      ScrollView {
+        if detailMode == .json, hasPerformanceReceipt {
+          PerformanceJSONDesk(model: model)
+        } else if let inspection = model.performanceResultReceipt,
+          inspection.operation == .inspect
+        {
+          PerformanceRecordedRunDesk(inspection: inspection)
+        } else if let plan = model.performancePlanReceipt {
+          PerformanceReceiptDesk(model: model, plan: plan)
+        } else {
+          emptyEvidence
+        }
+      }
+    }
+  }
+
+  private var emptyEvidence: some View {
+    VStack(spacing: 18) {
+      Image(systemName: "gauge.with.dots.needle.67percent")
+        .font(.system(size: 30, weight: .light))
+        .foregroundStyle(EvidenceStyle.amberForeground)
+      VStack(spacing: 7) {
+        Text("No performance claim without admission.")
+          .font(.system(size: 18, weight: .semibold))
+        Text(
+          "Planning fingerprints the repository, diff, and exact target before project code runs. A blocked plan remains evidence—not a hidden failure."
+        )
+        .font(.system(size: 11))
+        .foregroundStyle(.secondary)
+        .multilineTextAlignment(.center)
+        .frame(maxWidth: 430)
+      }
+      HStack(spacing: 24) {
+        contractStep("01", "Admit", "Exact identity")
+        contractStep("02", "Capture", "Observed proof")
+        contractStep("03", "Diagnose", "Bounded inference")
+        contractStep("04", "Compare", "Paired verdict")
+      }
+      .padding(.top, 8)
+      Label("Authority: codevetter performance", systemImage: "checkmark.seal.fill")
+        .font(.system(size: 10, weight: .semibold, design: .monospaced))
+        .foregroundStyle(EvidenceStyle.success)
+    }
+    .frame(maxWidth: .infinity, minHeight: 450)
+    .padding(28)
+  }
+
+  private func contractStep(_ index: String, _ title: String, _ detail: String) -> some View {
+    VStack(spacing: 6) {
+      Text(index).font(.system(size: 9, weight: .bold, design: .monospaced))
+        .foregroundStyle(EvidenceStyle.amberForeground)
+      Text(title).font(.system(size: 11, weight: .semibold))
+      Text(detail).font(.system(size: 9)).foregroundStyle(.secondary)
+    }
+  }
+
+  private var repositoryLabel: String {
+    guard !model.repositoryPath.isEmpty else { return "No repository selected" }
+    return URL(fileURLWithPath: model.repositoryPath).lastPathComponent
+  }
+
+  private var isInspectingRecordedRun: Bool {
+    model.performanceResultReceipt?.operation == .inspect
+  }
+
+  private var hasPerformanceReceipt: Bool {
+    model.performancePlanReceipt != nil || model.performanceResultReceipt != nil
+  }
+
+  private var currentInputIssue: String? {
+    guard model.performanceState != .planning, model.performanceState != .running else {
+      return nil
+    }
+    if model.performancePlanReceipt?.admitted == true,
+      model.performancePlanScopeFingerprint != model.performanceScopeFingerprint
+    {
+      return "The workload changed. Plan again before capture."
+    }
+    return model.performanceInputIssue
+  }
+
+  private var performanceStateColor: Color {
+    switch model.performanceState {
+    case .completed, .planned: EvidenceStyle.success
+    case .limited: EvidenceStyle.warning
+    case .failed: EvidenceStyle.failure
+    case .planning, .running: EvidenceStyle.amber
+    case .ready, .cancelled: .secondary
+    }
+  }
+}
+
+private struct PerformanceEvidenceLane: View {
+  let model: WorkbenchModel
+
+  var body: some View {
+    HStack(spacing: 0) {
+      step("01", "Scope", state: model.performanceInputIssue == nil ? .ready : .waiting)
+      step("02", "Admit", state: admissionState)
+      step("03", "Capture", state: captureState)
+      step("04", "Compare", state: comparisonState)
+    }
+    .frame(height: 58)
+  }
+
+  private enum LaneState { case waiting, active, ready, blocked }
+
+  private var admissionState: LaneState {
+    if model.performanceState == .planning { return .active }
+    guard let plan = model.performancePlanReceipt else { return .waiting }
+    return plan.admitted ? .ready : .blocked
+  }
+
+  private var captureState: LaneState {
+    if model.performanceState == .running, model.performanceResultReceipt == nil { return .active }
+    guard let receipt = model.performanceResultReceipt else { return .waiting }
+    return receipt.state == .succeeded ? .ready : .blocked
+  }
+
+  private var comparisonState: LaneState {
+    if model.performanceState == .running,
+      model.performanceResultReceipt?.operation == .diagnose
+    {
+      return .active
+    }
+    guard let receipt = model.performanceResultReceipt, receipt.operation == .verifyPaired else {
+      return .waiting
+    }
+    return receipt.state == .succeeded ? .ready : .blocked
+  }
+
+  private func step(_ index: String, _ label: String, state: LaneState) -> some View {
+    HStack(spacing: 9) {
+      Text(index)
+        .font(.system(size: 9, weight: .bold, design: .monospaced))
+        .foregroundStyle(state == .active ? EvidenceStyle.ink : laneColor(state))
+        .frame(width: 25, height: 25)
+        .background(
+          state == .active ? EvidenceStyle.amber : laneColor(state).opacity(0.1), in: Circle())
+      Text(label).font(.system(size: 10, weight: .semibold))
+      Spacer()
+    }
+    .padding(.horizontal, 13)
+    .frame(maxWidth: .infinity)
+    .overlay(alignment: .trailing) { Rectangle().fill(EvidenceStyle.separator).frame(width: 1) }
+  }
+
+  private func laneColor(_ state: LaneState) -> Color {
+    switch state {
+    case .ready: EvidenceStyle.success
+    case .blocked: EvidenceStyle.failure
+    case .active: EvidenceStyle.amber
+    case .waiting: .secondary
+    }
+  }
+}
+
+private struct PerformanceReceiptDesk: View {
+  @Bindable var model: WorkbenchModel
+  let plan: PerformanceRunReceipt
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      VStack(alignment: .leading, spacing: 15) {
+        HStack(alignment: .top) {
+          VStack(alignment: .leading, spacing: 6) {
+            PremiumFieldLabel("EXECUTION PLAN")
+            HStack(spacing: 8) {
+              Circle().fill(plan.admitted ? EvidenceStyle.success : EvidenceStyle.failure)
+                .frame(width: 7, height: 7)
+              Text(plan.outcome.replacingOccurrences(of: "_", with: " ").capitalized)
+                .font(.system(size: 20, weight: .semibold))
+            }
+            Text(plan.summary).font(.system(size: 11)).foregroundStyle(.secondary)
+          }
+          Spacer()
+          StatusPill(
+            label: plan.admitted ? "Admitted" : "Blocked",
+            color: plan.admitted ? EvidenceStyle.success : EvidenceStyle.failure
+          )
+        }
+
+        HStack(spacing: 8) {
+          planMetric("MODE", plan.result.value(at: "mode")?.displayValue ?? "—")
+          planMetric(
+            "PROCESSES", plan.result.value(at: "limits", "max_processes")?.displayValue ?? "—")
+          planMetric(
+            "EGRESS",
+            plan.result.value(at: "limits", "max_external_requests")?.displayValue == "0"
+              ? "Blocked" : "Unknown")
+          planMetric(
+            "COST",
+            plan.result.value(at: "limits", "max_cost_microusd")?.displayValue == "0"
+              ? "$0" : "Unknown")
+          planMetric("CLEANUP", plan.cleanup.ownedProcessReaped ? "Reaped" : "Unproven")
+        }
+      }
+      .padding(22)
+
+      if !plan.blockers.isEmpty {
+        ReceiptList(title: "BLOCKERS", items: plan.blockers, color: EvidenceStyle.failure)
+      }
+
+      if let resources = model.performanceResultReceipt?.resources ?? plan.resources {
+        Rectangle().fill(EvidenceStyle.separator).frame(height: 1)
+        resourceEvidence(resources)
+      }
+
+      if let result = model.performanceResultReceipt {
+        Rectangle().fill(EvidenceStyle.separator).frame(height: 1)
+        VStack(alignment: .leading, spacing: 16) {
+          HStack {
+            VStack(alignment: .leading, spacing: 5) {
+              PremiumFieldLabel(
+                result.operation == .verifyPaired ? "PAIRED VERIFICATION" : "CAPTURED DIAGNOSIS")
+              Text(result.outcome.replacingOccurrences(of: "_", with: " ").capitalized)
+                .font(.system(size: 18, weight: .semibold))
+              Text(result.summary).font(.system(size: 11)).foregroundStyle(.secondary)
+            }
+            Spacer()
+            StatusPill(
+              label: result.state.rawValue.replacingOccurrences(of: "_", with: " "),
+              color: resultColor(result))
+          }
+          evidenceSection(
+            "OBSERVED", rows: result.evidenceRows("observed"), color: EvidenceStyle.success)
+          evidenceSection(
+            "INFERRED", rows: result.evidenceRows("inferred"), color: EvidenceStyle.amber)
+          evidenceSection(
+            "UNVERIFIED", rows: result.evidenceRows("unverified"), color: EvidenceStyle.warning)
+        }
+        .padding(22)
+      }
+
+      if plan.admitted, model.performanceResultReceipt != nil {
+        Rectangle().fill(EvidenceStyle.separator).frame(height: 1)
+        pairedVerification
+      }
+
+      let limitations = (plan.limitations + (model.performanceResultReceipt?.limitations ?? []))
+      if !limitations.isEmpty {
+        ReceiptList(
+          title: "LIMITATIONS", items: Array(Set(limitations)).sorted(),
+          color: EvidenceStyle.warning)
+      }
+    }
+  }
+
+  private var pairedVerification: some View {
+    let presentation = campaignPresentation
+    return VStack(alignment: .leading, spacing: 12) {
+      HStack {
+        VStack(alignment: .leading, spacing: 4) {
+          PremiumFieldLabel("AGENT CAMPAIGN HANDOFF")
+          Text(presentation.summary)
+            .font(.system(size: 11, weight: .medium))
+        }
+        Spacer()
+        if model.performanceResultReceipt?.operation == .diagnose {
+          Button("Choose baseline…") { model.choosingPerformanceBaseline = true }
+            .buttonStyle(.bordered)
+            .accessibilityLabel("Choose performance baseline repository")
+          Button("Verify paired") { model.verifyPairedPerformance() }
+            .buttonStyle(PremiumPrimaryButtonStyle())
+            .disabled(!model.canVerifyPairedPerformance)
+        }
+      }
+      HStack(spacing: 8) {
+        campaignCell("BASELINE", presentation.baseline, ready: true)
+        campaignCell("CANDIDATE", presentation.candidate, ready: presentation.confirmed)
+        campaignCell("PROMOTION", presentation.promotion, ready: presentation.confirmed)
+      }
+      Text(baselineLabel)
+        .font(.system(size: 9, design: .monospaced))
+        .foregroundStyle(.secondary)
+        .lineLimit(1)
+        .truncationMode(.middle)
+      if model.performanceResultReceipt?.operation == .diagnose,
+        !model.canVerifyPairedPerformance, let issue = model.performancePairedInputIssue
+      {
+        Text(issue).font(.system(size: 9)).foregroundStyle(.tertiary)
+      }
+    }
+    .padding(22)
+  }
+
+  private var campaignPresentation:
+    (
+      summary: String, baseline: String, candidate: String, promotion: String, confirmed: Bool
+    )
+  {
+    guard let result = model.performanceResultReceipt, result.operation == .verifyPaired else {
+      return (
+        "Change one thing, then compare it against an exact baseline checkout.",
+        "Receipt captured",
+        "Awaiting one change",
+        "Requires paired proof",
+        false
+      )
+    }
+    let confirmed = result.outcome == "confirmed" && result.state == .succeeded
+    return confirmed
+      ? (
+        "The paired candidate and baseline were compared under the same admitted scope.",
+        "Paired baseline",
+        "Candidate accepted",
+        "Confirmed",
+        true
+      )
+      : (
+        "The paired comparison did not produce promotable evidence.",
+        "Paired baseline",
+        "Not comparable",
+        "Blocked",
+        false
+      )
+  }
+
+  private func campaignCell(_ label: String, _ value: String, ready: Bool) -> some View {
+    VStack(alignment: .leading, spacing: 5) {
+      PremiumFieldLabel(label)
+      Text(value)
+        .font(.system(size: 9, weight: .semibold))
+        .foregroundStyle(ready ? EvidenceStyle.success : Color.secondary)
+        .lineLimit(1)
+    }
+    .padding(10)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 9))
+    .overlay { RoundedRectangle(cornerRadius: 9).stroke(EvidenceStyle.separator) }
+  }
+
+  private var baselineLabel: String {
+    model.performanceBaselineRepositoryPath.isEmpty
+      ? "No baseline repository selected" : model.performanceBaselineRepositoryPath
+  }
+
+  private func planMetric(_ label: String, _ value: String) -> some View {
+    VStack(alignment: .leading, spacing: 5) {
+      PremiumFieldLabel(label)
+      Text(value).font(.system(size: 10, weight: .semibold, design: .monospaced)).lineLimit(1)
+    }
+    .padding(11)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 9))
+    .overlay { RoundedRectangle(cornerRadius: 9).stroke(EvidenceStyle.separator) }
+  }
+
+  @ViewBuilder
+  private func evidenceSection(_ title: String, rows: [PerformanceJSONValue], color: Color)
+    -> some View
+  {
+    if !rows.isEmpty {
+      LazyVStack(alignment: .leading, spacing: 8) {
+        PremiumFieldLabel(title)
+        ForEach(Array(rows.prefix(performanceEvidencePreviewLimit).enumerated()), id: \.offset) {
+          _, row in
+          HStack(alignment: .top, spacing: 9) {
+            Circle().fill(color).frame(width: 5, height: 5).padding(.top, 5)
+            VStack(alignment: .leading, spacing: 3) {
+              Text(
+                row.value(at: "summary")?.stringValue ?? row.value(at: "kind")?.displayValue
+                  ?? "Evidence"
+              )
+              .font(.system(size: 10, weight: .semibold))
+              Text(row.displayValue).font(.system(size: 9, design: .monospaced)).foregroundStyle(
+                .secondary
+              )
+              .lineLimit(3)
+            }
+          }
+        }
+        if rows.count > performanceEvidencePreviewLimit {
+          Text(
+            "+ \(rows.count - performanceEvidencePreviewLimit) more evidence rows in canonical JSON"
+          )
+          .font(.system(size: 8, design: .monospaced))
+          .foregroundStyle(.secondary)
+        }
+      }
+    }
+  }
+
+  private func resultColor(_ receipt: PerformanceRunReceipt) -> Color {
+    switch receipt.state {
+    case .succeeded: EvidenceStyle.success
+    case .completedWithRejection: EvidenceStyle.failure
+    case .noConfidence: EvidenceStyle.warning
+    case .cancelled: .secondary
+    }
+  }
+
+  private func resourceEvidence(_ resources: PerformanceResourceReceipt) -> some View {
+    VStack(alignment: .leading, spacing: 11) {
+      HStack {
+        VStack(alignment: .leading, spacing: 4) {
+          PremiumFieldLabel("OWNED PROCESS TREE")
+          Text("Periodically sampled while the Rust-supervised operation was active.")
+            .font(.system(size: 10))
+            .foregroundStyle(.secondary)
+        }
+        Spacer()
+        StatusPill(
+          label: resources.samples > 0 ? "Observed" : "Unavailable",
+          color: resources.samples > 0 ? EvidenceStyle.success : EvidenceStyle.warning)
+      }
+      HStack(spacing: 8) {
+        planMetric(
+          "PEAK RSS",
+          resources.peakRSSBytes.map {
+            ByteCountFormatter.string(fromByteCount: Int64($0), countStyle: .memory)
+          } ?? "—")
+        planMetric("PEAK PROCESSES", resources.peakProcesses.map(String.init) ?? "—")
+        planMetric("SAMPLES", String(resources.samples))
+        planMetric("INTERVAL", "\(resources.sampleIntervalMS)ms")
+      }
+      ForEach(resources.limitations, id: \.self) { limitation in
+        Text(limitation).font(.system(size: 9)).foregroundStyle(.tertiary)
+      }
+    }
+    .padding(22)
+  }
+}
+
+private struct PerformanceRecordedRunDesk: View {
+  let inspection: PerformanceRunReceipt
+
+  private var receipt: PerformanceJSONValue? { inspection.result.value(at: "receipt") }
+  private var resultSummary: PerformanceJSONValue? {
+    inspection.result.value(at: "result_summary")
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      VStack(alignment: .leading, spacing: 16) {
+        HStack(alignment: .top) {
+          VStack(alignment: .leading, spacing: 6) {
+            PremiumFieldLabel("CANONICAL STORED RECEIPT")
+            Text(runID)
+              .font(.system(size: 20, weight: .semibold, design: .monospaced))
+            Text(
+              "The Rust core re-read the bounded receipt, verified its result digest, and returned only recorded evidence."
+            )
+            .font(.system(size: 11))
+            .foregroundStyle(.secondary)
+          }
+          Spacer()
+          StatusPill(label: runState.replacingOccurrences(of: "_", with: " "), color: stateColor)
+        }
+
+        HStack(spacing: 8) {
+          metric("ADAPTER", value("scope", "adapter"))
+          metric("TARGET", value("scope", "target"))
+          metric("REVISION", short(value("subject", "repository_revision")))
+          metric("DIRTY", value("subject", "dirty"))
+        }
+      }
+      .padding(22)
+
+      Rectangle().fill(EvidenceStyle.separator).frame(height: 1)
+
+      LazyVGrid(
+        columns: [GridItem(.flexible()), GridItem(.flexible()), GridItem(.flexible())],
+        alignment: .leading,
+        spacing: 18
+      ) {
+        detail("CREATED", value("lifecycle", "created_at"))
+        detail("STARTED", value("lifecycle", "started_at"))
+        detail("COMPLETED", value("lifecycle", "completed_at"))
+        detail("SAMPLES", value("policy", "samples"))
+        detail("WARMUPS", value("policy", "warmups"))
+        detail("TIMEOUT", milliseconds(value("policy", "timeout_ms")))
+        detail("CHILD PID", value("child", "pid"))
+        detail("EXIT", value("child", "exit_code"))
+        detail("SIGNAL", value("child", "signal"))
+        detail("RESULT BYTES", bytes(value("result", "bytes")))
+        detail("STDOUT", bytes(value("capture", "stdout_bytes")))
+        detail("STDERR", bytes(value("capture", "stderr_bytes")))
+      }
+      .padding(22)
+
+      if let diagnosis = resultSummary?.value(at: "diagnosis", "summary")?.stringValue {
+        Rectangle().fill(EvidenceStyle.separator).frame(height: 1)
+        VStack(alignment: .leading, spacing: 9) {
+          PremiumFieldLabel("RECORDED RESULT SUMMARY")
+          Text(diagnosis).font(.system(size: 12, weight: .medium))
+          if let verdict = resultSummary?.value(at: "verdict", "status")?.stringValue {
+            Text("Verdict · \(verdict.replacingOccurrences(of: "_", with: " "))")
+              .font(.system(size: 9, weight: .semibold, design: .monospaced))
+              .foregroundStyle(EvidenceStyle.amberForeground)
+          }
+        }
+        .padding(22)
+      }
+
+      let limitations = receipt?.value(at: "limitations")?.arrayValue?.map(\.displayValue) ?? []
+      if !limitations.isEmpty {
+        ReceiptList(title: "LIMITATIONS", items: limitations, color: EvidenceStyle.warning)
+      }
+
+      if let failure = receipt?.value(at: "failure"), failure.objectValue != nil,
+        failure.displayValue != "—"
+      {
+        Rectangle().fill(EvidenceStyle.separator).frame(height: 1)
+        VStack(alignment: .leading, spacing: 8) {
+          PremiumFieldLabel("RECORDED FAILURE")
+          Text(failure.value(at: "operational_error")?.displayValue ?? failure.displayValue)
+            .font(.system(size: 10, design: .monospaced))
+            .foregroundStyle(EvidenceStyle.failure)
+            .textSelection(.enabled)
+        }
+        .padding(22)
+      }
+    }
+  }
+
+  private var runID: String { value("run_id") }
+  private var runState: String { value("state") }
+
+  private var stateColor: Color {
+    switch runState {
+    case "succeeded": EvidenceStyle.success
+    case "running", "initialized": EvidenceStyle.amber
+    case "blocked", "failed", "timed_out", "signaled", "spawn_failed", "invalid_result":
+      EvidenceStyle.failure
+    default: .secondary
+    }
+  }
+
+  private func value(_ path: String...) -> String {
+    path.reduce(receipt) { current, key in current?.objectValue?[key] }?.displayValue ?? "—"
+  }
+
+  private func short(_ value: String) -> String {
+    value.count > 12 ? String(value.prefix(12)) : value
+  }
+
+  private func milliseconds(_ value: String) -> String {
+    guard let number = Double(value) else { return value }
+    return number >= 1_000 ? String(format: "%.1fs", number / 1_000) : "\(Int(number))ms"
+  }
+
+  private func bytes(_ value: String) -> String {
+    guard let number = Double(value) else { return value }
+    return ByteCountFormatter.string(fromByteCount: Int64(number), countStyle: .file)
+  }
+
+  private func metric(_ label: String, _ value: String) -> some View {
+    VStack(alignment: .leading, spacing: 5) {
+      PremiumFieldLabel(label)
+      Text(value)
+        .font(.system(size: 10, weight: .semibold, design: .monospaced))
+        .lineLimit(1)
+        .truncationMode(.middle)
+    }
+    .padding(11)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 9))
+    .overlay { RoundedRectangle(cornerRadius: 9).stroke(EvidenceStyle.separator) }
+  }
+
+  private func detail(_ label: String, _ value: String) -> some View {
+    VStack(alignment: .leading, spacing: 5) {
+      PremiumFieldLabel(label)
+      Text(value)
+        .font(.system(size: 10, weight: .medium, design: .monospaced))
+        .lineLimit(1)
+        .truncationMode(.middle)
+    }
+  }
+}
+
+private struct PerformanceJSONDesk: View {
+  let model: WorkbenchModel
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 14) {
+      PremiumFieldLabel("CANONICAL RUST RECEIPT")
+      Text(
+        model.performanceResultReceiptJSON.isEmpty
+          ? model.performancePlanReceiptJSON : model.performanceResultReceiptJSON
+      )
+      .font(.system(size: 9, design: .monospaced))
+      .textSelection(.enabled)
+      .foregroundStyle(.secondary)
+      .frame(maxWidth: .infinity, alignment: .leading)
+      if !model.performanceResultReceiptJSON.isEmpty {
+        Rectangle().fill(EvidenceStyle.separator).frame(height: 1)
+        PremiumFieldLabel("ADMISSION RECEIPT")
+        Text(model.performancePlanReceiptJSON)
+          .font(.system(size: 9, design: .monospaced))
+          .textSelection(.enabled)
+          .foregroundStyle(.secondary)
+      }
+    }
+    .padding(22)
+  }
+}
+
+private struct ReceiptList: View {
+  let title: String
+  let items: [String]
+  let color: Color
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      PremiumFieldLabel(title)
+      ForEach(items, id: \.self) { item in
+        HStack(alignment: .top, spacing: 8) {
+          Circle().fill(color).frame(width: 5, height: 5).padding(.top, 5)
+          Text(item).font(.system(size: 10)).foregroundStyle(.secondary)
+        }
+      }
+    }
+    .padding(.horizontal, 22)
+    .padding(.vertical, 16)
+  }
+}
+
+private struct PerformanceTextField: View {
+  let label: String
+  let icon: String
+  let placeholder: String
+  @Binding var text: String
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 7) {
+      PremiumFieldLabel(label)
+      HStack(spacing: 9) {
+        Image(systemName: icon).foregroundStyle(EvidenceStyle.amberForeground)
+        TextField(placeholder, text: $text)
+          .textFieldStyle(.plain)
+          .font(.system(size: 11, design: .monospaced))
+      }
+      .padding(.horizontal, 12)
+      .frame(height: 41)
+      .premiumField()
+    }
+  }
+}
+
+private struct PerformanceNumberField: View {
+  let label: String
+  @Binding var value: Int
+  let range: ClosedRange<Int>
+  var suffix = ""
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 6) {
+      PremiumFieldLabel(label)
+      Stepper(value: $value, in: range) {
+        Text("\(value)\(suffix)")
+          .font(.system(size: 10, weight: .semibold, design: .monospaced))
+      }
+      .labelsHidden()
+      Text("\(value)\(suffix)")
+        .font(.system(size: 10, weight: .semibold, design: .monospaced))
+        .frame(maxWidth: .infinity, alignment: .center)
+    }
+    .padding(9)
+    .frame(maxWidth: .infinity)
+    .premiumField()
+    .accessibilityElement(children: .contain)
+    .accessibilityLabel(label.capitalized)
+    .accessibilityValue("\(value)\(suffix)")
+  }
+}

--- a/apps/macos/CodeVetterPackage/Sources/CodeVetterFeature/PremiumSettingsView.swift
+++ b/apps/macos/CodeVetterPackage/Sources/CodeVetterFeature/PremiumSettingsView.swift
@@ -1,0 +1,1948 @@
+import AppKit
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct PremiumSettingsView: View {
+  @Bindable var model: WorkbenchModel
+  @State private var copiedMcpValue: String?
+  @State private var confirmingAuditClear = false
+  @State private var confirmingRetentionApply = false
+  @State private var confirmingRetentionVacuum = false
+  @State private var retentionAgeDays = "90"
+  @State private var retentionMaxMiB = "2048"
+  @State private var expandedRubricID: String?
+  @State private var newRubricName = ""
+  @State private var newRubricFocus = ""
+  @State private var newRubricChecks = ""
+  @State private var memorySourceQuery = ""
+  @State private var memoryContentQuery = ""
+  @State private var copiedMemory = false
+
+  var body: some View {
+    VStack(spacing: 0) {
+      header
+      Rectangle().fill(EvidenceStyle.separator).frame(height: 1)
+      HStack(spacing: 0) {
+        sectionRail
+          .frame(width: 230)
+        Rectangle().fill(EvidenceStyle.separator).frame(width: 1)
+        settingsDesk
+      }
+    }
+    .background(EvidenceStyle.canvas)
+    .fileImporter(
+      isPresented: $model.choosingRepository,
+      allowedContentTypes: [.folder],
+      allowsMultipleSelection: false
+    ) { result in
+      guard case .success(let urls) = result, let url = urls.first else { return }
+      model.selectRepository(url)
+      if model.settingsSection == .mcp { model.loadMcpSettings() }
+    }
+    .fileImporter(
+      isPresented: $model.choosingHistoryRoot,
+      allowedContentTypes: [.folder],
+      allowsMultipleSelection: false
+    ) { result in
+      guard case .success(let urls) = result, let url = urls.first else { return }
+      model.addHistoryRoot(url)
+    }
+    .task(id: model.settingsSection) {
+      if model.settingsSection == .mcp, !model.repositoryPath.isEmpty,
+        model.mcpSettingsReceipt == nil
+      {
+        model.loadMcpSettings()
+      } else if model.settingsSection == .rubrics, model.rubricReceipt == nil {
+        model.loadRubrics()
+      } else if model.settingsSection == .usage, model.historyRootsReceipt == nil {
+        model.loadHistoryRoots()
+      } else if model.settingsSection == .memories, model.memoryReceipt == nil {
+        model.loadMemories()
+      } else if model.settingsSection == .ops, model.opsReceipt == nil {
+        model.loadOpsStatus()
+      }
+    }
+    .confirmationDialog(
+      "Clear bounded MCP access metadata?",
+      isPresented: $confirmingAuditClear,
+      titleVisibility: .visible
+    ) {
+      Button("Clear access audit", role: .destructive) {
+        model.runMcpSettings(operation: .clearAudit)
+      }
+      Button("Cancel", role: .cancel) {}
+    } message: {
+      Text(
+        "This removes operational access rows only. It does not change repository evidence or MCP enablement."
+      )
+    }
+    .confirmationDialog(
+      "Apply this exact retention plan?",
+      isPresented: $confirmingRetentionApply,
+      titleVisibility: .visible
+    ) {
+      Button("Apply reviewed plan", role: .destructive) {
+        model.applyReviewedRetentionPlan()
+      }
+      Button("Cancel", role: .cancel) {}
+    } message: {
+      Text(retentionApplyConfirmation)
+    }
+    .confirmationDialog(
+      "Checkpoint and compact the local archive?",
+      isPresented: $confirmingRetentionVacuum,
+      titleVisibility: .visible
+    ) {
+      Button("Checkpoint + VACUUM", role: .destructive) {
+        model.checkpointSessionArchive(vacuum: true)
+      }
+      Button("Cancel", role: .cancel) {}
+    } message: {
+      Text(
+        "VACUUM rewrites the local SQLite archive after checkpointing. It does not remove provider transcripts or apply a retention plan."
+      )
+    }
+  }
+
+  private var header: some View {
+    HStack(alignment: .top, spacing: 18) {
+      VStack(alignment: .leading, spacing: 5) {
+        Text("LOCAL CONTROL PLANE")
+          .font(.system(size: 9, weight: .bold, design: .monospaced))
+          .tracking(1.1)
+          .foregroundStyle(EvidenceStyle.amberForeground)
+        Text("Settings").font(.system(size: 25, weight: .semibold))
+        Text("Rust-persisted preferences with a deliberately non-secret native projection")
+          .font(.system(size: 10))
+          .foregroundStyle(.secondary)
+      }
+      Spacer()
+      StatusPill(
+        label: model.opsLoading
+          ? "Reading aggregates"
+          : (model.settingsLoading ? "Reading preferences" : "Secrets excluded"),
+        color: (model.settingsIssue == nil && model.opsIssue == nil)
+          ? EvidenceStyle.success : EvidenceStyle.warning
+      )
+      Button {
+        if model.settingsSection == .ops {
+          model.loadOpsStatus()
+        } else {
+          model.loadNativeSettings()
+        }
+      } label: {
+        Label("Refresh", systemImage: "arrow.clockwise")
+      }
+      .buttonStyle(.bordered)
+      .disabled(model.settingsLoading || model.opsLoading)
+      .accessibilityLabel(
+        model.settingsSection == .ops ? "Refresh operational evidence" : "Refresh native settings"
+      )
+    }
+    .padding(.horizontal, 22)
+    .padding(.vertical, 18)
+    .background(EvidenceStyle.chrome)
+  }
+
+  private var sectionRail: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      PremiumFieldLabel("SETTINGS SECTIONS")
+        .padding(16)
+      Rectangle().fill(EvidenceStyle.separator).frame(height: 1)
+      ScrollView {
+        LazyVStack(spacing: 4) {
+          ForEach(NativeSettingsSection.allCases) { section in
+            Button {
+              model.settingsSection = section
+            } label: {
+              HStack(spacing: 10) {
+                Image(systemName: section.systemImage)
+                  .frame(width: 18)
+                  .foregroundStyle(
+                    model.settingsSection == section
+                      ? EvidenceStyle.amberForeground : Color.secondary)
+                Text(section.label).font(.system(size: 10, weight: .semibold))
+                Spacer()
+                if !settings(in: section).isEmpty {
+                  Text("\(settings(in: section).count)")
+                    .font(.system(size: 8, design: .monospaced))
+                    .foregroundStyle(.secondary)
+                }
+              }
+              .padding(.horizontal, 12)
+              .frame(height: 36)
+              .contentShape(Rectangle())
+              .background(
+                model.settingsSection == section ? EvidenceStyle.amber.opacity(0.09) : Color.clear,
+                in: RoundedRectangle(cornerRadius: 9)
+              )
+              .overlay {
+                RoundedRectangle(cornerRadius: 9).stroke(
+                  model.settingsSection == section
+                    ? EvidenceStyle.amber.opacity(0.25) : Color.clear)
+              }
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(section.label)
+            .accessibilityIdentifier("settings-section-\(section.rawValue)")
+            .accessibilityValue(model.settingsSection == section ? "Selected" : "")
+            .accessibilityAddTraits(model.settingsSection == section ? .isSelected : [])
+            .accessibilityRemoveTraits(model.settingsSection == section ? [] : .isSelected)
+          }
+        }
+        .padding(10)
+      }
+      Rectangle().fill(EvidenceStyle.separator).frame(height: 1)
+      VStack(alignment: .leading, spacing: 6) {
+        Label("Rust owns persistence", systemImage: "lock.shield.fill")
+          .foregroundStyle(EvidenceStyle.success)
+        Text(
+          "Swift receives declared values only. Credentials and provider tokens never enter this receipt."
+        )
+        .foregroundStyle(.secondary)
+      }
+      .font(.system(size: 8))
+      .padding(14)
+    }
+    .background(EvidenceStyle.inspector)
+  }
+
+  @ViewBuilder
+  private var settingsDesk: some View {
+    if model.settingsLoading, model.settingsReceipt == nil,
+      ![NativeSettingsSection.mcp, .usage, .rubrics, .memories, .ops, .about].contains(
+        model.settingsSection)
+    {
+      VStack(spacing: 12) {
+        ProgressView().controlSize(.small).tint(EvidenceStyle.amber)
+        Text("Opening declared settings…").font(.system(size: 12, weight: .medium))
+        Text("No credential value is requested by this projection.")
+          .font(.system(size: 9))
+          .foregroundStyle(.secondary)
+      }
+      .frame(maxWidth: .infinity, maxHeight: .infinity)
+    } else {
+      ScrollView {
+        LazyVStack(alignment: .leading, spacing: 14) {
+          sectionHeader
+          if let issue = model.settingsIssue {
+            Label(issue, systemImage: "exclamationmark.triangle.fill")
+              .font(.system(size: 10))
+              .foregroundStyle(EvidenceStyle.warning)
+              .padding(14)
+              .frame(maxWidth: .infinity, alignment: .leading)
+              .background(
+                EvidenceStyle.warning.opacity(0.08), in: RoundedRectangle(cornerRadius: 10))
+          }
+          if model.settingsSection == .mcp {
+            mcpPanel
+          } else if model.settingsSection == .usage {
+            usagePanel
+          } else if model.settingsSection == .rubrics {
+            rubricPanel
+          } else if model.settingsSection == .memories {
+            memoryPanel
+          } else if model.settingsSection == .agentIsland {
+            agentIslandPanel
+          } else if model.settingsSection == .ops {
+            opsPanel
+          } else if model.settingsSection == .about {
+            aboutPanel
+          } else if settings(in: model.settingsSection).isEmpty {
+            transferredSurface
+          } else {
+            VStack(spacing: 0) {
+              ForEach(Array(settings(in: model.settingsSection).enumerated()), id: \.element.id) {
+                index, setting in
+                NativeSettingRow(
+                  setting: setting,
+                  saving: model.settingsSavingKeys.contains(setting.key),
+                  save: { model.saveNativeSetting(key: setting.key, value: $0) }
+                )
+                if index < settings(in: model.settingsSection).count - 1 {
+                  Rectangle().fill(EvidenceStyle.separator).frame(height: 1)
+                }
+              }
+            }
+            .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 14))
+            .overlay { RoundedRectangle(cornerRadius: 14).stroke(EvidenceStyle.separator) }
+          }
+          projectionBoundary
+        }
+        .padding(22)
+        .frame(maxWidth: 820, alignment: .leading)
+      }
+    }
+  }
+
+  private var sectionHeader: some View {
+    HStack(alignment: .top) {
+      VStack(alignment: .leading, spacing: 5) {
+        PremiumFieldLabel(model.settingsSection.rawValue.uppercased())
+        Text(model.settingsSection.label).font(.system(size: 22, weight: .semibold))
+        Text(sectionDescription)
+          .font(.system(size: 10))
+          .foregroundStyle(.secondary)
+      }
+      Spacer()
+      Text(sectionStatusLabel)
+        .font(.system(size: 8, weight: .bold, design: .monospaced))
+        .foregroundStyle(sectionStatusColor)
+    }
+  }
+
+  private var transferredSurface: some View {
+    VStack(alignment: .leading, spacing: 14) {
+      Label(transferTitle, systemImage: model.settingsSection.systemImage)
+        .font(.system(size: 14, weight: .semibold))
+      Text(transferDetail)
+        .font(.system(size: 10))
+        .foregroundStyle(.secondary)
+        .fixedSize(horizontal: false, vertical: true)
+      HStack(spacing: 8) {
+        StatusPill(label: "Incumbent authority retained", color: EvidenceStyle.warning)
+        Text("No preference, credential, or destructive action is silently substituted.")
+          .font(.system(size: 8))
+          .foregroundStyle(.secondary)
+      }
+    }
+    .padding(18)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 14))
+    .overlay { RoundedRectangle(cornerRadius: 14).stroke(EvidenceStyle.separator) }
+  }
+
+  private var agentIslandPanel: some View {
+    VStack(alignment: .leading, spacing: 14) {
+      HStack(alignment: .center, spacing: 18) {
+        VStack(alignment: .leading, spacing: 7) {
+          PremiumFieldLabel("PRESENTATION CONTRACT")
+          Text("A calm status surface, not another agent runtime")
+            .font(.system(size: 15, weight: .semibold))
+          Text(
+            "These preferences are shared with the retained supervised helper. The new Evidence Workbench does not yet launch it, read transcripts, or action provider requests."
+          )
+          .font(.system(size: 9))
+          .foregroundStyle(.secondary)
+          .fixedSize(horizontal: false, vertical: true)
+          HStack(spacing: 7) {
+            StatusPill(
+              label: agentIslandEnabled ? "Preference enabled" : "Off by default",
+              color: agentIslandEnabled ? EvidenceStyle.success : EvidenceStyle.warning
+            )
+            StatusPill(label: "Runtime transfer pending", color: EvidenceStyle.warning)
+          }
+        }
+        Spacer(minLength: 18)
+        VStack(spacing: 8) {
+          HStack(spacing: 7) {
+            Circle().fill(EvidenceStyle.amber).frame(width: 7, height: 7)
+            Text("CODEX · REVIEW READY")
+              .font(.system(size: 8, weight: .bold, design: .monospaced))
+              .foregroundStyle(Color.white.opacity(0.86))
+            Text("+2")
+              .font(.system(size: 8, weight: .bold, design: .monospaced))
+              .foregroundStyle(EvidenceStyle.amber)
+          }
+          .padding(.horizontal, 13)
+          .frame(height: 30)
+          .background(Color.black, in: Capsule())
+          .overlay { Capsule().stroke(EvidenceStyle.amber.opacity(0.32)) }
+          Text("Non-activating preview · no live session content")
+            .font(.system(size: 7, design: .monospaced))
+            .foregroundStyle(.secondary)
+        }
+      }
+      .padding(18)
+      .background(EvidenceStyle.inspector, in: RoundedRectangle(cornerRadius: 14))
+      .overlay { RoundedRectangle(cornerRadius: 14).stroke(EvidenceStyle.separator) }
+
+      VStack(spacing: 0) {
+        ForEach(Array(settings(in: .agentIsland).enumerated()), id: \.element.id) {
+          index, setting in
+          NativeSettingRow(
+            setting: setting,
+            saving: model.settingsSavingKeys.contains(setting.key),
+            save: { model.saveNativeSetting(key: setting.key, value: $0) }
+          )
+          if index < settings(in: .agentIsland).count - 1 {
+            Rectangle().fill(EvidenceStyle.separator).frame(height: 1)
+          }
+        }
+      }
+      .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 14))
+      .overlay { RoundedRectangle(cornerRadius: 14).stroke(EvidenceStyle.separator) }
+
+      HStack(alignment: .top, spacing: 10) {
+        Image(systemName: "lock.shield.fill").foregroundStyle(EvidenceStyle.success)
+        Text(
+          "Swift receives preference labels and values only. Session identities, prompts, output, commands, paths, provider responses, and credentials are excluded from this settings receipt."
+        )
+        .font(.system(size: 9))
+        .foregroundStyle(.secondary)
+      }
+      .padding(.horizontal, 4)
+    }
+  }
+
+  private var usagePanel: some View {
+    VStack(alignment: .leading, spacing: 14) {
+      historyRootsPanel
+      retentionPanel
+    }
+  }
+
+  private var opsPanel: some View {
+    VStack(alignment: .leading, spacing: 14) {
+      HStack(alignment: .top, spacing: 18) {
+        VStack(alignment: .leading, spacing: 7) {
+          PremiumFieldLabel("READ-ONLY OPERATIONS RECEIPT")
+          Text("Operational evidence without credential exposure")
+            .font(.system(size: 15, weight: .semibold))
+          Text(
+            "Rust reads aggregate local evidence and configuration presence. This path never fetches a provider invoice, returns a key or endpoint, or sends a webhook."
+          )
+          .font(.system(size: 9))
+          .foregroundStyle(.secondary)
+          .fixedSize(horizontal: false, vertical: true)
+        }
+        Spacer(minLength: 12)
+        StatusPill(
+          label: model.opsReceipt?.databaseAvailable == true ? "LOCAL EVIDENCE" : "NO LOCAL STORE",
+          color: model.opsReceipt?.databaseAvailable == true
+            ? EvidenceStyle.success : EvidenceStyle.warning
+        )
+      }
+      .padding(18)
+      .background(EvidenceStyle.inspector, in: RoundedRectangle(cornerRadius: 14))
+      .overlay { RoundedRectangle(cornerRadius: 14).stroke(EvidenceStyle.separator) }
+
+      HStack(spacing: 7) {
+        PremiumFieldLabel("AGGREGATE WINDOW")
+        Spacer()
+        ForEach([7, 30, 90], id: \.self) { days in
+          Button {
+            model.loadOpsStatus(windowDays: days)
+          } label: {
+            Text("\(days)d")
+              .font(.system(size: 9, weight: .semibold, design: .monospaced))
+              .padding(.horizontal, 10)
+              .frame(height: 26)
+              .foregroundStyle(
+                model.opsWindowDays == days ? EvidenceStyle.amberForeground : .secondary
+              )
+              .background(
+                model.opsWindowDays == days ? EvidenceStyle.amber.opacity(0.12) : Color.clear,
+                in: RoundedRectangle(cornerRadius: 7)
+              )
+              .overlay {
+                RoundedRectangle(cornerRadius: 7).stroke(
+                  model.opsWindowDays == days
+                    ? EvidenceStyle.amber.opacity(0.35) : EvidenceStyle.separator)
+              }
+          }
+          .buttonStyle(.plain)
+          .disabled(model.opsLoading)
+          .accessibilityLabel("Show \(days) day operational evidence")
+        }
+      }
+
+      if model.opsLoading, model.opsReceipt == nil {
+        HStack(spacing: 10) {
+          ProgressView().controlSize(.small).tint(EvidenceStyle.amber)
+          Text("Reading bounded local aggregates…")
+            .font(.system(size: 10, weight: .medium))
+        }
+        .padding(18)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 14))
+      } else if let issue = model.opsIssue, model.opsReceipt == nil {
+        Label(issue, systemImage: "exclamationmark.triangle.fill")
+          .font(.system(size: 10))
+          .foregroundStyle(EvidenceStyle.warning)
+          .padding(18)
+          .frame(maxWidth: .infinity, alignment: .leading)
+          .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 14))
+      } else if let receipt = model.opsReceipt {
+        HStack(spacing: 10) {
+          settingsMetric(
+            "ANTHROPIC BILLING",
+            receipt.billing.anthropicConfigured ? "Configured" : "Not configured")
+          settingsMetric(
+            "OPENAI BILLING",
+            receipt.billing.openaiConfigured ? "Configured" : "Not configured")
+          settingsMetric(
+            "WEBHOOK",
+            receipt.webhook.configured ? "Configured · \(receipt.webhook.flavor)" : "Not configured"
+          )
+        }
+
+        VStack(spacing: 0) {
+          HStack(spacing: 10) {
+            PremiumFieldLabel("TASK TYPE").frame(maxWidth: .infinity, alignment: .leading)
+            PremiumFieldLabel("SESSIONS").frame(width: 62, alignment: .trailing)
+            PremiumFieldLabel("SUCCESS").frame(width: 62, alignment: .trailing)
+            PremiumFieldLabel("FAIL").frame(width: 52, alignment: .trailing)
+            PremiumFieldLabel("RATE").frame(width: 58, alignment: .trailing)
+            PremiumFieldLabel("P50").frame(width: 62, alignment: .trailing)
+            PremiumFieldLabel("P95").frame(width: 62, alignment: .trailing)
+          }
+          .padding(.horizontal, 14)
+          .frame(height: 34)
+          .background(EvidenceStyle.inspector)
+
+          if receipt.observability.isEmpty {
+            Text("No stored operational rows in this window.")
+              .font(.system(size: 10))
+              .foregroundStyle(.secondary)
+              .padding(18)
+              .frame(maxWidth: .infinity, alignment: .leading)
+          } else {
+            ForEach(Array(receipt.observability.enumerated()), id: \.element.id) { index, row in
+              HStack(spacing: 10) {
+                Text(row.taskType)
+                  .font(.system(size: 10, weight: .semibold, design: .monospaced))
+                  .frame(maxWidth: .infinity, alignment: .leading)
+                Text(row.sessionCount.formatted()).frame(width: 62, alignment: .trailing)
+                Text(row.successCount.formatted())
+                  .foregroundStyle(EvidenceStyle.success)
+                  .frame(width: 62, alignment: .trailing)
+                Text(row.failureCount.formatted())
+                  .foregroundStyle(row.failureCount > 0 ? EvidenceStyle.failure : .secondary)
+                  .frame(width: 52, alignment: .trailing)
+                Text("\(row.successRatePercent, specifier: "%.1f")%")
+                  .frame(width: 58, alignment: .trailing)
+                Text(opsDuration(row.medianDurationSeconds)).frame(width: 62, alignment: .trailing)
+                Text(opsDuration(row.p95DurationSeconds)).frame(width: 62, alignment: .trailing)
+              }
+              .font(.system(size: 9, design: .monospaced))
+              .padding(.horizontal, 14)
+              .frame(height: 38)
+              if index < receipt.observability.count - 1 {
+                Rectangle().fill(EvidenceStyle.separator).frame(height: 1)
+              }
+            }
+          }
+        }
+        .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 14))
+        .overlay { RoundedRectangle(cornerRadius: 14).stroke(EvidenceStyle.separator) }
+
+        VStack(alignment: .leading, spacing: 6) {
+          PremiumFieldLabel("AUTHORITY HELD BACK")
+          ForEach(receipt.limitations, id: \.self) { limitation in
+            Label(limitation, systemImage: "lock.fill")
+              .font(.system(size: 8))
+              .foregroundStyle(.secondary)
+          }
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(EvidenceStyle.inspector, in: RoundedRectangle(cornerRadius: 12))
+      }
+    }
+  }
+
+  private var memoryPanel: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      HStack(spacing: 8) {
+        StatusPill(
+          label: "\(model.memoryReceipt?.sources.filter(\.readable).count ?? 0) readable",
+          color: EvidenceStyle.success
+        )
+        if let checked = model.memoryReceipt?.candidateLocationsChecked {
+          Text("\(checked) known locations checked")
+            .font(.system(size: 8, design: .monospaced))
+            .foregroundStyle(.secondary)
+        }
+        if model.memoryReceipt?.limits.sourcesTruncated == true {
+          StatusPill(label: "Catalog bounded", color: EvidenceStyle.warning)
+        }
+        Spacer()
+        Button {
+          model.loadMemories()
+        } label: {
+          Label("Refresh", systemImage: "arrow.clockwise")
+        }
+        .buttonStyle(.bordered)
+        .disabled(model.memoryLoading)
+      }
+
+      if let issue = model.memoryIssue {
+        Label(issue, systemImage: "exclamationmark.triangle.fill")
+          .font(.system(size: 10))
+          .foregroundStyle(EvidenceStyle.warning)
+          .padding(12)
+          .frame(maxWidth: .infinity, alignment: .leading)
+          .background(EvidenceStyle.warning.opacity(0.08), in: RoundedRectangle(cornerRadius: 10))
+      }
+
+      HStack(alignment: .top, spacing: 12) {
+        VStack(alignment: .leading, spacing: 10) {
+          Label("SOURCE CATALOG", systemImage: "memorychip")
+            .font(.system(size: 9, weight: .bold, design: .monospaced))
+            .foregroundStyle(EvidenceStyle.amberForeground)
+          TextField("Filter sources", text: $memorySourceQuery)
+            .textFieldStyle(.roundedBorder)
+            .font(.system(size: 10))
+
+          ScrollView {
+            LazyVStack(spacing: 6) {
+              ForEach(filteredMemorySources) { source in
+                Button {
+                  guard source.readable else { return }
+                  memoryContentQuery = ""
+                  model.selectMemorySource(source.id)
+                } label: {
+                  VStack(alignment: .leading, spacing: 5) {
+                    HStack(spacing: 7) {
+                      Circle()
+                        .fill(
+                          source.readable ? EvidenceStyle.success : Color.secondary.opacity(0.4)
+                        )
+                        .frame(width: 6, height: 6)
+                      Text(source.label)
+                        .font(.system(size: 10, weight: .semibold))
+                        .lineLimit(1)
+                      Spacer()
+                      Text(source.tool.uppercased())
+                        .font(.system(size: 7, weight: .bold, design: .monospaced))
+                        .foregroundStyle(.secondary)
+                    }
+                    Text(source.displayPath)
+                      .font(.system(size: 8, design: .monospaced))
+                      .foregroundStyle(.secondary)
+                      .lineLimit(1)
+                    Text(source.preview.isEmpty ? source.note : source.preview)
+                      .font(.system(size: 8))
+                      .foregroundStyle(.secondary)
+                      .lineLimit(2)
+                  }
+                  .padding(10)
+                  .frame(maxWidth: .infinity, alignment: .leading)
+                  .background(
+                    model.selectedMemorySourceID == source.id
+                      ? EvidenceStyle.amber.opacity(0.09) : EvidenceStyle.inspector,
+                    in: RoundedRectangle(cornerRadius: 9)
+                  )
+                  .overlay {
+                    RoundedRectangle(cornerRadius: 9).stroke(
+                      model.selectedMemorySourceID == source.id
+                        ? EvidenceStyle.amber.opacity(0.35) : EvidenceStyle.separator)
+                  }
+                }
+                .buttonStyle(.plain)
+                .disabled(!source.readable)
+                .accessibilityLabel("\(source.label), \(source.tool)")
+              }
+            }
+          }
+          .frame(height: 390)
+        }
+        .padding(12)
+        .frame(width: 270, alignment: .topLeading)
+        .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 12))
+        .overlay { RoundedRectangle(cornerRadius: 12).stroke(EvidenceStyle.separator) }
+
+        memoryDocumentPanel
+      }
+
+      Label(
+        "Rust admits only known sources, emits opaque identities and display paths, redacts secret-like lines, and caps one read at 512 KiB / 120,000 characters.",
+        systemImage: "lock.shield.fill"
+      )
+      .font(.system(size: 9))
+      .foregroundStyle(.secondary)
+      .padding(12)
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .background(EvidenceStyle.inspector, in: RoundedRectangle(cornerRadius: 10))
+    }
+  }
+
+  private var memoryDocumentPanel: some View {
+    VStack(alignment: .leading, spacing: 10) {
+      HStack(spacing: 8) {
+        VStack(alignment: .leading, spacing: 2) {
+          Text(selectedMemorySource?.label ?? "Select a memory source")
+            .font(.system(size: 12, weight: .semibold))
+          if let selectedMemorySource {
+            Text(
+              [
+                selectedMemorySource.sourceKind,
+                memoryByteLabel(selectedMemorySource.fileSizeBytes),
+              ]
+              .filter { !$0.isEmpty }.joined(separator: " · ")
+            )
+            .font(.system(size: 8, design: .monospaced))
+            .foregroundStyle(.secondary)
+          }
+        }
+        Spacer()
+        if model.memoryDiff != nil {
+          Button("Document") { model.showSelectedMemoryDocument() }
+            .buttonStyle(.bordered)
+        } else {
+          Button("Git diff") { model.loadSelectedMemoryDiff() }
+            .buttonStyle(.bordered)
+            .disabled(model.selectedMemorySourceID == nil || model.memoryLoading)
+        }
+        Button(copiedMemory ? "Copied" : "Copy") {
+          copyToPasteboard(memoryVisibleText)
+          copiedMemory = true
+          Task { @MainActor in
+            try? await Task.sleep(for: .seconds(1.2))
+            copiedMemory = false
+          }
+        }
+        .buttonStyle(PremiumPrimaryButtonStyle())
+        .disabled(memoryVisibleText.isEmpty)
+      }
+
+      TextField("Filter lines or /regular expression/", text: $memoryContentQuery)
+        .textFieldStyle(.roundedBorder)
+        .font(.system(size: 10))
+        .disabled(memoryVisibleText.isEmpty)
+
+      if model.memoryLoading, memoryVisibleText.isEmpty {
+        VStack(spacing: 8) {
+          ProgressView().controlSize(.small).tint(EvidenceStyle.amber)
+          Text("Reading bounded source…").font(.system(size: 9)).foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, minHeight: 340)
+      } else if memoryVisibleText.isEmpty {
+        VStack(spacing: 8) {
+          Image(systemName: "doc.text.magnifyingglass")
+            .font(.system(size: 24))
+            .foregroundStyle(EvidenceStyle.amberForeground)
+          Text("No readable document selected").font(.system(size: 11, weight: .semibold))
+          Text("Unavailable sources remain visible without expanding file authority.")
+            .font(.system(size: 9))
+            .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, minHeight: 340)
+      } else {
+        ScrollView([.horizontal, .vertical]) {
+          Text(filteredMemoryText)
+            .font(.system(size: 9, design: .monospaced))
+            .textSelection(.enabled)
+            .frame(maxWidth: .infinity, alignment: .topLeading)
+            .padding(12)
+        }
+        .frame(height: 340)
+        .background(EvidenceStyle.canvas, in: RoundedRectangle(cornerRadius: 9))
+        .overlay { RoundedRectangle(cornerRadius: 9).stroke(EvidenceStyle.separator) }
+      }
+
+      if let document = model.memoryDocument, model.memoryDiff == nil {
+        HStack(spacing: 7) {
+          StatusPill(
+            label: document.truncated ? "Truncated safely" : "Complete bounded read",
+            color: document.truncated ? EvidenceStyle.warning : EvidenceStyle.success
+          )
+          Text(document.extractionNote).font(.system(size: 8)).foregroundStyle(.secondary)
+        }
+      } else if let diff = model.memoryDiff {
+        StatusPill(
+          label: diff.hasChanges
+            ? "Modified vs HEAD"
+            : diff.status.replacingOccurrences(
+              of: "_", with: " "
+            ).capitalized,
+          color: diff.hasChanges ? EvidenceStyle.warning : EvidenceStyle.success
+        )
+      }
+    }
+    .padding(12)
+    .frame(maxWidth: .infinity, alignment: .topLeading)
+    .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 12))
+    .overlay { RoundedRectangle(cornerRadius: 12).stroke(EvidenceStyle.separator) }
+  }
+
+  private var filteredMemorySources: [MemorySourceReceipt] {
+    let sources = model.memoryReceipt?.sources ?? []
+    let query = memorySourceQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !query.isEmpty else { return sources }
+    return sources.filter {
+      [$0.label, $0.tool, $0.displayPath, $0.preview, $0.note]
+        .joined(separator: " ").localizedCaseInsensitiveContains(query)
+    }
+  }
+
+  private var selectedMemorySource: MemorySourceReceipt? {
+    model.memoryReceipt?.sources.first { $0.id == model.selectedMemorySourceID }
+  }
+
+  private var memoryVisibleText: String {
+    model.memoryDiff?.diff ?? model.memoryDocument?.content ?? ""
+  }
+
+  private var filteredMemoryText: String {
+    let query = memoryContentQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !query.isEmpty else { return memoryVisibleText }
+    let lines = memoryVisibleText.split(separator: "\n", omittingEmptySubsequences: false)
+    if query.hasPrefix("/"), query.hasSuffix("/"), query.count > 2,
+      let expression = try? NSRegularExpression(pattern: String(query.dropFirst().dropLast()))
+    {
+      return lines.filter { line in
+        let value = String(line)
+        let range = NSRange(value.startIndex..<value.endIndex, in: value)
+        return expression.firstMatch(in: value, range: range) != nil
+      }.joined(separator: "\n")
+    }
+    return lines.filter { $0.localizedCaseInsensitiveContains(query) }.joined(separator: "\n")
+  }
+
+  private func memoryByteLabel(_ bytes: UInt64?) -> String {
+    guard let bytes else { return "" }
+    if bytes >= 1_048_576 { return String(format: "%.1f MiB", Double(bytes) / 1_048_576) }
+    if bytes >= 1024 { return String(format: "%.1f KiB", Double(bytes) / 1024) }
+    return "\(bytes) B"
+  }
+
+  private var historyRootsPanel: some View {
+    VStack(alignment: .leading, spacing: 14) {
+      HStack(alignment: .top, spacing: 16) {
+        VStack(alignment: .leading, spacing: 5) {
+          PremiumFieldLabel("CODEX HISTORY RECOVERY")
+          Text("Additional Codex homes").font(.system(size: 15, weight: .semibold))
+          Text(
+            "Restore sessions outside the active CODEX_HOME. Rust normalizes, bounds, and deduplicates roots before Usage or reconciliation can consume them."
+          )
+          .font(.system(size: 9))
+          .foregroundStyle(.secondary)
+          .fixedSize(horizontal: false, vertical: true)
+        }
+        Spacer()
+        Button {
+          model.choosingHistoryRoot = true
+        } label: {
+          Label("Add history root", systemImage: "folder.badge.plus")
+        }
+        .buttonStyle(.bordered)
+        .disabled(model.historyRootsLoading)
+        .accessibilityIdentifier("add-history-root")
+      }
+
+      if let issue = model.historyRootsIssue {
+        Label(issue, systemImage: "exclamationmark.triangle.fill")
+          .font(.system(size: 9))
+          .foregroundStyle(EvidenceStyle.warning)
+          .padding(12)
+          .frame(maxWidth: .infinity, alignment: .leading)
+          .background(EvidenceStyle.warning.opacity(0.08), in: RoundedRectangle(cornerRadius: 9))
+      }
+
+      if model.historyRootsLoading, model.historyRootsReceipt == nil {
+        HStack(spacing: 10) {
+          ProgressView().controlSize(.small).tint(EvidenceStyle.amber)
+          Text("Reading bounded history-root configuration…").font(.system(size: 9))
+        }
+        .padding(.vertical, 8)
+      } else if let receipt = model.historyRootsReceipt, !receipt.roots.isEmpty {
+        VStack(spacing: 0) {
+          ForEach(Array(receipt.roots.enumerated()), id: \.element.id) { index, root in
+            HStack(spacing: 12) {
+              Image(
+                systemName: root.exists
+                  ? "externaldrive.fill.badge.checkmark" : "externaldrive.badge.xmark"
+              )
+              .foregroundStyle(root.exists ? EvidenceStyle.success : EvidenceStyle.warning)
+              .frame(width: 20)
+              VStack(alignment: .leading, spacing: 3) {
+                Text(root.displayPath)
+                  .font(.system(size: 10, weight: .medium, design: .monospaced))
+                  .lineLimit(1)
+                  .truncationMode(.middle)
+                  .help(root.path)
+                Text(historyRootState(root))
+                  .font(.system(size: 8))
+                  .foregroundStyle(.secondary)
+              }
+              Spacer()
+              StatusPill(
+                label: root.exists ? "Available" : "Missing",
+                color: root.exists ? EvidenceStyle.success : EvidenceStyle.warning
+              )
+              Button("Remove") { model.removeHistoryRoot(path: root.path) }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .disabled(model.historyRootsLoading)
+                .accessibilityLabel("Remove Codex history root \(root.displayPath)")
+            }
+            .padding(.horizontal, 13)
+            .padding(.vertical, 11)
+            if index < receipt.roots.count - 1 {
+              Rectangle().fill(EvidenceStyle.separator).frame(height: 1)
+            }
+          }
+        }
+        .background(EvidenceStyle.inspector, in: RoundedRectangle(cornerRadius: 10))
+        .overlay { RoundedRectangle(cornerRadius: 10).stroke(EvidenceStyle.separator) }
+      } else {
+        HStack(alignment: .top, spacing: 11) {
+          Image(systemName: "checkmark.shield.fill").foregroundStyle(EvidenceStyle.success)
+          VStack(alignment: .leading, spacing: 4) {
+            Text("The active Codex home is already automatic")
+              .font(.system(size: 10, weight: .semibold))
+            Text("Add a root only when older sessions live elsewhere.")
+              .font(.system(size: 8))
+              .foregroundStyle(.secondary)
+          }
+        }
+        .padding(13)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(EvidenceStyle.inspector, in: RoundedRectangle(cornerRadius: 10))
+      }
+
+      Label(
+        "Adding or removing a root never reads or deletes transcript content. Reconcile from Usage when ready.",
+        systemImage: "lock.shield.fill"
+      )
+      .font(.system(size: 8))
+      .foregroundStyle(.secondary)
+    }
+    .padding(18)
+    .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 14))
+    .overlay { RoundedRectangle(cornerRadius: 14).stroke(EvidenceStyle.separator) }
+  }
+
+  private func historyRootState(_ root: HistoryRoot) -> String {
+    switch (root.sessionsAvailable, root.archivedSessionsAvailable) {
+    case (true, true): "Active and archived sessions available"
+    case (true, false): "Active sessions available"
+    case (false, true): "Archived sessions available"
+    case (false, false): "Configured path is currently unavailable"
+    }
+  }
+
+  private var retentionPanel: some View {
+    VStack(alignment: .leading, spacing: 14) {
+      VStack(alignment: .leading, spacing: 14) {
+        HStack(alignment: .top) {
+          VStack(alignment: .leading, spacing: 4) {
+            PremiumFieldLabel("INDEXED SESSION ARCHIVE")
+            Text("Dry run before cleanup").font(.system(size: 15, weight: .semibold))
+            Text(
+              "Only CodeVetter archive and FTS rows are candidates. Provider transcripts and source sessions stay untouched."
+            )
+            .font(.system(size: 9))
+            .foregroundStyle(.secondary)
+          }
+          Spacer()
+          StatusPill(label: "Identity rechecked", color: EvidenceStyle.success)
+        }
+        HStack(spacing: 12) {
+          retentionInput("MAXIMUM AGE", suffix: "days", value: $retentionAgeDays)
+          retentionInput("MAXIMUM ARCHIVE", suffix: "MiB", value: $retentionMaxMiB)
+        }
+        HStack(spacing: 9) {
+          Button {
+            model.previewSessionRetention(
+              maxAgeDays: Int(retentionAgeDays),
+              maxArchiveMiB: Int(retentionMaxMiB)
+            )
+          } label: {
+            Text("Preview cleanup")
+              .fixedSize(horizontal: true, vertical: false)
+          }
+          .buttonStyle(PremiumPrimaryButtonStyle())
+          .disabled(model.retentionLoading || retentionInputsInvalid)
+          .accessibilityLabel("Preview session retention")
+          .accessibilityIdentifier("preview-session-retention")
+
+          Button("Apply reviewed plan") { confirmingRetentionApply = true }
+            .buttonStyle(.bordered)
+            .disabled(
+              model.retentionLoading
+                || model.retentionReceipt?.plan?.candidates.isEmpty != false)
+
+          Spacer()
+          Button("Checkpoint") { model.checkpointSessionArchive(vacuum: false) }
+            .buttonStyle(.bordered)
+            .disabled(model.retentionLoading)
+            .accessibilityIdentifier("checkpoint-session-archive")
+          Button("Checkpoint + VACUUM") { confirmingRetentionVacuum = true }
+            .buttonStyle(.bordered)
+            .disabled(model.retentionLoading)
+            .accessibilityIdentifier("vacuum-session-archive")
+        }
+      }
+      .padding(18)
+      .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 14))
+      .overlay { RoundedRectangle(cornerRadius: 14).stroke(EvidenceStyle.separator) }
+
+      if let issue = model.retentionIssue {
+        Label(issue, systemImage: "exclamationmark.triangle.fill")
+          .font(.system(size: 9))
+          .foregroundStyle(EvidenceStyle.warning)
+          .padding(14)
+          .frame(maxWidth: .infinity, alignment: .leading)
+          .background(EvidenceStyle.warning.opacity(0.08), in: RoundedRectangle(cornerRadius: 10))
+      }
+
+      if model.retentionLoading {
+        HStack(spacing: 10) {
+          ProgressView().controlSize(.small).tint(EvidenceStyle.amber)
+          Text("Rust is checking archive identity and protected references…")
+            .font(.system(size: 10))
+        }
+        .padding(14)
+      } else if let plan = model.retentionReceipt?.plan {
+        retentionPlanCard(plan)
+      } else if let receipt = model.retentionReceipt {
+        retentionOperationCard(receipt)
+      } else {
+        HStack(alignment: .top, spacing: 12) {
+          Image(systemName: "shield.checkered").foregroundStyle(EvidenceStyle.amberForeground)
+          VStack(alignment: .leading, spacing: 5) {
+            Text("No cleanup plan has been created").font(.system(size: 11, weight: .semibold))
+            Text(
+              "Previewing persists a stable plan identity. Applying it later fails closed if the archive or protected-reference set changed."
+            )
+            .font(.system(size: 9))
+            .foregroundStyle(.secondary)
+          }
+        }
+        .padding(18)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(EvidenceStyle.inspector, in: RoundedRectangle(cornerRadius: 12))
+        .overlay { RoundedRectangle(cornerRadius: 12).stroke(EvidenceStyle.separator) }
+      }
+    }
+  }
+
+  private func retentionInput(_ label: String, suffix: String, value: Binding<String>) -> some View
+  {
+    VStack(alignment: .leading, spacing: 7) {
+      PremiumFieldLabel(label)
+      HStack {
+        TextField("", text: value)
+          .textFieldStyle(.plain)
+          .font(.system(size: 15, weight: .semibold, design: .monospaced))
+          .onChange(of: value.wrappedValue) { _, _ in model.clearRetentionPreview() }
+        Text(suffix).font(.system(size: 9)).foregroundStyle(.secondary)
+      }
+      .padding(.horizontal, 12)
+      .frame(height: 38)
+      .background(EvidenceStyle.inspector, in: RoundedRectangle(cornerRadius: 9))
+      .overlay { RoundedRectangle(cornerRadius: 9).stroke(EvidenceStyle.separator) }
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+  }
+
+  private func retentionPlanCard(_ plan: SessionRetentionPlan) -> some View {
+    VStack(alignment: .leading, spacing: 14) {
+      HStack {
+        VStack(alignment: .leading, spacing: 4) {
+          PremiumFieldLabel("REVIEWED PLAN")
+          Text(plan.id).font(.system(size: 9, design: .monospaced)).textSelection(.enabled)
+        }
+        Spacer()
+        StatusPill(label: "Dry run", color: EvidenceStyle.amber)
+      }
+      HStack(spacing: 8) {
+        settingsMetric("REMOVABLE", "\(plan.candidates.count) sessions")
+        settingsMetric("ROWS", plan.candidateRows.formatted())
+        settingsMetric("RECLAIM", formatStorage(plan.candidateBytes))
+        settingsMetric("PROJECTED", formatStorage(plan.projectedBytes))
+      }
+      if plan.candidates.isEmpty {
+        Label("Nothing matches this policy.", systemImage: "checkmark.circle.fill")
+          .font(.system(size: 9, weight: .semibold))
+          .foregroundStyle(EvidenceStyle.success)
+      }
+      if !plan.protected.isEmpty {
+        VStack(alignment: .leading, spacing: 8) {
+          HStack {
+            PremiumFieldLabel("PROTECTED REFERENCES")
+            Spacer()
+            Text(
+              "\(plan.protected.count) \(plan.protected.count == 1 ? "session" : "sessions")"
+            )
+            .font(.system(size: 8, weight: .semibold, design: .monospaced))
+            .foregroundStyle(EvidenceStyle.success)
+          }
+          ForEach(plan.protected.prefix(8)) { entry in
+            HStack(alignment: .firstTextBaseline, spacing: 10) {
+              Text(String(entry.sessionID.prefix(14)))
+                .font(.system(size: 8, design: .monospaced))
+                .foregroundStyle(.secondary)
+              Text(entry.reasons.joined(separator: " · "))
+                .font(.system(size: 8))
+              Spacer()
+              Text("\(entry.rows) rows")
+                .font(.system(size: 8, design: .monospaced))
+                .foregroundStyle(.secondary)
+            }
+          }
+        }
+        .padding(14)
+        .background(EvidenceStyle.inspector, in: RoundedRectangle(cornerRadius: 10))
+      }
+      Label(
+        "Provider-owned transcripts are never deleted by this plan.",
+        systemImage: "lock.shield.fill"
+      )
+      .font(.system(size: 8, weight: .semibold))
+      .foregroundStyle(EvidenceStyle.success)
+    }
+    .padding(18)
+    .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 14))
+    .overlay { RoundedRectangle(cornerRadius: 14).stroke(EvidenceStyle.amber.opacity(0.35)) }
+  }
+
+  private func retentionOperationCard(_ receipt: SessionRetentionReceipt) -> some View {
+    HStack(spacing: 12) {
+      Image(systemName: "checkmark.seal.fill").foregroundStyle(EvidenceStyle.success)
+      VStack(alignment: .leading, spacing: 4) {
+        Text(receipt.operation == .apply ? "Reviewed plan applied" : "Archive checkpoint complete")
+          .font(.system(size: 12, weight: .semibold))
+        Text(receipt.generatedAt)
+          .font(.system(size: 8, design: .monospaced))
+          .foregroundStyle(.secondary)
+      }
+      Spacer()
+      StatusPill(label: receipt.operation.rawValue.uppercased(), color: EvidenceStyle.success)
+    }
+    .padding(18)
+    .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 14))
+    .overlay { RoundedRectangle(cornerRadius: 14).stroke(EvidenceStyle.separator) }
+  }
+
+  private var retentionInputsInvalid: Bool {
+    guard let age = Int(retentionAgeDays), let size = Int(retentionMaxMiB) else { return true }
+    return !(1...3650).contains(age) || !(1...524_288).contains(size)
+  }
+
+  private var retentionApplyConfirmation: String {
+    guard let plan = model.retentionReceipt?.plan else {
+      return "No reviewed retention plan is available."
+    }
+    return
+      "Remove \(plan.candidateRows.formatted()) indexed archive rows from \(plan.candidates.count) unprotected sessions? Rust will reject the operation if the plan identity changed."
+  }
+
+  private func formatStorage(_ bytes: Int64) -> String {
+    ByteCountFormatter.string(fromByteCount: bytes, countStyle: .file)
+  }
+
+  @ViewBuilder
+  private var rubricPanel: some View {
+    Group {
+      if model.rubricLoading, model.rubricReceipt == nil {
+        HStack(spacing: 10) {
+          ProgressView().controlSize(.small).tint(EvidenceStyle.amber)
+          Text("Loading Rust-owned review standards…").font(.system(size: 10))
+        }
+        .padding(18)
+      } else {
+        VStack(alignment: .leading, spacing: 14) {
+          if let issue = model.rubricIssue {
+            Label(issue, systemImage: "exclamationmark.triangle.fill")
+              .font(.system(size: 9))
+              .foregroundStyle(EvidenceStyle.warning)
+              .padding(14)
+              .frame(maxWidth: .infinity, alignment: .leading)
+              .background(
+                EvidenceStyle.warning.opacity(0.08), in: RoundedRectangle(cornerRadius: 10))
+          }
+          if let receipt = model.rubricReceipt {
+            HStack(alignment: .top, spacing: 14) {
+              LazyVStack(spacing: 10) {
+                ForEach(receipt.packs) { pack in rubricPackCard(pack) }
+              }
+              customRubricCard(existing: receipt.packs)
+                .frame(width: 260)
+            }
+            HStack(spacing: 8) {
+              StatusPill(
+                label: receipt.activePackID == nil
+                  ? "Default not attributed" : "Selection attributed",
+                color: receipt.activePackID == nil ? EvidenceStyle.warning : EvidenceStyle.success)
+              Text("Each completed review stores the selected pack id with its evidence.")
+                .font(.system(size: 8))
+                .foregroundStyle(.secondary)
+              Spacer()
+              Button {
+                model.loadRubrics()
+              } label: {
+                Label("Refresh", systemImage: "arrow.clockwise")
+              }
+              .buttonStyle(.bordered)
+              .disabled(model.rubricLoading)
+              .accessibilityIdentifier("refresh-rubrics")
+            }
+            .padding(14)
+            .background(EvidenceStyle.inspector, in: RoundedRectangle(cornerRadius: 11))
+          } else {
+            ContentUnavailableView(
+              "Rubrics unavailable",
+              systemImage: "checklist",
+              description: Text("The canonical Rust rubric receipt could not be loaded.")
+            )
+            .frame(maxWidth: .infinity, minHeight: 240)
+          }
+        }
+      }
+    }
+    .accessibilityElement(children: .contain)
+    .accessibilityIdentifier("rubric-settings-workspace")
+  }
+
+  private func rubricPackCard(_ pack: RubricPackReceipt) -> some View {
+    VStack(alignment: .leading, spacing: 12) {
+      HStack(alignment: .top) {
+        VStack(alignment: .leading, spacing: 4) {
+          HStack(spacing: 7) {
+            Text(pack.name).font(.system(size: 14, weight: .semibold))
+            if pack.builtIn { StatusPill(label: "Built in", color: Color.secondary) }
+          }
+          Text(pack.focus).font(.system(size: 9)).foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+        Spacer()
+        if pack.active {
+          StatusPill(label: "Selected", color: EvidenceStyle.success)
+            .accessibilityLabel("Active rubric pack")
+            .accessibilityIdentifier("active-rubric-\(pack.id)")
+        } else {
+          Button {
+            model.selectRubricPack(pack.id)
+          } label: {
+            Text("Use pack").fixedSize(horizontal: true, vertical: false)
+          }
+          .buttonStyle(PremiumPrimaryButtonStyle())
+          .disabled(model.rubricLoading)
+          .accessibilityIdentifier("select-rubric-\(pack.id)")
+        }
+      }
+      ForEach(pack.checks, id: \.self) { check in
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+          Circle().fill(EvidenceStyle.amber).frame(width: 4, height: 4)
+          Text(check).font(.system(size: 8)).fixedSize(horizontal: false, vertical: true)
+        }
+      }
+      HStack(spacing: 8) {
+        settingsMetric("REVIEWS", pack.reviewCount.formatted())
+        settingsMetric("FINDINGS", pack.totalFindings.formatted())
+        Spacer()
+        Button("Duplicate") { duplicateRubric(pack) }.buttonStyle(.bordered)
+        Button(expandedRubricID == pack.id ? "Hide preview" : "Prompt preview") {
+          expandedRubricID = expandedRubricID == pack.id ? nil : pack.id
+        }
+        .buttonStyle(.bordered)
+      }
+      if expandedRubricID == pack.id {
+        VStack(alignment: .leading, spacing: 8) {
+          HStack {
+            PremiumFieldLabel("EXACT REVIEW CONTEXT")
+            Spacer()
+            Button(copiedMcpValue == "rubric-\(pack.id)" ? "Copied" : "Copy") {
+              copyToPasteboard(pack.promptPreview)
+              copiedMcpValue = "rubric-\(pack.id)"
+            }
+            .buttonStyle(.borderless)
+          }
+          ScrollView {
+            Text(pack.promptPreview)
+              .font(.system(size: 8, design: .monospaced))
+              .textSelection(.enabled)
+              .frame(maxWidth: .infinity, alignment: .leading)
+          }
+          .frame(maxHeight: 180)
+        }
+        .padding(12)
+        .background(EvidenceStyle.inspector, in: RoundedRectangle(cornerRadius: 9))
+      }
+    }
+    .padding(16)
+    .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 13))
+    .overlay {
+      RoundedRectangle(cornerRadius: 13).stroke(
+        pack.active ? EvidenceStyle.amber.opacity(0.55) : EvidenceStyle.separator)
+    }
+    .accessibilityElement(children: .contain)
+    .accessibilityIdentifier("rubric-pack-\(pack.id)")
+  }
+
+  private func customRubricCard(existing: [RubricPackReceipt]) -> some View {
+    VStack(alignment: .leading, spacing: 12) {
+      PremiumFieldLabel("CUSTOM PACK")
+      Text("Create and use").font(.system(size: 14, weight: .semibold))
+      Text("The Rust core validates ids, text bounds, and 1–32 checks before persistence.")
+        .font(.system(size: 8))
+        .foregroundStyle(.secondary)
+      rubricTextField("Pack name", text: $newRubricName)
+      rubricTextField("Review focus", text: $newRubricFocus)
+      VStack(alignment: .leading, spacing: 5) {
+        PremiumFieldLabel("ONE CHECK PER LINE")
+        TextEditor(text: $newRubricChecks)
+          .font(.system(size: 9))
+          .scrollContentBackground(.hidden)
+          .padding(8)
+          .frame(minHeight: 145)
+          .background(EvidenceStyle.inspector, in: RoundedRectangle(cornerRadius: 8))
+          .overlay { RoundedRectangle(cornerRadius: 8).stroke(EvidenceStyle.separator) }
+      }
+      Button {
+        createRubric(existing: existing)
+      } label: {
+        Label("Save and use pack", systemImage: "square.and.arrow.down")
+          .frame(maxWidth: .infinity)
+      }
+      .buttonStyle(.borderedProminent)
+      .tint(EvidenceStyle.amber)
+      .disabled(!customRubricIsValid || model.rubricLoading)
+      .accessibilityIdentifier("save-custom-rubric")
+    }
+    .padding(16)
+    .background(EvidenceStyle.inspector, in: RoundedRectangle(cornerRadius: 13))
+    .overlay { RoundedRectangle(cornerRadius: 13).stroke(EvidenceStyle.separator) }
+  }
+
+  private func rubricTextField(_ label: String, text: Binding<String>) -> some View {
+    TextField(label, text: text)
+      .textFieldStyle(.plain)
+      .font(.system(size: 9))
+      .padding(.horizontal, 10)
+      .frame(height: 36)
+      .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 8))
+      .overlay { RoundedRectangle(cornerRadius: 8).stroke(EvidenceStyle.separator) }
+  }
+
+  private var customRubricChecks: [String] {
+    newRubricChecks.split(separator: "\n").map { $0.trimmingCharacters(in: .whitespaces) }
+      .filter { !$0.isEmpty }
+  }
+
+  private var customRubricIsValid: Bool {
+    !newRubricName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+      && !newRubricFocus.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+      && (1...32).contains(customRubricChecks.count)
+  }
+
+  private func createRubric(existing: [RubricPackReceipt]) {
+    let id = uniqueRubricID(for: newRubricName, existing: existing)
+    model.saveRubricPack(
+      RubricPackInput(
+        id: id,
+        name: newRubricName.trimmingCharacters(in: .whitespacesAndNewlines),
+        focus: newRubricFocus.trimmingCharacters(in: .whitespacesAndNewlines),
+        checks: customRubricChecks
+      ))
+    newRubricName = ""
+    newRubricFocus = ""
+    newRubricChecks = ""
+  }
+
+  private func duplicateRubric(_ pack: RubricPackReceipt) {
+    let packs = model.rubricReceipt?.packs ?? []
+    let name = "\(pack.name) (copy)"
+    model.saveRubricPack(
+      RubricPackInput(
+        id: uniqueRubricID(for: name, existing: packs),
+        name: name,
+        focus: pack.focus,
+        checks: pack.checks
+      ))
+  }
+
+  private func uniqueRubricID(for name: String, existing: [RubricPackReceipt]) -> String {
+    let base = String(
+      name.lowercased().map { $0.isLetter || $0.isNumber ? $0 : "-" }
+    )
+    .split(separator: "-").joined(separator: "-").prefix(48)
+    let normalized = base.isEmpty ? "custom-pack" : String(base)
+    let taken = Set(existing.map(\.id))
+    if !taken.contains(normalized) { return normalized }
+    for suffix in 2...99 {
+      let candidate = String("\(normalized)-\(suffix)".prefix(64))
+      if !taken.contains(candidate) { return candidate }
+    }
+    return String("\(normalized)-copy".prefix(64))
+  }
+
+  private var aboutPanel: some View {
+    VStack(alignment: .leading, spacing: 14) {
+      HStack(alignment: .center, spacing: 16) {
+        ZStack {
+          RoundedRectangle(cornerRadius: 14).fill(EvidenceStyle.amber)
+          Image(systemName: "checkmark.shield.fill")
+            .font(.system(size: 24, weight: .semibold))
+            .foregroundStyle(EvidenceStyle.ink)
+        }
+        .frame(width: 58, height: 58)
+        VStack(alignment: .leading, spacing: 4) {
+          Text("CodeVetter").font(.system(size: 20, weight: .semibold))
+          Text("Execution-backed verification for coding agents")
+            .font(.system(size: 10))
+            .foregroundStyle(.secondary)
+        }
+        Spacer()
+        Button("Welcome tour") { model.presentOnboarding() }
+          .buttonStyle(.bordered)
+          .accessibilityLabel("Open the CodeVetter welcome tour")
+        StatusPill(label: "Native preview", color: EvidenceStyle.amber)
+      }
+      .padding(18)
+      .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 14))
+      .overlay { RoundedRectangle(cornerRadius: 14).stroke(EvidenceStyle.separator) }
+
+      VStack(spacing: 0) {
+        aboutRow(
+          "VERSION",
+          Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "Development")
+        Rectangle().fill(EvidenceStyle.separator).frame(height: 1)
+        aboutRow("BUILD", "AppKit + SwiftUI over the Rust core")
+        Rectangle().fill(EvidenceStyle.separator).frame(height: 1)
+        aboutRow("LICENSE", "ISC")
+        Rectangle().fill(EvidenceStyle.separator).frame(height: 1)
+        aboutRow(
+          "IDENTIFIER", Bundle.main.bundleIdentifier ?? "com.codevetter.desktop.native-preview")
+      }
+      .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 14))
+      .overlay { RoundedRectangle(cornerRadius: 14).stroke(EvidenceStyle.separator) }
+
+      HStack(alignment: .top, spacing: 12) {
+        VStack(alignment: .leading, spacing: 8) {
+          PremiumFieldLabel("UPDATES")
+          Text("Sparkle 2.9.6 selected · preview disabled")
+            .font(.system(size: 11, weight: .semibold))
+          Text(
+            "The native updater stays off until the production bundle has an HTTPS appcast and a real EdDSA public key. The Tauri feed remains authoritative through the one-time dual-feed cutover."
+          )
+          .font(.system(size: 9))
+          .foregroundStyle(.secondary)
+          .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .topLeading)
+        .background(EvidenceStyle.inspector, in: RoundedRectangle(cornerRadius: 12))
+        .overlay { RoundedRectangle(cornerRadius: 12).stroke(EvidenceStyle.separator) }
+
+        VStack(alignment: .leading, spacing: 10) {
+          PremiumFieldLabel("LINKS")
+          Link(
+            "GitHub Repository",
+            destination: URL(string: "https://github.com/Codevetter/codevetter")!)
+          Link("Product", destination: URL(string: "https://codevetter.com")!)
+          Link("Documentation", destination: URL(string: "https://docs.codevetter.com")!)
+        }
+        .font(.system(size: 10, weight: .semibold))
+        .tint(EvidenceStyle.amber)
+        .padding(16)
+        .frame(width: 230, alignment: .topLeading)
+        .background(EvidenceStyle.inspector, in: RoundedRectangle(cornerRadius: 12))
+        .overlay { RoundedRectangle(cornerRadius: 12).stroke(EvidenceStyle.separator) }
+      }
+    }
+  }
+
+  private func aboutRow(_ label: String, _ value: String) -> some View {
+    HStack {
+      PremiumFieldLabel(label)
+      Spacer()
+      Text(value)
+        .font(.system(size: 9, design: label == "IDENTIFIER" ? .monospaced : .default))
+        .foregroundStyle(.secondary)
+        .textSelection(.enabled)
+    }
+    .padding(.horizontal, 16)
+    .frame(height: 44)
+  }
+
+  @ViewBuilder
+  private var mcpPanel: some View {
+    VStack(alignment: .leading, spacing: 14) {
+      HStack(alignment: .center, spacing: 14) {
+        VStack(alignment: .leading, spacing: 5) {
+          PremiumFieldLabel("REPOSITORY SCOPE")
+          Text(model.repositoryPath.isEmpty ? "No repository selected" : model.repositoryPath)
+            .font(.system(size: 9, design: .monospaced))
+            .foregroundStyle(model.repositoryPath.isEmpty ? Color.secondary : Color.primary)
+            .lineLimit(1)
+        }
+        Spacer()
+        Button {
+          model.choosingRepository = true
+        } label: {
+          Label(
+            model.repositoryPath.isEmpty ? "Choose repository" : "Change", systemImage: "folder")
+        }
+        .buttonStyle(.bordered)
+        .accessibilityLabel("Choose MCP repository")
+        .accessibilityIdentifier("choose-mcp-repository")
+        Button {
+          model.loadMcpSettings()
+        } label: {
+          Image(systemName: "arrow.clockwise")
+        }
+        .buttonStyle(.bordered)
+        .disabled(model.repositoryPath.isEmpty || model.mcpLoading)
+        .accessibilityLabel("Refresh MCP settings")
+      }
+      .padding(16)
+      .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 12))
+      .overlay { RoundedRectangle(cornerRadius: 12).stroke(EvidenceStyle.separator) }
+
+      if let issue = model.mcpIssue {
+        Label(issue, systemImage: "exclamationmark.triangle.fill")
+          .font(.system(size: 9))
+          .foregroundStyle(EvidenceStyle.warning)
+          .padding(14)
+          .frame(maxWidth: .infinity, alignment: .leading)
+          .background(EvidenceStyle.warning.opacity(0.08), in: RoundedRectangle(cornerRadius: 10))
+      }
+
+      if model.mcpLoading, model.mcpSettingsReceipt == nil {
+        HStack(spacing: 10) {
+          ProgressView().controlSize(.small).tint(EvidenceStyle.amber)
+          Text("Resolving repository-scoped MCP authority…").font(.system(size: 10))
+        }
+        .padding(18)
+      } else if let receipt = model.mcpSettingsReceipt {
+        mcpAuthorityCard(receipt.settings)
+        mcpClientCard(receipt.settings)
+        mcpAuditCard(receipt.settings)
+        mcpBoundaryLists(receipt.settings)
+      } else if model.repositoryPath.isEmpty {
+        ContentUnavailableView(
+          "Choose one repository",
+          systemImage: "arrow.trianglehead.branch",
+          description: Text("MCP authority is always explicit and repository-scoped.")
+        )
+        .frame(maxWidth: .infinity, minHeight: 220)
+      }
+    }
+  }
+
+  private func mcpAuthorityCard(_ settings: McpRepositorySettings) -> some View {
+    VStack(alignment: .leading, spacing: 15) {
+      HStack(alignment: .top, spacing: 16) {
+        VStack(alignment: .leading, spacing: 5) {
+          HStack(spacing: 8) {
+            Text("Repository history over MCP").font(.system(size: 15, weight: .semibold))
+            StatusPill(
+              label: settings.enabled ? "Enabled" : "Disabled",
+              color: settings.enabled ? EvidenceStyle.success : Color.secondary)
+          }
+          Text(
+            "Local stdio only · no file writes, provider calls, index refresh, or network listener"
+          )
+          .font(.system(size: 9))
+          .foregroundStyle(.secondary)
+        }
+        Spacer()
+        Button(settings.enabled ? "Disable" : "Enable") {
+          model.runMcpSettings(operation: settings.enabled ? .disable : .enable)
+        }
+        .buttonStyle(.borderedProminent)
+        .tint(EvidenceStyle.amber)
+        .disabled(model.mcpLoading || (!settings.enabled && !settings.indexed))
+        .accessibilityLabel(settings.enabled ? "Disable repository MCP" : "Enable repository MCP")
+      }
+      if !settings.indexed {
+        Label(
+          "Build release history in Repo Unpack before enabling MCP.",
+          systemImage: "clock.badge.exclamationmark"
+        )
+        .font(.system(size: 9))
+        .foregroundStyle(EvidenceStyle.warning)
+      }
+      HStack(spacing: 8) {
+        settingsMetric(
+          "HISTORY", settings.indexed ? (settings.stale ? "Stale" : "Current") : "Not built")
+        settingsMetric("TOOLS", "\(settings.toolNames.count)")
+        settingsMetric("RESOURCES", "\(settings.resourceKinds.count)")
+        settingsMetric("RECENT ACCESS", "\(settings.recentAudit.count)")
+      }
+      HStack(spacing: 8) {
+        Circle()
+          .fill(
+            settings.enabled && settings.indexed ? EvidenceStyle.success : EvidenceStyle.warning
+          )
+          .frame(width: 7, height: 7)
+        Text(mcpReadiness(settings))
+          .font(.system(size: 9, weight: .semibold))
+        Spacer()
+        Text("prepare_review")
+          .font(.system(size: 8, design: .monospaced))
+          .foregroundStyle(.secondary)
+      }
+    }
+    .padding(18)
+    .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 14))
+    .overlay { RoundedRectangle(cornerRadius: 14).stroke(EvidenceStyle.separator) }
+  }
+
+  private func mcpClientCard(_ settings: McpRepositorySettings) -> some View {
+    VStack(alignment: .leading, spacing: 12) {
+      HStack {
+        VStack(alignment: .leading, spacing: 3) {
+          PremiumFieldLabel("CLIENT CONFIGURATION")
+          Text("Exact local stdio connection").font(.system(size: 14, weight: .semibold))
+        }
+        Spacer()
+        Button(copiedMcpValue == "config" ? "Copied" : "Copy config") {
+          copyToPasteboard(settings.clientConfigJSON ?? "")
+          copiedMcpValue = "config"
+        }
+        .buttonStyle(.bordered)
+        .disabled(settings.clientConfigJSON == nil)
+      }
+      Text(settings.serverPath)
+        .font(.system(size: 8, design: .monospaced))
+        .foregroundStyle(.secondary)
+        .textSelection(.enabled)
+      ScrollView(.horizontal) {
+        Text(settings.clientConfigJSON ?? "Configuration unavailable for this repository.")
+          .font(.system(size: 8, design: .monospaced))
+          .textSelection(.enabled)
+          .padding(12)
+      }
+      .frame(height: 126)
+      .background(EvidenceStyle.inspector, in: RoundedRectangle(cornerRadius: 9))
+      .overlay { RoundedRectangle(cornerRadius: 9).stroke(EvidenceStyle.separator) }
+      HStack {
+        VStack(alignment: .leading, spacing: 3) {
+          Text("Prepare one review").font(.system(size: 10, weight: .semibold))
+          Text("Context and suggested checks—not a verdict.")
+            .font(.system(size: 8))
+            .foregroundStyle(.secondary)
+        }
+        Spacer()
+        Button(copiedMcpValue == "invocation" ? "Copied" : "Copy invocation") {
+          copyToPasteboard(mcpReviewInvocation)
+          copiedMcpValue = "invocation"
+        }
+        .buttonStyle(.bordered)
+        .disabled(!settings.toolNames.contains("prepare_review"))
+      }
+    }
+    .padding(18)
+    .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 14))
+    .overlay { RoundedRectangle(cornerRadius: 14).stroke(EvidenceStyle.separator) }
+  }
+
+  private func mcpAuditCard(_ settings: McpRepositorySettings) -> some View {
+    VStack(alignment: .leading, spacing: 12) {
+      HStack {
+        VStack(alignment: .leading, spacing: 3) {
+          PremiumFieldLabel("LOCAL ACCESS AUDIT")
+          Text("Operational metadata only").font(.system(size: 14, weight: .semibold))
+        }
+        Spacer()
+        Button("Clear access audit") { confirmingAuditClear = true }
+          .buttonStyle(.bordered)
+          .disabled(model.mcpLoading || settings.recentAudit.isEmpty)
+      }
+      Text("Arguments, prompts, query text, credentials, and evidence are never recorded here.")
+        .font(.system(size: 9))
+        .foregroundStyle(.secondary)
+      if settings.recentAudit.isEmpty {
+        Text("No MCP accesses recorded for this repository.")
+          .font(.system(size: 9))
+          .foregroundStyle(.secondary)
+          .padding(.vertical, 12)
+      } else {
+        ForEach(settings.recentAudit.prefix(12)) { entry in
+          HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 2) {
+              Text(entry.operation).font(.system(size: 9, weight: .medium, design: .monospaced))
+              Text(entry.createdAt).font(.system(size: 7, design: .monospaced)).foregroundStyle(
+                .secondary)
+            }
+            Spacer()
+            Text(entry.status)
+              .font(.system(size: 8, weight: .semibold, design: .monospaced))
+              .foregroundStyle(entry.status == "ok" ? EvidenceStyle.success : EvidenceStyle.warning)
+            Text("\(entry.durationMS) ms · \(entry.responseBytes) B")
+              .font(.system(size: 8, design: .monospaced))
+              .foregroundStyle(.secondary)
+          }
+          .padding(.vertical, 5)
+        }
+      }
+    }
+    .padding(18)
+    .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 14))
+    .overlay { RoundedRectangle(cornerRadius: 14).stroke(EvidenceStyle.separator) }
+  }
+
+  private func mcpBoundaryLists(_ settings: McpRepositorySettings) -> some View {
+    HStack(alignment: .top, spacing: 12) {
+      mcpListCard("EXPOSED KINDS", settings.resourceKinds)
+      mcpListCard("REDACTION", settings.redactionRules)
+    }
+  }
+
+  private func mcpListCard(_ title: String, _ values: [String]) -> some View {
+    VStack(alignment: .leading, spacing: 8) {
+      PremiumFieldLabel(title)
+      Text(values.joined(separator: " · "))
+        .font(.system(size: 9))
+        .foregroundStyle(.secondary)
+        .fixedSize(horizontal: false, vertical: true)
+    }
+    .padding(16)
+    .frame(maxWidth: .infinity, alignment: .topLeading)
+    .background(EvidenceStyle.inspector, in: RoundedRectangle(cornerRadius: 12))
+    .overlay { RoundedRectangle(cornerRadius: 12).stroke(EvidenceStyle.separator) }
+  }
+
+  private func settingsMetric(_ label: String, _ value: String) -> some View {
+    VStack(alignment: .leading, spacing: 4) {
+      PremiumFieldLabel(label)
+      Text(value).font(.system(size: 11, weight: .semibold))
+    }
+    .padding(11)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .background(EvidenceStyle.inspector, in: RoundedRectangle(cornerRadius: 9))
+  }
+
+  private func opsDuration(_ seconds: Double?) -> String {
+    guard let seconds else { return "—" }
+    if seconds < 60 { return String(format: "%.0fs", seconds) }
+    if seconds < 3_600 { return String(format: "%.1fm", seconds / 60) }
+    return String(format: "%.1fh", seconds / 3_600)
+  }
+
+  private func mcpReadiness(_ settings: McpRepositorySettings) -> String {
+    if !settings.indexed { return "Build release history before agent setup" }
+    if !settings.toolNames.contains("prepare_review") { return "prepare_review is unavailable" }
+    if !settings.enabled { return "Enable this repository to authorize local review preparation" }
+    return settings.stale ? "Ready with stale context" : "Ready for review agents"
+  }
+
+  private func copyToPasteboard(_ value: String) {
+    NSPasteboard.general.clearContents()
+    NSPasteboard.general.setString(value, forType: .string)
+  }
+
+  private var mcpReviewInvocation: String {
+    """
+    {
+      "tool": "prepare_review",
+      "arguments": {
+        "task": "Review this change against its task and acceptance criteria.",
+        "change": "main...feature"
+      }
+    }
+    """
+  }
+
+  private var projectionBoundary: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      PremiumFieldLabel("AUTHORITY BOUNDARY")
+      Label(projectionCommand, systemImage: "terminal")
+        .font(.system(size: 10, weight: .semibold, design: .monospaced))
+      Text(projectionDetail)
+        .font(.system(size: 9))
+        .foregroundStyle(.secondary)
+    }
+    .padding(16)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .background(EvidenceStyle.inspector, in: RoundedRectangle(cornerRadius: 12))
+    .overlay { RoundedRectangle(cornerRadius: 12).stroke(EvidenceStyle.separator) }
+  }
+
+  private var projectionCommand: String {
+    switch model.settingsSection {
+    case .mcp: "codevetter mcp"
+    case .agentIsland: "codevetter settings --set native_agent_island_…"
+    case .usage: "codevetter history-roots · codevetter retention"
+    case .rubrics: "codevetter rubrics"
+    case .memories: "codevetter memories"
+    case .ops: "codevetter ops --window-days \(model.opsWindowDays)"
+    default: "codevetter settings"
+    }
+  }
+
+  private var projectionDetail: String {
+    switch model.settingsSection {
+    case .mcp:
+      "The CLI and native UI share codevetter.mcp-settings/v1. Repository authority changes are explicit; credentials and evidence payloads never enter the access audit."
+    case .agentIsland:
+      "The CLI, native UI, and retained Tauri helper share the same twelve non-secret preferences through codevetter.native-settings/v1. This host stores configuration only; live helper status, preview, session presentation, speech, and validated actions remain incumbent authority."
+    case .usage:
+      "The CLI and native UI share codevetter.history-roots/v1 and codevetter.session-retention/v1. Root changes are bounded and never read or delete transcripts; retention preview, apply, checkpoint, and VACUUM remain separate operations."
+    case .rubrics:
+      "The CLI and native UI share codevetter.rubric-settings/v1. Rust owns validation, active selection, custom packs, usage attribution, and the exact prompt preview passed into reviews."
+    case .memories:
+      "The CLI and native UI share codevetter.memories/v1. Rust owns source discovery, opaque identity, canonical admission, redaction, payload bounds, and supervised Git diff; agents and MCP receive no memory authority."
+    case .ops:
+      "The CLI and native UI share codevetter.ops-status/v1. Only aggregate local rows and configuration presence cross the boundary; credentials, endpoint values, provider fetches, webhook sends, and configuration writes remain excluded."
+    default:
+      "The CLI and native UI share codevetter.native-settings/v1. Only one validated, allowlisted value is saved per receipt; github_token and all credential material are excluded."
+    }
+  }
+
+  private func settings(in section: NativeSettingsSection) -> [NativeSettingValue] {
+    model.settingsReceipt?.settings.filter { $0.section == section.rawValue } ?? []
+  }
+
+  private var sectionIsLive: Bool {
+    if model.settingsSection == .mcp { return model.mcpSettingsReceipt != nil }
+    if model.settingsSection == .usage { return true }
+    if model.settingsSection == .rubrics { return model.rubricReceipt != nil }
+    if model.settingsSection == .memories { return model.memoryReceipt != nil }
+    if model.settingsSection == .ops { return model.opsReceipt != nil }
+    if model.settingsSection == .about { return true }
+    return !settings(in: model.settingsSection).isEmpty
+  }
+
+  private var sectionStatusLabel: String {
+    if model.settingsSection == .agentIsland {
+      return settings(in: .agentIsland).isEmpty ? "TRANSFER TRACKED" : "CONFIG LIVE"
+    }
+    if model.settingsSection == .ops {
+      return model.opsReceipt == nil ? "TRANSFER TRACKED" : "READ-ONLY LIVE"
+    }
+    return sectionIsLive ? "LIVE" : "TRANSFER TRACKED"
+  }
+
+  private var sectionStatusColor: Color {
+    if model.settingsSection == .agentIsland { return EvidenceStyle.warning }
+    return sectionIsLive ? EvidenceStyle.success : EvidenceStyle.warning
+  }
+
+  private var agentIslandEnabled: Bool {
+    settings(in: .agentIsland)
+      .first(where: { $0.key == "native_agent_island_enabled" })?.value == "true"
+  }
+
+  private var sectionDescription: String {
+    switch model.settingsSection {
+    case .general: "Review defaults and deliberate indexing behavior."
+    case .appearance: "Visual density and evidence presentation preferences."
+    case .integrations: "External connection readiness without credential exposure."
+    case .agents: "Default agent roles, concurrency, and local executable discovery."
+    case .agentIsland: "Opt-in native presentation, speech, and privacy-safe preferences."
+    case .mcp: "Repository-scoped machine access, tools, resources, and audit."
+    case .notifications: "Observed local events and provider-telemetry thresholds."
+    case .usage: "History recovery and guarded local archive retention."
+    case .rubrics: "Review rubric packs and deterministic review policy."
+    case .ops: "Operational evidence and local system readiness."
+    case .memories: "Bounded local agent-memory inspection."
+    case .about: "Native build, update, license, and product identity."
+    }
+  }
+
+  private var transferTitle: String {
+    switch model.settingsSection {
+    case .integrations: "Credential-safe integration transfer"
+    case .agentIsland: "Agent Island runtime transfer"
+    case .mcp: "Repository-scoped MCP transfer"
+    case .usage: "Retention and recovery transfer"
+    case .rubrics: "Rubric editor transfer"
+    case .ops: "Operations workspace transfer"
+    case .memories: "Memory inspector transfer"
+    case .about: "Native packaging and updater transfer"
+    default: "No declared settings in this section"
+    }
+  }
+
+  private var transferDetail: String {
+    switch model.settingsSection {
+    case .integrations:
+      "GitHub and Linear connection state must move through a status-only Rust projection. Existing tokens and OAuth material stay in their current owner until secure native storage is separately qualified."
+    case .agentIsland:
+      "All twelve non-secret preferences now share the Rust-owned settings contract across native UI, CLI, and the retained helper. Live session status, preview, presentation, speech execution, and identity-checked actions remain incumbent authority until the helper is integrated and requalified in the new host."
+    case .mcp:
+      "The native surface must preserve repository selection, indexed/stale state, tool and resource catalogs, copyable client configuration, audit history, enablement, review readiness, and clear-audit confirmation."
+    case .usage:
+      "Additional Codex roots, dry-run retention planning, protected-session reasons, apply confirmation, checkpoint, and VACUUM remain to be transferred through Rust-owned commands."
+    case .rubrics:
+      "Rubric packs, editing, preview, validation, and review handoff remain reachable in the incumbent while their canonical Rust boundary is defined."
+    case .ops:
+      "Operational diagnostics remain in the incumbent until their read and execute authorities are enumerated and qualified."
+    case .memories:
+      "Memory source discovery, content inspection, search, copy, and redacted Git diff now share a bounded read-only Rust receipt across native UI and CLI. Editing and deletion remain unavailable."
+    case .about:
+      "Sparkle 2.9.6 owns update discovery, signed installation, and relaunch. The preview cannot update; Developer ID notarization, a real EdDSA key, dual-feed cutover, and installed-upgrade proof remain packaging gates."
+    default:
+      "This section has no current declared non-secret setting."
+    }
+  }
+}
+
+private struct NativeSettingRow: View {
+  let setting: NativeSettingValue
+  let saving: Bool
+  let save: (String) -> Void
+  @State private var draft: String
+
+  init(setting: NativeSettingValue, saving: Bool, save: @escaping (String) -> Void) {
+    self.setting = setting
+    self.saving = saving
+    self.save = save
+    _draft = State(initialValue: setting.value)
+  }
+
+  var body: some View {
+    HStack(alignment: .center, spacing: 20) {
+      VStack(alignment: .leading, spacing: 4) {
+        HStack(spacing: 7) {
+          Text(setting.label).font(.system(size: 11, weight: .semibold))
+          if saving { ProgressView().controlSize(.mini).tint(EvidenceStyle.amber) }
+        }
+        Text(setting.description)
+          .font(.system(size: 9))
+          .foregroundStyle(.secondary)
+      }
+      Spacer(minLength: 28)
+      control
+        .frame(width: setting.kind == .text ? 300 : 180, alignment: .trailing)
+    }
+    .padding(.horizontal, 18)
+    .padding(.vertical, 14)
+    .onChange(of: setting.value) { _, value in draft = value }
+  }
+
+  @ViewBuilder
+  private var control: some View {
+    switch setting.kind {
+    case .toggle:
+      Toggle(
+        "",
+        isOn: Binding(
+          get: { setting.value == "true" },
+          set: { save($0 ? "true" : "false") }
+        )
+      )
+      .labelsHidden()
+      .toggleStyle(.switch)
+      .tint(EvidenceStyle.amber)
+      .disabled(saving)
+      .accessibilityLabel(setting.label)
+    case .choice:
+      Picker(
+        setting.label,
+        selection: Binding(
+          get: { setting.value },
+          set: { save($0) }
+        )
+      ) {
+        ForEach(setting.options) { option in
+          Text(option.label).tag(option.value)
+        }
+      }
+      .labelsHidden()
+      .pickerStyle(.menu)
+      .disabled(saving)
+      .accessibilityLabel(setting.label)
+    case .text:
+      HStack(spacing: 7) {
+        TextField(setting.defaultValue, text: $draft)
+          .textFieldStyle(.roundedBorder)
+          .font(.system(size: 9, design: .monospaced))
+          .onSubmit { if draft != setting.value { save(draft) } }
+          .accessibilityLabel(setting.label)
+        Button("Save") {
+          save(draft)
+        }
+        .buttonStyle(.bordered)
+        .disabled(saving || draft == setting.value)
+      }
+    }
+  }
+}


### PR DESCRIPTION
Part 2/40 of the dependency-ordered native macOS evidence-workbench stack.

Base: `stack/01-native-models`
Head: `stack/02-native-settings`

This layer stays within the repository's 40-file, 4,000-addition, and 6,000-gross-line limits. Merge only in stack order.
The top tree is byte-identical to the snapshot qualified in draft PR #203; protected signing, notarization, release, and Tauri cutover remain owner-approval gates.
Tracks #193, #194, #199, #200, #201, and #202 without auto-closing them before the full stack lands.