### PR TITLE
[stack 03/40] Native verification workflow views

### DIFF
--- a/apps/macos/CodeVetterPackage/Sources/CodeVetterFeature/PremiumTestingView.swift
+++ b/apps/macos/CodeVetterPackage/Sources/CodeVetterFeature/PremiumTestingView.swift
@@ -1,0 +1,750 @@
+import SwiftUI
+import UniformTypeIdentifiers
+
+private enum TestingDetailMode: String, CaseIterable, Identifiable {
+  case evidence = "Evidence"
+  case json = "JSON"
+
+  var id: String { rawValue }
+}
+
+struct PremiumTestingView: View {
+  @Bindable var model: WorkbenchModel
+  @State private var detailMode: TestingDetailMode = .evidence
+
+  var body: some View {
+    Group {
+      if let receipt = model.testingReceipt {
+        receiptDesk(receipt)
+      } else {
+        HStack(spacing: 0) {
+          testingSetup
+          Rectangle().fill(EvidenceStyle.separator).frame(width: 1)
+          TestingExecutionContract(model: model).frame(width: 310)
+        }
+      }
+    }
+    .background(EvidenceStyle.canvas)
+    .fileImporter(
+      isPresented: $model.choosingRepository,
+      allowedContentTypes: [.folder],
+      allowsMultipleSelection: false
+    ) { result in
+      guard case .success(let urls) = result, let url = urls.first else { return }
+      model.selectRepository(url)
+    }
+    .sheet(isPresented: $model.showingWarmVerifier) {
+      PremiumWarmVerificationView(model: model)
+        .frame(minWidth: 980, minHeight: 680)
+    }
+    .sheet(isPresented: $model.showingDifferentialVerifier) {
+      PremiumDifferentialVerificationView(model: model)
+        .frame(minWidth: 980, minHeight: 680)
+    }
+    .sheet(isPresented: $model.showingScenarioCompiler) {
+      PremiumScenarioCompilerView(model: model)
+        .frame(minWidth: 1_020, minHeight: 700)
+    }
+    .sheet(isPresented: $model.showingTrexWatcher) {
+      PremiumTrexWatcherView(model: model)
+        .frame(minWidth: 1_080, minHeight: 720)
+    }
+    .sheet(isPresented: $model.showingQaWorkspace) {
+      QaJourneyWorkspaceView(model: model)
+        .frame(minWidth: 1_080, minHeight: 720)
+    }
+    .accessibilityElement(children: .contain)
+    .accessibilityIdentifier("testing-workspace")
+  }
+
+  private var testingSetup: some View {
+    VStack(spacing: 0) {
+      ScrollView {
+        VStack(alignment: .leading, spacing: 24) {
+          HStack(alignment: .top) {
+            VStack(alignment: .leading, spacing: 7) {
+              Text("T-REX / DIRECT PREVIEW")
+                .font(.system(size: 9, weight: .bold, design: .monospaced))
+                .tracking(1.2)
+                .foregroundStyle(EvidenceStyle.amberForeground)
+              Text("Test the change where users touch it.")
+                .font(.system(size: 30, weight: .semibold))
+                .tracking(-0.55)
+              Text(
+                "Bind one exact change to one deployed preview, then keep every route, journey, artifact, and limitation attached to the Rust receipt."
+              )
+              .font(.system(size: 13))
+              .foregroundStyle(.secondary)
+              .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer(minLength: 20)
+            StatusPill(label: model.testingState.rawValue, color: testingStatusColor)
+          }
+
+          VStack(alignment: .leading, spacing: 15) {
+            PremiumFieldLabel("REPOSITORY")
+            Button {
+              model.choosingRepository = true
+            } label: {
+              HStack(spacing: 11) {
+                Image(systemName: "folder.fill").foregroundStyle(EvidenceStyle.amberForeground)
+                Text(repositoryLabel)
+                  .font(.system(size: 13, weight: .medium, design: .monospaced))
+                  .foregroundStyle(model.repositoryPath.isEmpty ? .secondary : .primary)
+                  .lineLimit(1)
+                  .truncationMode(.middle)
+                Spacer()
+                Text("Choose…")
+                  .font(.system(size: 10, weight: .semibold))
+                  .foregroundStyle(.secondary)
+              }
+              .padding(.horizontal, 15)
+              .frame(height: 48)
+              .premiumField()
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Choose testing repository")
+
+            VStack(alignment: .leading, spacing: 8) {
+              PremiumFieldLabel("CHANGE IDENTITY")
+              Picker("Change identity", selection: $model.testingChangeKind) {
+                Text("Git range").tag(TrexChangeKind.range)
+                Text("GitHub pull request").tag(TrexChangeKind.pullRequest)
+              }
+              .pickerStyle(.segmented)
+              .labelsHidden()
+              .tint(EvidenceStyle.amber)
+            }
+
+            PremiumInput(
+              label: model.testingChangeKind == .range ? "EXACT RANGE" : "PULL REQUEST",
+              icon: "arrow.triangle.branch",
+              placeholder: changePlaceholder,
+              text: $model.testingChange
+            )
+
+            PremiumScopePlanner(
+              title: "Changed-scope planner",
+              subtitle:
+                "Resolve this change, one user flow, or a bounded codebase portfolio into Rust-owned runnable targets before browser execution.",
+              kind: $model.testingScopeKind,
+              value: testingScopeValue,
+              plan: model.testingScopePlan,
+              loading: model.testingScopeLoading,
+              issue: model.testingScopeIssue ?? model.testingScopeInputIssue,
+              canResolve: model.canResolveTestingScope,
+              selectedCandidateID: model.selectedTestingScopeCandidateID,
+              compact: false,
+              accessibilityID: "testing-scope-planner",
+              onResolve: model.resolveTestingScope,
+              onSelect: model.selectTestingScopeCandidate
+            )
+
+            Button {
+              model.openQaWorkspace()
+            } label: {
+              HStack(spacing: 12) {
+                ZStack {
+                  RoundedRectangle(cornerRadius: 9)
+                    .fill(EvidenceStyle.amber.opacity(0.12))
+                    .frame(width: 38, height: 38)
+                  Image(systemName: "point.3.connected.trianglepath.dotted")
+                    .foregroundStyle(EvidenceStyle.amberForeground)
+                }
+                VStack(alignment: .leading, spacing: 3) {
+                  Text(
+                    model.testingQaWorkflowName.isEmpty
+                      ? "Journey setup" : model.testingQaWorkflowName
+                  )
+                  .font(.system(size: 12, weight: .semibold))
+                  Text(
+                    model.testingTargetRoute.isEmpty
+                      ? "Saved targets, repository Playwright specs, and post-fix rerun setup"
+                      : "\(model.testingTargetRoute) · \(model.testingTargetGoal)"
+                  )
+                  .font(.system(size: 10))
+                  .foregroundStyle(.secondary)
+                  .lineLimit(2)
+                }
+                Spacer()
+                Text("Configure")
+                  .font(.system(size: 10, weight: .semibold))
+                  .foregroundStyle(.secondary)
+                Image(systemName: "chevron.right")
+                  .font(.system(size: 9, weight: .bold))
+                  .foregroundStyle(.tertiary)
+              }
+              .padding(13)
+              .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 12))
+              .overlay { RoundedRectangle(cornerRadius: 12).stroke(EvidenceStyle.separator) }
+            }
+            .buttonStyle(.plain)
+            .disabled(model.repositoryPath.isEmpty)
+            .accessibilityLabel("Configure saved QA journeys")
+
+            PremiumInput(
+              label: "DEPLOYED PREVIEW",
+              icon: "safari",
+              placeholder: "https://preview.example.com",
+              text: $model.testingPreviewURL
+            )
+          }
+
+          Toggle(isOn: $model.testingConfirmed) {
+            VStack(alignment: .leading, spacing: 4) {
+              Text("Allow this bounded preview verification")
+                .font(.system(size: 12, weight: .semibold))
+              Text(
+                "CodeVetter will contact the selected HTTP(S) preview and may run read-only browser journeys against derived routes."
+              )
+              .font(.system(size: 10))
+              .foregroundStyle(.secondary)
+              .fixedSize(horizontal: false, vertical: true)
+            }
+          }
+          .toggleStyle(.checkbox)
+          .tint(EvidenceStyle.amber)
+          .accessibilityLabel("Allow this bounded preview verification")
+          .accessibilityHint(
+            "Contacts the selected HTTP or HTTPS preview and runs read-only browser journeys."
+          )
+          .padding(15)
+          .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 12))
+          .overlay { RoundedRectangle(cornerRadius: 12).stroke(EvidenceStyle.separator) }
+
+          TestingCapabilityStrip()
+
+          if model.testingState == .failed || model.testingState == .cancelled {
+            Label(
+              model.testingStatusMessage,
+              systemImage: model.testingState == .cancelled ? "stop.circle" : "xmark.octagon.fill"
+            )
+            .font(.system(size: 11, weight: .medium))
+            .foregroundStyle(
+              model.testingState == .cancelled ? Color.secondary : EvidenceStyle.failure
+            )
+            .padding(14)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+              (model.testingState == .cancelled ? Color.secondary : EvidenceStyle.failure).opacity(
+                0.08),
+              in: RoundedRectangle(cornerRadius: 12)
+            )
+          }
+
+        }
+        .padding(34)
+        .frame(maxWidth: 820, alignment: .leading)
+      }
+      Rectangle().fill(EvidenceStyle.separator).frame(height: 1)
+      testingActionBar
+    }
+  }
+
+  private var testingScopeValue: Binding<String> {
+    Binding(
+      get: {
+        model.testingScopeKind == .change ? model.testingChange : model.testingScopeValue
+      },
+      set: { value in
+        if model.testingScopeKind == .change {
+          model.testingChange = value
+        } else {
+          model.testingScopeValue = value
+        }
+      }
+    )
+  }
+
+  private var testingActionBar: some View {
+    HStack(spacing: 12) {
+      if model.testingState == .running {
+        ProgressView().controlSize(.small).tint(EvidenceStyle.amber)
+      }
+      VStack(alignment: .leading, spacing: 3) {
+        Text(model.testingStatusMessage)
+          .font(.system(size: 11, weight: .medium))
+          .foregroundStyle(.secondary)
+          .lineLimit(2)
+        if !model.canStartTesting, model.testingState != .running,
+          let issue = model.testingInputIssue
+        {
+          Text(issue)
+            .font(.system(size: 9))
+            .foregroundStyle(.tertiary)
+            .lineLimit(2)
+        }
+      }
+      Spacer()
+      Button("Warm changed proof") {
+        model.showingWarmVerifier = true
+      }
+      .buttonStyle(.bordered)
+      .disabled(model.repositoryPath.isEmpty || model.testingState == .running)
+      Button("Differential") {
+        model.showingDifferentialVerifier = true
+      }
+      .buttonStyle(.bordered)
+      .disabled(model.repositoryPath.isEmpty || model.testingState == .running)
+      Button("Scenarios") {
+        model.showingScenarioCompiler = true
+      }
+      .buttonStyle(.bordered)
+      .disabled(model.repositoryPath.isEmpty || model.testingState == .running)
+      Button("PR watcher") {
+        model.showingTrexWatcher = true
+      }
+      .buttonStyle(.bordered)
+      .disabled(model.repositoryPath.isEmpty || model.testingState == .running)
+      if model.testingState == .running {
+        Button("Cancel", role: .destructive) { model.cancelTesting() }
+          .buttonStyle(.bordered)
+      } else {
+        Button("Run preview proof") { model.runTesting() }
+          .buttonStyle(PremiumPrimaryButtonStyle())
+          .disabled(!model.canStartTesting)
+          .keyboardShortcut(.return, modifiers: [.command])
+      }
+    }
+    .padding(.horizontal, 22)
+    .frame(minHeight: 68)
+    .background(EvidenceStyle.chrome)
+  }
+
+  private func receiptDesk(_ receipt: TrexPreviewReceipt) -> some View {
+    VStack(spacing: 0) {
+      HStack(spacing: 16) {
+        VStack(alignment: .leading, spacing: 4) {
+          Text("T-REX PREVIEW RECEIPT")
+            .font(.system(size: 9, weight: .bold, design: .monospaced))
+            .tracking(1.1)
+            .foregroundStyle(EvidenceStyle.amberForeground)
+          Text(receipt.summary)
+            .font(.system(size: 18, weight: .semibold))
+            .lineLimit(1)
+          Text(
+            "\(receipt.source.input)  ·  \(receipt.routes.count) routes  ·  \(receipt.journeys.count) journeys"
+          )
+          .font(.system(size: 9, design: .monospaced))
+          .foregroundStyle(.secondary)
+        }
+        Spacer()
+        StatusPill(label: verdictLabel(receipt.verdict), color: verdictColor(receipt.verdict))
+        Button("Open in Runs") {
+          model.section = .runs
+          model.loadRuns()
+        }
+        .buttonStyle(.bordered)
+        Button("New test") { model.resetTesting() }
+          .buttonStyle(.bordered)
+      }
+      .padding(.horizontal, 22)
+      .frame(height: 82)
+      .background(EvidenceStyle.chrome)
+      .overlay(alignment: .bottom) { Rectangle().fill(EvidenceStyle.separator).frame(height: 1) }
+
+      HStack(spacing: 0) {
+        TestingSourceIndex(receipt: receipt).frame(width: 230)
+        Rectangle().fill(EvidenceStyle.separator).frame(width: 1)
+        VStack(spacing: 0) {
+          HStack {
+            Text("EXECUTABLE PROOF")
+              .font(.system(size: 9, weight: .bold, design: .monospaced))
+              .tracking(0.9)
+            Spacer()
+            Picker("Detail", selection: $detailMode) {
+              ForEach(TestingDetailMode.allCases) { mode in
+                Text(mode.rawValue).tag(mode)
+              }
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            .frame(width: 166)
+            .tint(EvidenceStyle.amber)
+          }
+          .padding(.horizontal, 16)
+          .frame(height: 48)
+          .background(EvidenceStyle.surface)
+          .overlay(alignment: .bottom) {
+            Rectangle().fill(EvidenceStyle.separator).frame(height: 1)
+          }
+
+          if detailMode == .evidence {
+            TestingEvidenceView(receipt: receipt)
+          } else {
+            ScrollView([.horizontal, .vertical]) {
+              Text(model.testingReceiptJSON)
+                .font(.system(size: 10, design: .monospaced))
+                .foregroundStyle(.secondary)
+                .textSelection(.enabled)
+                .padding(18)
+                .frame(maxWidth: .infinity, alignment: .topLeading)
+            }
+          }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        Rectangle().fill(EvidenceStyle.separator).frame(width: 1)
+        TestingReceiptInspector(receipt: receipt).frame(width: 290)
+      }
+    }
+  }
+
+  private var repositoryLabel: String {
+    guard !model.repositoryPath.isEmpty else { return "No repository selected" }
+    return URL(fileURLWithPath: model.repositoryPath).lastPathComponent
+  }
+
+  private var changePlaceholder: String {
+    switch model.testingChangeKind {
+    case .range: "main…HEAD"
+    case .pullRequest: "https://github.com/owner/repo/pull/42"
+    }
+  }
+
+  private var testingStatusColor: Color {
+    switch model.testingState {
+    case .running: EvidenceStyle.amber
+    case .completed, .planned: EvidenceStyle.success
+    case .limited: EvidenceStyle.warning
+    case .failed: EvidenceStyle.failure
+    case .ready, .planning, .cancelled: .secondary
+    }
+  }
+}
+
+private struct TestingCapabilityStrip: View {
+  private let capabilities = [
+    ("Direct preview", "Available now", true),
+    ("Changed scope", "Available now", true),
+    ("Scenarios", "Available now", true),
+    ("PR watchers", "Available now", true),
+    ("Warm verify", "Available now", true),
+    ("Differential", "Available now", true),
+  ]
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 10) {
+      HStack {
+        PremiumFieldLabel("TESTING COVERAGE")
+        Spacer()
+        Text("No hidden parity claims")
+          .font(.system(size: 9, weight: .medium))
+          .foregroundStyle(.secondary)
+      }
+      LazyVGrid(columns: [GridItem(.adaptive(minimum: 130), spacing: 8)], spacing: 8) {
+        ForEach(capabilities, id: \.0) { capability in
+          HStack(spacing: 8) {
+            Circle()
+              .fill(capability.2 ? EvidenceStyle.success : Color.secondary.opacity(0.45))
+              .frame(width: 6, height: 6)
+            VStack(alignment: .leading, spacing: 2) {
+              Text(capability.0).font(.system(size: 10, weight: .semibold))
+              Text(capability.1).font(.system(size: 8)).foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 0)
+          }
+          .padding(10)
+          .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 10))
+          .overlay { RoundedRectangle(cornerRadius: 10).stroke(EvidenceStyle.separator) }
+        }
+      }
+    }
+  }
+}
+
+private struct TestingExecutionContract: View {
+  let model: WorkbenchModel
+
+  private let steps = [
+    ("Resolve exact source", "PR or Git range becomes immutable SHAs"),
+    ("Prove preview identity", "Revision header is verified, claimed, or mismatched"),
+    ("Derive affected routes", "Changed paths select bounded browser scope"),
+    ("Run browser journeys", "Read-only executable evidence and artifacts"),
+    ("Persist the receipt", "Verdict and limitations remain inseparable"),
+  ]
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      PremiumFieldLabel("RUST EXECUTION CONTRACT").padding(.bottom, 24)
+      ForEach(Array(steps.enumerated()), id: \.offset) { index, step in
+        HStack(alignment: .top, spacing: 12) {
+          VStack(spacing: 0) {
+            ZStack {
+              Circle().fill(stepColor(index).opacity(index == activeIndex ? 1 : 0.12))
+              Text(String(format: "%02d", index + 1))
+                .font(.system(size: 8, weight: .bold, design: .monospaced))
+                .foregroundStyle(index == activeIndex ? EvidenceStyle.ink : .secondary)
+            }
+            .frame(width: 28, height: 28)
+            if index < steps.count - 1 {
+              Rectangle().fill(EvidenceStyle.separator).frame(width: 1, height: 48)
+            }
+          }
+          VStack(alignment: .leading, spacing: 4) {
+            Text(step.0).font(.system(size: 11, weight: .semibold))
+            Text(step.1)
+              .font(.system(size: 9))
+              .foregroundStyle(.secondary)
+              .fixedSize(horizontal: false, vertical: true)
+          }
+          .padding(.top, 2)
+        }
+      }
+      Spacer()
+      Divider()
+      VStack(alignment: .leading, spacing: 9) {
+        PremiumFieldLabel("CURRENT AUTHORITY")
+        Label("codevetter trex", systemImage: "checkmark.seal.fill")
+          .font(.system(size: 10, weight: .semibold, design: .monospaced))
+          .foregroundStyle(EvidenceStyle.success)
+        Text(
+          "Swift validates the form and renders the receipt. Rust owns source resolution, network checks, route selection, execution, persistence, and verdict semantics."
+        )
+        .font(.system(size: 9))
+        .foregroundStyle(.secondary)
+        .fixedSize(horizontal: false, vertical: true)
+      }
+      .padding(.top, 16)
+    }
+    .padding(26)
+    .background(EvidenceStyle.inspector)
+  }
+
+  private var activeIndex: Int {
+    switch model.testingState {
+    case .ready, .cancelled: 0
+    case .running: 2
+    case .completed, .limited, .failed: 4
+    case .planning, .planned: 1
+    }
+  }
+
+  private func stepColor(_ index: Int) -> Color {
+    index == activeIndex ? EvidenceStyle.amber : .secondary
+  }
+}
+
+private struct TestingSourceIndex: View {
+  let receipt: TrexPreviewReceipt
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      PremiumFieldLabel("CHANGED PATHS").padding(16)
+      Rectangle().fill(EvidenceStyle.separator).frame(height: 1)
+      if receipt.source.changedPaths.isEmpty {
+        Text("No changed paths recorded")
+          .font(.system(size: 10))
+          .foregroundStyle(.secondary)
+          .padding(16)
+      } else {
+        ScrollView {
+          LazyVStack(alignment: .leading, spacing: 2) {
+            ForEach(receipt.source.changedPaths, id: \.self) { path in
+              HStack(spacing: 8) {
+                Image(systemName: "doc.text").foregroundStyle(EvidenceStyle.amberForeground)
+                Text(path)
+                  .font(.system(size: 9, design: .monospaced))
+                  .lineLimit(2)
+                Spacer(minLength: 0)
+              }
+              .padding(.horizontal, 14)
+              .padding(.vertical, 8)
+            }
+          }
+        }
+      }
+      Spacer(minLength: 0)
+      Divider()
+      VStack(alignment: .leading, spacing: 5) {
+        PremiumFieldLabel("SOURCE")
+        Text(receipt.source.kind == .range ? "Git range" : "GitHub pull request")
+          .font(.system(size: 10, weight: .semibold))
+        Text("\(receipt.source.commits.count) commits")
+          .font(.system(size: 9, design: .monospaced))
+          .foregroundStyle(.secondary)
+      }
+      .padding(16)
+    }
+    .background(EvidenceStyle.chrome)
+  }
+}
+
+private struct TestingEvidenceView: View {
+  let receipt: TrexPreviewReceipt
+
+  var body: some View {
+    ScrollView {
+      LazyVStack(alignment: .leading, spacing: 14) {
+        VStack(alignment: .leading, spacing: 10) {
+          HStack {
+            Label(
+              previewStatusLabel(receipt.preview.status),
+              systemImage: receipt.preview.status == .verified
+                ? "checkmark.seal.fill" : "link.badge.plus"
+            )
+            .font(.system(size: 12, weight: .semibold))
+            .foregroundStyle(previewStatusColor(receipt.preview.status))
+            Spacer()
+            Text(receipt.preview.finalURL)
+              .font(.system(size: 9, design: .monospaced))
+              .foregroundStyle(.secondary)
+              .lineLimit(1)
+          }
+          Text(receipt.preview.evidence)
+            .font(.system(size: 11))
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(15)
+        .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 12))
+        .overlay { RoundedRectangle(cornerRadius: 12).stroke(EvidenceStyle.separator) }
+
+        HStack {
+          PremiumFieldLabel("BROWSER JOURNEYS")
+          Spacer()
+          Text("\(receipt.journeys.filter(\.pass).count)/\(receipt.journeys.count) passed")
+            .font(.system(size: 9, weight: .semibold, design: .monospaced))
+            .foregroundStyle(.secondary)
+        }
+
+        if receipt.journeys.isEmpty {
+          Label("No browser journey evidence was produced", systemImage: "exclamationmark.triangle")
+            .font(.system(size: 11))
+            .foregroundStyle(EvidenceStyle.warning)
+            .padding(15)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(EvidenceStyle.warning.opacity(0.07), in: RoundedRectangle(cornerRadius: 12))
+        } else {
+          ForEach(receipt.journeys) { journey in
+            VStack(alignment: .leading, spacing: 9) {
+              HStack {
+                Label(
+                  journey.route,
+                  systemImage: journey.pass ? "checkmark.circle.fill" : "xmark.circle.fill"
+                )
+                .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                .foregroundStyle(journey.pass ? EvidenceStyle.success : EvidenceStyle.failure)
+                Spacer()
+                Text("\(journey.durationMS) ms")
+                  .font(.system(size: 9, design: .monospaced))
+                  .foregroundStyle(.secondary)
+              }
+              Text(journey.notes)
+                .font(.system(size: 10))
+                .foregroundStyle(.secondary)
+              if let error = journey.error {
+                Text(error).font(.system(size: 10)).foregroundStyle(EvidenceStyle.failure)
+              }
+              if !journey.trace.consoleErrors.isEmpty {
+                Label(
+                  "\(journey.trace.consoleErrors.count) console errors",
+                  systemImage: "terminal.fill"
+                )
+                .font(.system(size: 9, weight: .medium))
+                .foregroundStyle(EvidenceStyle.warning)
+              }
+              let artifacts = journey.artifacts + [journey.screenshotPath].compactMap { $0 }
+              if !artifacts.isEmpty {
+                Text(artifacts.joined(separator: "  ·  "))
+                  .font(.system(size: 8, design: .monospaced))
+                  .foregroundStyle(.tertiary)
+                  .lineLimit(2)
+              }
+            }
+            .padding(15)
+            .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 12))
+            .overlay { RoundedRectangle(cornerRadius: 12).stroke(EvidenceStyle.separator) }
+          }
+        }
+      }
+      .padding(16)
+    }
+  }
+}
+
+private struct TestingReceiptInspector: View {
+  let receipt: TrexPreviewReceipt
+
+  var body: some View {
+    ScrollView {
+      VStack(alignment: .leading, spacing: 18) {
+        PremiumFieldLabel("PROOF IDENTITY")
+        inspectorPair("REPOSITORY", URL(fileURLWithPath: receipt.repoPath).lastPathComponent)
+        inspectorPair("RUN", receipt.runID)
+        inspectorPair("HEAD", String(receipt.source.headSHA.prefix(12)))
+        inspectorPair("PREVIEW", previewStatusLabel(receipt.preview.status))
+        inspectorPair(
+          "REVISION",
+          receipt.preview.revision.map { String($0.prefix(12)) } ?? "Not exposed"
+        )
+        inspectorPair("DURATION", "\(receipt.durationMS) ms")
+        Divider()
+        PremiumFieldLabel("ROUTES")
+        ForEach(receipt.routes) { route in
+          VStack(alignment: .leading, spacing: 3) {
+            Text(route.route).font(.system(size: 10, weight: .semibold, design: .monospaced))
+            Text(route.reason).font(.system(size: 9)).foregroundStyle(.secondary)
+          }
+        }
+        Divider()
+        PremiumFieldLabel("LIMITATIONS")
+        if receipt.limitations.isEmpty {
+          Label("No limitations recorded", systemImage: "checkmark.circle")
+            .font(.system(size: 10))
+            .foregroundStyle(EvidenceStyle.success)
+        } else {
+          ForEach(receipt.limitations, id: \.self) { limitation in
+            Label(limitation, systemImage: "exclamationmark.triangle")
+              .font(.system(size: 9))
+              .foregroundStyle(.secondary)
+              .fixedSize(horizontal: false, vertical: true)
+          }
+        }
+        Divider()
+        Label("Rust-persisted receipt", systemImage: "checkmark.seal.fill")
+          .font(.system(size: 10, weight: .semibold))
+          .foregroundStyle(EvidenceStyle.success)
+      }
+      .padding(20)
+    }
+    .background(EvidenceStyle.inspector)
+  }
+
+  private func inspectorPair(_ label: String, _ value: String) -> some View {
+    VStack(alignment: .leading, spacing: 4) {
+      PremiumFieldLabel(label)
+      Text(value)
+        .font(.system(size: 10, weight: .medium, design: .monospaced))
+        .textSelection(.enabled)
+        .lineLimit(2)
+    }
+  }
+}
+
+private func verdictLabel(_ verdict: TrexPreviewVerdict) -> String {
+  verdict.rawValue.replacingOccurrences(of: "_", with: " ")
+}
+
+private func verdictColor(_ verdict: TrexPreviewVerdict) -> Color {
+  switch verdict {
+  case .passedWithLimits: EvidenceStyle.success
+  case .failed: EvidenceStyle.failure
+  case .noConfidence: EvidenceStyle.warning
+  }
+}
+
+private func previewStatusLabel(_ status: TrexPreviewIdentityStatus) -> String {
+  switch status {
+  case .verified: "Preview revision verified"
+  case .claimed: "Preview identity claimed"
+  case .mismatch: "Preview revision mismatch"
+  }
+}
+
+private func previewStatusColor(_ status: TrexPreviewIdentityStatus) -> Color {
+  switch status {
+  case .verified: EvidenceStyle.success
+  case .claimed: EvidenceStyle.warning
+  case .mismatch: EvidenceStyle.failure
+  }
+}

--- a/apps/macos/CodeVetterPackage/Sources/CodeVetterFeature/PremiumUnpackView.swift
+++ b/apps/macos/CodeVetterPackage/Sources/CodeVetterFeature/PremiumUnpackView.swift
@@ -1,0 +1,1641 @@
+import AppKit
+import SwiftUI
+import UniformTypeIdentifiers
+
+private enum UnpackDeskSection: String, CaseIterable, Identifiable {
+  case overview = "Overview"
+  case brief = "Brief"
+  case activity = "Activity"
+  case inventory = "Inventory"
+  case graph = "Graph"
+  case analysis = "Analysis"
+  case rules = "Rules"
+  case handoff = "Handoff"
+  case delta = "Delta"
+
+  var id: String { rawValue }
+}
+
+struct PremiumUnpackView: View {
+  @Bindable var model: WorkbenchModel
+  @State private var section: UnpackDeskSection = .overview
+
+  init(model: WorkbenchModel, startsInQueryDesk: Bool = false) {
+    self.model = model
+    _section = State(initialValue: startsInQueryDesk ? .graph : .overview)
+  }
+
+  var body: some View {
+    VStack(spacing: 0) {
+      header
+      Rectangle().fill(EvidenceStyle.separator).frame(height: 1)
+      scanBar
+      Rectangle().fill(EvidenceStyle.separator).frame(height: 1)
+      HStack(spacing: 0) {
+        snapshotLedger
+          .frame(width: 270)
+        Rectangle().fill(EvidenceStyle.separator).frame(width: 1)
+        detailDesk
+      }
+    }
+    .background(EvidenceStyle.canvas)
+    .fileImporter(
+      isPresented: $model.choosingRepository,
+      allowedContentTypes: [.folder],
+      allowsMultipleSelection: false
+    ) { result in
+      guard case .success(let urls) = result, let url = urls.first else { return }
+      model.selectRepository(url)
+    }
+    .accessibilityElement(children: .contain)
+    .accessibilityIdentifier("repo-unpack-workspace")
+  }
+
+  private var header: some View {
+    HStack(alignment: .top, spacing: 18) {
+      VStack(alignment: .leading, spacing: 5) {
+        Text("REPOSITORY MEMORY")
+          .font(.system(size: 9, weight: .bold, design: .monospaced))
+          .tracking(1.1)
+          .foregroundStyle(EvidenceStyle.amberForeground)
+        Text("Repo Unpack").font(.system(size: 25, weight: .semibold))
+        Text("Stored source maps, history leads, structural evidence, and explicit coverage")
+          .font(.system(size: 10))
+          .foregroundStyle(.secondary)
+      }
+      Spacer()
+      StatusPill(
+        label: (model.unpackLoading || model.repositoryQueryLoading)
+          ? "Rust operation active" : "Native scan + query",
+        color: model.unpackIssue == nil ? EvidenceStyle.success : EvidenceStyle.warning
+      )
+      .accessibilityIdentifier("repo-unpack-read-only-status")
+      Menu {
+        ForEach(UnpackExportFormat.allCases) { format in
+          Button(format.label) { chooseExport(format) }
+        }
+      } label: {
+        Label("Export", systemImage: "square.and.arrow.up")
+      }
+      .menuStyle(.borderlessButton)
+      .fixedSize()
+      .disabled(model.unpackSnapshot == nil || model.isBusy)
+      .accessibilityIdentifier("repo-unpack-export")
+      Button {
+        model.loadUnpackSnapshots()
+      } label: {
+        Label("Refresh", systemImage: "arrow.clockwise")
+      }
+      .buttonStyle(.bordered)
+      .disabled(model.unpackLoading)
+      .accessibilityLabel("Refresh Repo Unpack snapshots")
+    }
+    .padding(.horizontal, 22)
+    .padding(.vertical, 18)
+    .background(EvidenceStyle.chrome)
+  }
+
+  private var scanBar: some View {
+    HStack(spacing: 12) {
+      Button {
+        model.choosingRepository = true
+      } label: {
+        HStack(spacing: 9) {
+          Image(systemName: "folder.fill").foregroundStyle(EvidenceStyle.amberForeground)
+          Text(repositoryLabel)
+            .font(.system(size: 10, weight: .medium, design: .monospaced))
+            .foregroundStyle(model.repositoryPath.isEmpty ? .secondary : .primary)
+            .lineLimit(1)
+            .truncationMode(.middle)
+          Spacer(minLength: 8)
+          Text("Choose…")
+            .font(.system(size: 8, weight: .semibold))
+            .foregroundStyle(.secondary)
+        }
+        .padding(.horizontal, 12)
+        .frame(width: 310, height: 38)
+        .premiumField()
+      }
+      .buttonStyle(.plain)
+      .accessibilityLabel("Choose repository to unpack")
+      .accessibilityIdentifier("repo-unpack-choose-repository")
+
+      VStack(alignment: .leading, spacing: 2) {
+        PremiumFieldLabel(
+          (model.unpackLoading || model.repositoryQueryLoading)
+            ? "RUST OPERATION ACTIVE" : "DETERMINISTIC SNAPSHOT")
+        Text(model.unpackStatusMessage)
+          .font(.system(size: 9))
+          .foregroundStyle(model.unpackIssue == nil ? Color.secondary : EvidenceStyle.warning)
+          .lineLimit(1)
+      }
+      Spacer(minLength: 12)
+
+      if model.unpackLoading || model.repositoryQueryLoading {
+        Button("Cancel", role: .cancel) { model.cancelUnpackOperation() }
+          .buttonStyle(.bordered)
+          .accessibilityIdentifier("repo-unpack-cancel")
+      } else {
+        Button {
+          model.scanUnpackRepository()
+        } label: {
+          Label("Unpack repository", systemImage: "shippingbox.and.arrow.backward.fill")
+        }
+        .buttonStyle(.borderedProminent)
+        .tint(EvidenceStyle.amber)
+        .foregroundStyle(Color.black)
+        .disabled(!model.canScanUnpackRepository)
+        .accessibilityIdentifier("repo-unpack-scan")
+      }
+    }
+    .padding(.horizontal, 18)
+    .frame(height: 58)
+    .background(EvidenceStyle.surface)
+  }
+
+  private var repositoryLabel: String {
+    guard !model.repositoryPath.isEmpty else { return "Choose a local repository" }
+    return URL(fileURLWithPath: model.repositoryPath).lastPathComponent
+  }
+
+  private var snapshotLedger: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      HStack {
+        PremiumFieldLabel("SNAPSHOT LEDGER")
+        Spacer()
+        Text("\(model.unpackSnapshots.count)")
+          .font(.system(size: 9, weight: .semibold, design: .monospaced))
+          .foregroundStyle(.secondary)
+      }
+      .padding(16)
+      Rectangle().fill(EvidenceStyle.separator).frame(height: 1)
+
+      if model.unpackSnapshots.isEmpty, !model.unpackLoading {
+        ContentUnavailableView(
+          "No stored snapshots",
+          systemImage: "shippingbox",
+          description: Text(
+            model.unpackIssue ?? "Choose a repository above to create a deterministic snapshot.")
+        )
+      } else {
+        ScrollView {
+          LazyVStack(spacing: 5) {
+            ForEach(model.unpackSnapshots) { snapshot in
+              Button {
+                model.selectUnpackSnapshot(snapshot.id)
+              } label: {
+                UnpackSnapshotRow(
+                  snapshot: snapshot,
+                  selected: snapshot.id == model.selectedUnpackSnapshotID
+                )
+              }
+              .buttonStyle(.plain)
+              .accessibilityLabel("\(snapshot.repoName) snapshot")
+              .accessibilityValue(
+                snapshot.id == model.selectedUnpackSnapshotID ? "Selected" : snapshot.status)
+            }
+          }
+          .padding(10)
+        }
+      }
+
+      Rectangle().fill(EvidenceStyle.separator).frame(height: 1)
+      VStack(alignment: .leading, spacing: 7) {
+        Label("Rust-owned SQLite history", systemImage: "checkmark.seal.fill")
+          .foregroundStyle(EvidenceStyle.success)
+        Text(
+          "Native creation, bounded comparison, canonical exports, and read-only graph/history queries use shared Rust boundaries. Model synthesis and cleanup remain separately gated."
+        )
+        .foregroundStyle(.secondary)
+      }
+      .font(.system(size: 8))
+      .padding(14)
+    }
+    .background(EvidenceStyle.inspector)
+  }
+
+  @ViewBuilder
+  private var detailDesk: some View {
+    if let inventory = model.unpackInventory, let snapshot = model.unpackSnapshot {
+      VStack(spacing: 0) {
+        sectionRail(hasBrief: model.unpackReport != nil)
+        Rectangle().fill(EvidenceStyle.separator).frame(height: 1)
+        switch section {
+        case .overview:
+          overviewDesk(snapshot, inventory: inventory)
+        case .brief:
+          briefDesk(model.unpackReport)
+        case .activity:
+          activityDesk(inventory)
+        case .inventory:
+          inventoryDesk(inventory)
+        case .graph:
+          graphDesk(inventory)
+        case .analysis:
+          analysisDesk(inventory)
+        case .rules:
+          rulesDesk(inventory)
+        case .handoff:
+          handoffDesk(inventory, report: model.unpackReport)
+        case .delta:
+          deltaDesk(snapshot)
+        }
+      }
+    } else if model.unpackLoading {
+      VStack(spacing: 12) {
+        ProgressView().controlSize(.small)
+        Text("Opening the bounded Rust snapshot…").font(.system(size: 12, weight: .medium))
+        Text("The native client never opens or reinterprets SQLite directly.")
+          .font(.system(size: 9))
+          .foregroundStyle(.secondary)
+      }
+      .frame(maxWidth: .infinity, maxHeight: .infinity)
+    } else {
+      ContentUnavailableView(
+        "Select a stored snapshot",
+        systemImage: "shippingbox",
+        description: Text(model.unpackIssue ?? "Choose a repository snapshot from the ledger.")
+      )
+    }
+  }
+
+  private func sectionRail(hasBrief: Bool) -> some View {
+    HStack(spacing: 6) {
+      ForEach(UnpackDeskSection.allCases) { item in
+        Button {
+          section = item
+        } label: {
+          Text(item.rawValue)
+            .font(.system(size: 9, weight: .semibold))
+            .foregroundStyle(section == item ? Color.black : Color.secondary)
+            .padding(.horizontal, 12)
+            .frame(height: 29)
+            .background(
+              section == item ? EvidenceStyle.amber : Color.clear,
+              in: RoundedRectangle(cornerRadius: 8)
+            )
+        }
+        .buttonStyle(.plain)
+        .disabled(item == .brief && !hasBrief)
+        .accessibilityLabel("Repo Unpack \(item.rawValue)")
+        .accessibilityValue(section == item ? "Selected" : "")
+        .accessibilityIdentifier("repo-unpack-section-\(item.rawValue.lowercased())")
+      }
+      Spacer()
+      Text(hasBrief ? "LOCAL + MODEL-LABELLED" : "LOCAL EVIDENCE ONLY")
+        .font(.system(size: 7, weight: .bold, design: .monospaced))
+        .foregroundStyle(hasBrief ? EvidenceStyle.warning : EvidenceStyle.success)
+    }
+    .padding(.horizontal, 14)
+    .frame(height: 44)
+    .background(EvidenceStyle.chrome)
+  }
+
+  private func overviewDesk(_ snapshot: UnpackSnapshotRecord, inventory: UnpackInventory)
+    -> some View
+  {
+    ScrollView {
+      LazyVStack(alignment: .leading, spacing: 14) {
+        identity(snapshot, inventory: inventory)
+        metrics(snapshot, inventory: inventory)
+        HStack(alignment: .top, spacing: 14) {
+          systemMap(inventory)
+          sourceOutline(inventory)
+            .frame(width: 330)
+        }
+        HStack(alignment: .top, spacing: 14) {
+          historyPanel(inventory)
+          healthPanel(inventory)
+        }
+      }
+      .padding(18)
+    }
+  }
+
+  private func identity(_ snapshot: UnpackSnapshotRecord, inventory: UnpackInventory) -> some View {
+    HStack(alignment: .top, spacing: 18) {
+      VStack(alignment: .leading, spacing: 6) {
+        PremiumFieldLabel("SELECTED REPOSITORY")
+        Text(snapshot.repoName).font(.system(size: 22, weight: .semibold))
+        Text(snapshot.repoPath)
+          .font(.system(size: 9, design: .monospaced))
+          .foregroundStyle(.secondary)
+          .lineLimit(1)
+      }
+      Spacer()
+      VStack(alignment: .trailing, spacing: 7) {
+        StatusPill(
+          label: snapshot.status.replacingOccurrences(of: "_", with: " "),
+          color: EvidenceStyle.success)
+        HStack(spacing: 12) {
+          UnpackIdentity(label: "BRANCH", value: inventory.branch ?? "detached")
+          UnpackIdentity(
+            label: "COMMIT",
+            value: snapshot.commitSHA.map { String($0.prefix(12)) } ?? "unrecorded"
+          )
+        }
+      }
+    }
+    .padding(18)
+    .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 14))
+    .overlay { RoundedRectangle(cornerRadius: 14).stroke(EvidenceStyle.separator) }
+  }
+
+  private func metrics(_ snapshot: UnpackSnapshotRecord, inventory: UnpackInventory) -> some View {
+    HStack(spacing: 8) {
+      UnpackMetric(
+        value: compactCount(snapshot.filesScanned), label: "FILES SCANNED",
+        detail: "\(snapshot.filesSkipped) skipped")
+      UnpackMetric(
+        value: byteCount(snapshot.bytesScanned), label: "SOURCE BYTES",
+        detail: inventory.coverage.strategy.replacingOccurrences(of: "_", with: " "))
+      UnpackMetric(
+        value: "\(inventory.graph.nodes.count)", label: "GRAPH NODES",
+        detail: "\(inventory.graph.edges.count) relationships")
+      UnpackMetric(
+        value: String(format: "%.1f", inventory.health.averageScore), label: "HEALTH SCORE",
+        detail: "\(inventory.health.hotspotCount) hotspots")
+    }
+  }
+
+  private func systemMap(_ inventory: UnpackInventory) -> some View {
+    VStack(alignment: .leading, spacing: 16) {
+      HStack {
+        VStack(alignment: .leading, spacing: 3) {
+          PremiumFieldLabel("SYSTEM MAP")
+          Text("Technology and workspace boundaries").font(.system(size: 15, weight: .semibold))
+        }
+        Spacer()
+        Text("\(inventory.workspaceUnits.count) units")
+          .font(.system(size: 8, design: .monospaced))
+          .foregroundStyle(.secondary)
+      }
+      LazyVGrid(
+        columns: [GridItem(.adaptive(minimum: 72), spacing: 6)],
+        alignment: .leading,
+        spacing: 6
+      ) {
+        ForEach(inventory.stackTags, id: \.self) { tag in
+          Text(tag)
+            .font(.system(size: 8, weight: .semibold))
+            .padding(.horizontal, 9)
+            .frame(height: 25)
+            .background(EvidenceStyle.amber.opacity(0.1), in: Capsule())
+            .overlay { Capsule().stroke(EvidenceStyle.amber.opacity(0.25)) }
+        }
+      }
+      Divider()
+      ForEach(inventory.workspaceUnits.prefix(6)) { unit in
+        HStack(spacing: 10) {
+          Image(systemName: "shippingbox")
+            .foregroundStyle(EvidenceStyle.amberForeground)
+            .frame(width: 22)
+          VStack(alignment: .leading, spacing: 2) {
+            Text(unit.name).font(.system(size: 10, weight: .semibold))
+            Text("\(unit.kind.replacingOccurrences(of: "_", with: " ")) · \(unit.fileCount) files")
+              .font(.system(size: 8, design: .monospaced))
+              .foregroundStyle(.secondary)
+          }
+          Spacer()
+          Text(unit.languages.prefix(3).map(\.language).joined(separator: " · "))
+            .font(.system(size: 8))
+            .foregroundStyle(.secondary)
+        }
+        .frame(height: 36)
+      }
+      Divider()
+      PremiumFieldLabel("LANGUAGE WEIGHT")
+      ForEach(inventory.languages.prefix(6)) { language in
+        HStack {
+          Text(language.language).font(.system(size: 9, weight: .medium))
+          Spacer()
+          Text("\(language.files) files · \(byteCount(Int(language.bytes)))")
+            .font(.system(size: 8, design: .monospaced))
+            .foregroundStyle(.secondary)
+        }
+      }
+    }
+    .padding(18)
+    .frame(maxWidth: .infinity, alignment: .topLeading)
+    .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 14))
+    .overlay { RoundedRectangle(cornerRadius: 14).stroke(EvidenceStyle.separator) }
+  }
+
+  private func sourceOutline(_ inventory: UnpackInventory) -> some View {
+    VStack(alignment: .leading, spacing: 0) {
+      VStack(alignment: .leading, spacing: 3) {
+        PremiumFieldLabel("SOURCE OUTLINE")
+        Text("Entrypoints and bounded tree").font(.system(size: 15, weight: .semibold))
+      }
+      .padding(16)
+      Divider()
+      ScrollView {
+        LazyVStack(alignment: .leading, spacing: 0) {
+          ForEach(inventory.entrypoints.prefix(8)) { entry in
+            HStack(spacing: 8) {
+              Image(systemName: "arrow.right.square")
+                .foregroundStyle(EvidenceStyle.amberForeground)
+              VStack(alignment: .leading, spacing: 2) {
+                Text(entry.path).font(.system(size: 9, weight: .medium, design: .monospaced))
+                Text(entry.reason).font(.system(size: 8)).foregroundStyle(.secondary)
+              }
+              Spacer()
+            }
+            .padding(.horizontal, 14)
+            .frame(height: 39)
+          }
+          Divider().padding(.vertical, 5)
+          ForEach(inventory.directoryTree.children.prefix(20)) { node in
+            HStack(spacing: 8) {
+              Image(systemName: node.isDirectory ? "folder" : "doc")
+                .foregroundStyle(
+                  node.isDirectory ? EvidenceStyle.amberForeground : Color.secondary)
+              Text(node.path.isEmpty ? node.name : node.path)
+                .font(.system(size: 9, design: .monospaced))
+                .lineLimit(1)
+              Spacer()
+              Text("\(node.fileCount)")
+                .font(.system(size: 8, design: .monospaced))
+                .foregroundStyle(.secondary)
+            }
+            .padding(.horizontal, 14)
+            .frame(height: 28)
+          }
+        }
+      }
+      .frame(height: 290)
+      Divider()
+      Text(
+        inventory.allFilesCapped
+          ? "Raw file list withheld · tree projection only" : "Complete bounded tree projection"
+      )
+      .font(.system(size: 8, weight: .semibold, design: .monospaced))
+      .foregroundStyle(inventory.allFilesCapped ? EvidenceStyle.warning : EvidenceStyle.success)
+      .padding(14)
+    }
+    .background(EvidenceStyle.inspector, in: RoundedRectangle(cornerRadius: 14))
+    .clipShape(RoundedRectangle(cornerRadius: 14))
+    .overlay { RoundedRectangle(cornerRadius: 14).stroke(EvidenceStyle.separator) }
+  }
+
+  private func historyPanel(_ inventory: UnpackInventory) -> some View {
+    VStack(alignment: .leading, spacing: 12) {
+      HStack {
+        VStack(alignment: .leading, spacing: 3) {
+          PremiumFieldLabel("HISTORY LEADS")
+          Text("Recent decisions and commits").font(.system(size: 14, weight: .semibold))
+        }
+        Spacer()
+        Text(inventory.history.truncated ? "BOUNDED" : "COMPLETE")
+          .font(.system(size: 7, weight: .bold, design: .monospaced))
+          .foregroundStyle(EvidenceStyle.warning)
+      }
+      Text(inventory.history.summary)
+        .font(.system(size: 9))
+        .foregroundStyle(.secondary)
+        .lineLimit(3)
+      ForEach(inventory.history.recentCommits.prefix(4)) { commit in
+        HStack(alignment: .top, spacing: 9) {
+          Text(String(commit.sha.prefix(7)))
+            .font(.system(size: 8, weight: .semibold, design: .monospaced))
+            .foregroundStyle(EvidenceStyle.amberForeground)
+          Text(commit.subject).font(.system(size: 9)).lineLimit(2)
+          Spacer()
+        }
+      }
+    }
+    .padding(18)
+    .frame(maxWidth: .infinity, alignment: .topLeading)
+    .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 14))
+    .overlay { RoundedRectangle(cornerRadius: 14).stroke(EvidenceStyle.separator) }
+  }
+
+  private func healthPanel(_ inventory: UnpackInventory) -> some View {
+    VStack(alignment: .leading, spacing: 12) {
+      HStack {
+        VStack(alignment: .leading, spacing: 3) {
+          PremiumFieldLabel("DETERMINISTIC HEALTH")
+          Text("Review leads, not runtime proof").font(.system(size: 14, weight: .semibold))
+        }
+        Spacer()
+        Text("\(inventory.health.hotspotCount) hotspots")
+          .font(.system(size: 8, design: .monospaced))
+          .foregroundStyle(EvidenceStyle.warning)
+      }
+      ForEach(inventory.health.topFiles.prefix(4)) { file in
+        HStack(spacing: 10) {
+          Text(String(format: "%.1f", file.score))
+            .font(.system(size: 10, weight: .bold, design: .rounded))
+            .foregroundStyle(file.score < 5 ? EvidenceStyle.warning : EvidenceStyle.success)
+            .frame(width: 28)
+          VStack(alignment: .leading, spacing: 2) {
+            Text(file.path).font(.system(size: 9, weight: .medium, design: .monospaced)).lineLimit(
+              1)
+            Text(
+              "\(file.lines) lines · churn \(file.churn) · \(file.hasTestSignal ? "test signal" : "no adjacent test")"
+            )
+            .font(.system(size: 8))
+            .foregroundStyle(.secondary)
+          }
+          Spacer()
+        }
+      }
+    }
+    .padding(18)
+    .frame(maxWidth: .infinity, alignment: .topLeading)
+    .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 14))
+    .overlay { RoundedRectangle(cornerRadius: 14).stroke(EvidenceStyle.separator) }
+  }
+
+  @ViewBuilder
+  private func briefDesk(_ report: UnpackReport?) -> some View {
+    if let report {
+      ScrollView {
+        LazyVStack(alignment: .leading, spacing: 12) {
+          VStack(alignment: .leading, spacing: 7) {
+            PremiumFieldLabel("SYNTHESIZED BRIEF")
+            Text(report.overview ?? "Stored model-labelled repository brief")
+              .font(.system(size: 18, weight: .semibold))
+            Text(
+              "Claims retain their recorded source citations. This brief is navigation context, not executable verification."
+            )
+            .font(.system(size: 10))
+            .foregroundStyle(.secondary)
+          }
+          .padding(18)
+          .frame(maxWidth: .infinity, alignment: .leading)
+          .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 14))
+          .overlay { RoundedRectangle(cornerRadius: 14).stroke(EvidenceStyle.separator) }
+
+          ForEach(reportSections(report), id: \.0) { item in
+            UnpackBriefSectionCard(sectionID: item.0, section: item.1)
+          }
+
+          if let prompt = report.agentPrompt, !prompt.isEmpty {
+            DisclosureGroup("Recorded agent handoff prompt") {
+              Text(prompt)
+                .font(.system(size: 9, design: .monospaced))
+                .textSelection(.enabled)
+                .padding(.top, 10)
+            }
+            .font(.system(size: 10, weight: .semibold))
+            .padding(16)
+            .background(EvidenceStyle.inspector, in: RoundedRectangle(cornerRadius: 12))
+            .overlay { RoundedRectangle(cornerRadius: 12).stroke(EvidenceStyle.separator) }
+          }
+        }
+        .padding(18)
+      }
+    } else {
+      ContentUnavailableView(
+        "No synthesized brief",
+        systemImage: "text.book.closed",
+        description: Text(
+          "This snapshot contains deterministic local evidence only. No model-labelled claims are implied."
+        )
+      )
+    }
+  }
+
+  private func reportSections(_ report: UnpackReport) -> [(String, UnpackReportSection)] {
+    [
+      ("system-map", report.systemMap),
+      ("feature-catalog", report.featureCatalog),
+      ("data-flow", report.dataFlow),
+      ("behavior-traces", report.behaviorTraces),
+      ("testing-signals", report.testingSignals),
+      ("risk-map", report.riskMap),
+      ("extension-points", report.extensionPoints),
+      ("agent-handoff", report.agentHandoff),
+    ].compactMap { item in item.1.map { (item.0, $0) } }
+  }
+
+  private func activityDesk(_ inventory: UnpackInventory) -> some View {
+    ScrollView {
+      LazyVStack(alignment: .leading, spacing: 12) {
+        UnpackDeskHeader(
+          eyebrow: "ACTIVITY / SOURCE-BACKED LEADS",
+          title: "History without invented causality",
+          detail: inventory.history.summary
+        )
+        UnpackListPanel(title: "RECENT COMMITS", count: inventory.history.recentCommits.count) {
+          ForEach(inventory.history.recentCommits.prefix(30)) { commit in
+            UnpackEvidenceRow(
+              icon: "point.topleft.down.curvedto.point.bottomright.up",
+              title: commit.subject,
+              detail:
+                "\(String(commit.sha.prefix(10))) · \(commit.files.prefix(3).joined(separator: " · "))"
+            )
+          }
+        }
+        UnpackListPanel(title: "DECISION MARKERS", count: inventory.history.decisions.count) {
+          ForEach(inventory.history.decisions.prefix(40)) { decision in
+            UnpackEvidenceRow(
+              icon: "quote.bubble",
+              title: decision.text,
+              detail: "\(decision.marker) · \(decision.source)"
+            )
+          }
+        }
+        UnpackListPanel(title: "TEST LEADS", count: inventory.history.testHints.count) {
+          ForEach(inventory.history.testHints.prefix(40)) { hint in
+            UnpackEvidenceRow(icon: "checkmark.diamond", title: hint.path, detail: hint.reason)
+          }
+        }
+      }
+      .padding(18)
+    }
+  }
+
+  private func inventoryDesk(_ inventory: UnpackInventory) -> some View {
+    ScrollView {
+      LazyVStack(alignment: .leading, spacing: 12) {
+        UnpackDeskHeader(
+          eyebrow: "INVENTORY / BOUNDED SOURCE MAP",
+          title: "What Rust actually observed",
+          detail:
+            "\(inventory.coverage.sampledFiles) sampled files · \(inventory.coverage.strategy.replacingOccurrences(of: "_", with: " "))"
+        )
+        HStack(alignment: .top, spacing: 12) {
+          UnpackListPanel(title: "WORKSPACE UNITS", count: inventory.workspaceUnits.count) {
+            ForEach(inventory.workspaceUnits.prefix(40)) { unit in
+              UnpackEvidenceRow(
+                icon: "shippingbox",
+                title: unit.name,
+                detail:
+                  "\(unit.kind.replacingOccurrences(of: "_", with: " ")) · \(unit.fileCount) files · \(unit.path)"
+              )
+            }
+          }
+          UnpackListPanel(title: "MANIFESTS", count: inventory.manifests.count) {
+            ForEach(inventory.manifests.prefix(40)) { manifest in
+              UnpackEvidenceRow(
+                icon: "doc.badge.gearshape",
+                title: manifest.name ?? manifest.path,
+                detail: "\(manifest.kind) · \(manifest.dependencies.count) dependencies"
+              )
+            }
+          }
+        }
+        HStack(alignment: .top, spacing: 12) {
+          UnpackListPanel(title: "DOCUMENTS", count: inventory.documents.count) {
+            ForEach(inventory.documents.prefix(30)) { document in
+              UnpackEvidenceRow(
+                icon: "doc.text", title: document.path,
+                detail: ByteCountFormatter.string(
+                  fromByteCount: Int64(document.bytes), countStyle: .file))
+            }
+          }
+          UnpackListPanel(title: "CONFIGURATION", count: inventory.configFiles.count) {
+            ForEach(inventory.configFiles.prefix(40), id: \.self) { path in
+              UnpackEvidenceRow(icon: "gearshape.2", title: path, detail: "Observed configuration")
+            }
+          }
+        }
+        sourceOutline(inventory)
+      }
+      .padding(18)
+    }
+  }
+
+  private func graphDesk(_ inventory: UnpackInventory) -> some View {
+    ScrollView {
+      LazyVStack(alignment: .leading, spacing: 12) {
+        UnpackDeskHeader(
+          eyebrow: "QUERY DESK / CANONICAL READ MODEL",
+          title: "Ask the repository, keep the provenance",
+          detail:
+            "Structural and historical retrieval reuse the same Rust services exposed to CLI and MCP. Results stay bounded, source-qualified, and freshness-aware."
+        )
+        repositoryQueryConsole
+        repositoryQueryResults
+        UnpackDeskHeader(
+          eyebrow: "SNAPSHOT / QUALIFIED TOPOLOGY",
+          title: "Recorded relationships remain visible",
+          detail:
+            "\(inventory.graph.nodes.count) nodes · \(inventory.graph.edges.count) edges · \(inventory.graph.truncated ? "bounded projection" : "complete recorded projection")"
+        )
+        HStack(alignment: .top, spacing: 12) {
+          UnpackListPanel(title: "NODES", count: inventory.graph.nodes.count) {
+            ForEach(inventory.graph.nodes.prefix(80)) { node in
+              UnpackEvidenceRow(
+                icon: "circle.hexagongrid",
+                title: node.label,
+                detail: "\(node.kind) · \(node.path ?? node.detail ?? node.id)"
+              )
+            }
+          }
+          UnpackListPanel(title: "RELATIONSHIPS", count: inventory.graph.edges.count) {
+            ForEach(inventory.graph.edges.prefix(120)) { edge in
+              UnpackEvidenceRow(
+                icon: "arrow.triangle.branch",
+                title: "\(edge.from) → \(edge.to)",
+                detail: "\(edge.kind) · \(edge.trust) · \(edge.evidence)"
+              )
+            }
+          }
+        }
+      }
+      .padding(18)
+    }
+  }
+
+  private var repositoryQueryConsole: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      HStack(spacing: 12) {
+        HStack(spacing: 4) {
+          ForEach(RepositoryQueryDomain.allCases) { domain in
+            Button {
+              model.repositoryQueryDomain = domain
+              model.repositoryQueryReceipt = nil
+              model.repositoryQueryDetailReceipt = nil
+              model.repositoryQueryIssue = nil
+              model.repositoryQueryDetailIssue = nil
+              model.repositoryGraphPathOrigin = nil
+            } label: {
+              Text(domain.label)
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(
+                  model.repositoryQueryDomain == domain ? Color.black : Color.secondary
+                )
+                .padding(.horizontal, 15)
+                .frame(height: 30)
+                .background(
+                  model.repositoryQueryDomain == domain ? EvidenceStyle.amber : Color.clear,
+                  in: RoundedRectangle(cornerRadius: 8)
+                )
+            }
+            .buttonStyle(.plain)
+            .accessibilityValue(model.repositoryQueryDomain == domain ? "Selected" : "")
+          }
+        }
+        .padding(4)
+        .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 10))
+        .overlay { RoundedRectangle(cornerRadius: 10).stroke(EvidenceStyle.separator) }
+        .accessibilityIdentifier("repo-query-domain")
+
+        HStack(spacing: 9) {
+          Image(
+            systemName: model.repositoryQueryDomain == .graph
+              ? "point.3.connected.trianglepath.dotted"
+              : "clock.arrow.trianglehead.counterclockwise.rotate.90"
+          )
+          .font(.system(size: 11, weight: .semibold))
+          .foregroundStyle(EvidenceStyle.amberForeground)
+          TextField(
+            model.repositoryQueryDomain == .graph
+              ? "Find a service, symbol, path, or responsibility"
+              : "Find a commit, release, entity, or evidence event",
+            text: $model.repositoryQueryText
+          )
+          .textFieldStyle(.plain)
+          .font(.system(size: 11))
+          .onSubmit { model.queryRepositoryEvidence() }
+          .accessibilityIdentifier("repo-query-text")
+        }
+        .padding(.horizontal, 12)
+        .frame(height: 38)
+        .premiumField()
+
+        Button {
+          model.queryRepositoryEvidence()
+        } label: {
+          if model.repositoryQueryLoading {
+            ProgressView().controlSize(.small)
+          } else {
+            Label("Query", systemImage: "arrow.right")
+          }
+        }
+        .buttonStyle(.borderedProminent)
+        .tint(EvidenceStyle.amber)
+        .foregroundStyle(Color.black)
+        .frame(minWidth: 86)
+        .disabled(!model.canQueryRepositoryEvidence)
+        .accessibilityIdentifier("repo-query-submit")
+      }
+
+      HStack(spacing: 8) {
+        PremiumFieldLabel("READ ONLY")
+        Text("40-result bound")
+        Text("•")
+        Text("Canonical SQLite index")
+        Text("•")
+        Text("No repository mutation")
+        Spacer()
+        if let issue = model.repositoryQueryInputIssue,
+          !model.repositoryQueryText.isEmpty
+        {
+          Text(issue).foregroundStyle(EvidenceStyle.warning)
+        }
+      }
+      .font(.system(size: 8, design: .monospaced))
+      .foregroundStyle(.secondary)
+    }
+    .padding(14)
+    .background(EvidenceStyle.inspector, in: RoundedRectangle(cornerRadius: 12))
+    .overlay { RoundedRectangle(cornerRadius: 12).stroke(EvidenceStyle.separator) }
+  }
+
+  @ViewBuilder
+  private var repositoryQueryResults: some View {
+    if model.repositoryQueryLoading {
+      HStack(spacing: 10) {
+        ProgressView().controlSize(.small)
+        Text("Rust is applying canonical ranking and freshness checks…")
+          .font(.system(size: 10, weight: .medium))
+      }
+      .padding(16)
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .premiumField()
+    } else if let issue = model.repositoryQueryIssue {
+      Label(issue, systemImage: "exclamationmark.triangle.fill")
+        .font(.system(size: 9))
+        .foregroundStyle(EvidenceStyle.warning)
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .premiumField()
+    } else if let receipt = model.repositoryQueryReceipt {
+      VStack(alignment: .leading, spacing: 12) {
+        repositoryQueryStatus(receipt)
+        if receipt.status == "unavailable" {
+          Label(
+            receipt.issue ?? "The canonical index is unavailable.",
+            systemImage: "square.stack.3d.up.slash"
+          )
+          .font(.system(size: 10, weight: .medium))
+          .foregroundStyle(EvidenceStyle.warning)
+          .padding(16)
+          .frame(maxWidth: .infinity, alignment: .leading)
+          .background(EvidenceStyle.warning.opacity(0.06), in: RoundedRectangle(cornerRadius: 10))
+        } else if let result = receipt.graphResult {
+          UnpackListPanel(title: "STRUCTURAL MATCHES", count: result.hits.count) {
+            ForEach(result.hits) { hit in
+              repositoryGraphHit(hit)
+            }
+          }
+        } else if let result = receipt.historyResult {
+          UnpackListPanel(title: "HISTORY MATCHES", count: result.items.count) {
+            ForEach(result.items) { item in
+              repositoryHistoryHit(item)
+            }
+          }
+        }
+        repositoryQueryDetailResults
+      }
+    } else {
+      HStack(alignment: .top, spacing: 12) {
+        Image(systemName: "scope")
+          .font(.system(size: 18, weight: .medium))
+          .foregroundStyle(EvidenceStyle.amberForeground)
+        VStack(alignment: .leading, spacing: 4) {
+          Text("A query returns evidence, not a generated answer.")
+            .font(.system(size: 11, weight: .semibold))
+          Text(
+            "Structure ranks indexed symbols and paths. History searches Git revisions plus persisted entities and events, with any coverage gap shown beside the result."
+          )
+          .font(.system(size: 9))
+          .foregroundStyle(.secondary)
+        }
+        Spacer()
+      }
+      .padding(16)
+      .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 12))
+      .overlay { RoundedRectangle(cornerRadius: 12).stroke(EvidenceStyle.separator) }
+    }
+  }
+
+  private func repositoryGraphHit(_ hit: RepositoryGraphSearchHit) -> some View {
+    VStack(alignment: .leading, spacing: 7) {
+      Button {
+        model.explainRepositoryGraphNode(hit.node)
+      } label: {
+        UnpackEvidenceRow(
+          icon: "point.3.connected.trianglepath.dotted",
+          title: hit.node.label,
+          detail: graphHitDetail(hit)
+        )
+      }
+      .buttonStyle(.plain)
+      HStack(spacing: 7) {
+        repositoryQueryAction("Explain", icon: "info.circle") {
+          model.explainRepositoryGraphNode(hit.node)
+        }
+        repositoryQueryAction("Impact", icon: "scope") {
+          model.queryRepositoryImpact(hit.node)
+        }
+        repositoryQueryAction(
+          model.repositoryGraphPathOrigin == nil ? "Path origin" : "Route here",
+          icon: model.repositoryGraphPathOrigin == nil
+            ? "smallcircle.filled.circle" : "arrow.triangle.branch"
+        ) {
+          if model.repositoryGraphPathOrigin == nil {
+            model.setRepositoryGraphPathOrigin(hit.node)
+          } else {
+            model.queryRepositoryPath(to: hit.node)
+          }
+        }
+        Spacer()
+      }
+      .padding(.leading, 24)
+    }
+  }
+
+  private func repositoryHistoryHit(_ item: RepositoryHistorySearchItem) -> some View {
+    Button {
+      model.traceRepositoryHistory(item)
+    } label: {
+      HStack(spacing: 8) {
+        UnpackEvidenceRow(
+          icon: historyIcon(item.kind),
+          title: item.label,
+          detail: historyHitDetail(item)
+        )
+        Image(systemName: "arrow.right")
+          .font(.system(size: 9, weight: .bold))
+          .foregroundStyle(EvidenceStyle.amberForeground)
+      }
+    }
+    .buttonStyle(.plain)
+  }
+
+  private func repositoryQueryAction(
+    _ title: String,
+    icon: String,
+    action: @escaping () -> Void
+  ) -> some View {
+    Button(action: action) {
+      Label(title, systemImage: icon)
+        .font(.system(size: 8, weight: .semibold))
+        .foregroundStyle(.secondary)
+        .padding(.horizontal, 8)
+        .frame(height: 23)
+        .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 6))
+        .overlay { RoundedRectangle(cornerRadius: 6).stroke(EvidenceStyle.separator) }
+    }
+    .buttonStyle(.plain)
+    .disabled(model.repositoryQueryDetailLoading)
+  }
+
+  @ViewBuilder
+  private var repositoryQueryDetailResults: some View {
+    if model.repositoryQueryDetailLoading {
+      HStack(spacing: 10) {
+        ProgressView().controlSize(.small)
+        Text("Rust is resolving the bounded evidence detail…")
+          .font(.system(size: 10, weight: .medium))
+      }
+      .padding(16)
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .premiumField()
+    } else if let issue = model.repositoryQueryDetailIssue {
+      Label(issue, systemImage: "exclamationmark.triangle.fill")
+        .font(.system(size: 9))
+        .foregroundStyle(EvidenceStyle.warning)
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .premiumField()
+    } else if let receipt = model.repositoryQueryDetailReceipt {
+      if let explanation = receipt.graphExplanation {
+        repositoryGraphExplanation(explanation)
+      } else if let impact = receipt.graphImpact {
+        repositoryGraphImpact(impact, receipt: receipt)
+      } else if let path = receipt.graphPath {
+        repositoryGraphPath(path)
+      } else if let trace = receipt.historyTrace {
+        repositoryHistoryTrace(trace)
+      }
+    } else if let origin = model.repositoryGraphPathOrigin {
+      HStack(spacing: 10) {
+        Image(systemName: "smallcircle.filled.circle")
+          .foregroundStyle(EvidenceStyle.amberForeground)
+        VStack(alignment: .leading, spacing: 2) {
+          Text("PATH ORIGIN")
+            .font(.system(size: 8, weight: .bold, design: .monospaced))
+            .foregroundStyle(EvidenceStyle.amberForeground)
+          Text(origin.label).font(.system(size: 11, weight: .semibold))
+          Text("Choose Route here on a different structural match.")
+            .font(.system(size: 9)).foregroundStyle(.secondary)
+        }
+        Spacer()
+        Button("Clear") { model.repositoryGraphPathOrigin = nil }
+          .buttonStyle(.plain)
+          .font(.system(size: 9, weight: .semibold))
+      }
+      .padding(14)
+      .background(EvidenceStyle.amber.opacity(0.06), in: RoundedRectangle(cornerRadius: 10))
+      .overlay { RoundedRectangle(cornerRadius: 10).stroke(EvidenceStyle.amber.opacity(0.28)) }
+    }
+  }
+
+  private func repositoryGraphExplanation(_ explanation: RepositoryGraphExplanation) -> some View {
+    VStack(alignment: .leading, spacing: 12) {
+      HStack(alignment: .top, spacing: 12) {
+        VStack(alignment: .leading, spacing: 4) {
+          PremiumFieldLabel("NODE / CANONICAL IDENTITY")
+          Text(explanation.node.label).font(.system(size: 15, weight: .semibold))
+          Text(explanation.node.qualifiedName ?? explanation.node.id)
+            .font(.system(size: 9, design: .monospaced)).foregroundStyle(.secondary)
+        }
+        Spacer()
+        UnpackMetric(
+          value: "\(explanation.incomingCount)", label: "INCOMING",
+          detail: explanation.incomingKinds.joined(separator: ", "))
+        UnpackMetric(
+          value: "\(explanation.outgoingCount)", label: "OUTGOING",
+          detail: explanation.outgoingKinds.joined(separator: ", "))
+      }
+      HStack(spacing: 8) {
+        ForEach(RepositoryGraphDirection.allCases) { direction in
+          Button {
+            model.repositoryImpactDirection = direction
+          } label: {
+            Text(direction.rawValue.capitalized)
+              .font(.system(size: 8, weight: .semibold))
+              .foregroundStyle(
+                model.repositoryImpactDirection == direction ? Color.black : Color.secondary
+              )
+              .padding(.horizontal, 9)
+              .frame(height: 25)
+              .background(
+                model.repositoryImpactDirection == direction
+                  ? EvidenceStyle.amber : EvidenceStyle.surface,
+                in: RoundedRectangle(cornerRadius: 6))
+          }
+          .buttonStyle(.plain)
+        }
+        Stepper(
+          "Depth \(model.repositoryImpactDepth)", value: $model.repositoryImpactDepth, in: 1...12
+        )
+        .font(.system(size: 8, weight: .semibold))
+        .frame(width: 112)
+        Spacer()
+        repositoryQueryAction("Set path origin", icon: "smallcircle.filled.circle") {
+          model.setRepositoryGraphPathOrigin(explanation.node)
+        }
+        Button {
+          model.queryRepositoryImpact(explanation.node)
+        } label: {
+          Label("Trace impact", systemImage: "scope")
+        }
+        .buttonStyle(.borderedProminent)
+        .tint(EvidenceStyle.amber)
+        .foregroundStyle(Color.black)
+        .controlSize(.small)
+      }
+      if let source = explanation.node.sources.first {
+        Text("SOURCE  \(source.path):\(source.startLine ?? 1)")
+          .font(.system(size: 8, weight: .bold, design: .monospaced))
+          .foregroundStyle(.secondary)
+      }
+    }
+    .padding(16)
+    .background(EvidenceStyle.inspector, in: RoundedRectangle(cornerRadius: 12))
+    .overlay { RoundedRectangle(cornerRadius: 12).stroke(EvidenceStyle.separator) }
+  }
+
+  private func repositoryGraphImpact(
+    _ impact: RepositoryGraphImpactResult,
+    receipt: RepositoryQueryReceipt
+  ) -> some View {
+    VStack(alignment: .leading, spacing: 12) {
+      UnpackDeskHeader(
+        eyebrow:
+          "IMPACT / \((receipt.direction ?? .outgoing).rawValue.uppercased()) · DEPTH \(receipt.depth ?? 3)",
+        title: impact.root.label,
+        detail:
+          "\(impact.affected.count) affected nodes · \(impact.edges.count) retained relationships · \(impact.truncated ? "bounded result" : "within requested bound")"
+      )
+      UnpackListPanel(title: "AFFECTED NODES", count: impact.affected.count) {
+        ForEach(impact.affected) { node in
+          UnpackEvidenceRow(
+            icon: "arrow.triangle.branch", title: node.label,
+            detail: "\(node.kind) · \(node.trust) · \(node.path ?? node.id)")
+        }
+      }
+    }
+    .padding(16)
+    .background(EvidenceStyle.inspector, in: RoundedRectangle(cornerRadius: 12))
+    .overlay { RoundedRectangle(cornerRadius: 12).stroke(EvidenceStyle.separator) }
+  }
+
+  private func repositoryGraphPath(_ path: RepositoryGraphPathResult) -> some View {
+    VStack(alignment: .leading, spacing: 12) {
+      UnpackDeskHeader(
+        eyebrow: "DIRECTED PATH / \(path.edges.count) HOPS",
+        title: path.nodes.map(\.label).joined(separator: " → "),
+        detail:
+          "Canonical trust-weighted cost \(String(format: "%.3f", path.totalCost)) · \(path.visited) visited · \(path.truncated ? "search bound reached" : "path resolved")"
+      )
+      ForEach(Array(path.nodes.enumerated()), id: \.element.id) { index, node in
+        HStack(alignment: .top, spacing: 10) {
+          Text(String(format: "%02d", index + 1))
+            .font(.system(size: 8, weight: .bold, design: .monospaced))
+            .foregroundStyle(EvidenceStyle.amberForeground)
+          VStack(alignment: .leading, spacing: 2) {
+            Text(node.label).font(.system(size: 10, weight: .semibold))
+            Text(node.path ?? node.id).font(.system(size: 8, design: .monospaced))
+              .foregroundStyle(.secondary)
+            if index < path.edges.count {
+              Text(path.edges[index].kind.uppercased())
+                .font(.system(size: 7, weight: .bold, design: .monospaced))
+                .foregroundStyle(EvidenceStyle.amberForeground)
+            }
+          }
+        }
+      }
+    }
+    .padding(16)
+    .background(EvidenceStyle.inspector, in: RoundedRectangle(cornerRadius: 12))
+    .overlay { RoundedRectangle(cornerRadius: 12).stroke(EvidenceStyle.separator) }
+  }
+
+  private func repositoryHistoryTrace(_ trace: RepositoryHistoryTrace) -> some View {
+    VStack(alignment: .leading, spacing: 12) {
+      UnpackDeskHeader(
+        eyebrow: "CAUSAL THREAD / EVIDENCE QUALIFIED",
+        title: "\(trace.episodes.count) change episode\(trace.episodes.count == 1 ? "" : "s")",
+        detail:
+          "\(trace.scannedEvents) of \(trace.totalEvents) indexed events scanned · adjacency remains a lead unless the link carries evidence"
+      )
+      ForEach(trace.episodes) { episode in
+        VStack(alignment: .leading, spacing: 8) {
+          HStack {
+            PremiumFieldLabel(
+              episode.stagesPresent.map { $0.uppercased() }.joined(separator: " → "))
+            Spacer()
+            Text("\(episode.startedAt) — \(episode.endedAt)")
+              .font(.system(size: 7, design: .monospaced)).foregroundStyle(.secondary)
+          }
+          ForEach(episode.events) { event in
+            UnpackEvidenceRow(
+              icon: "waveform.path.ecg", title: event.summary,
+              detail:
+                "\(event.stage) · \(event.trust) · \(event.eventKind) · \(event.sourceID)")
+          }
+          ForEach(episode.gaps, id: \.self) { gap in
+            Label(gap, systemImage: "questionmark.diamond")
+              .font(.system(size: 8)).foregroundStyle(EvidenceStyle.warning)
+          }
+        }
+        .padding(12)
+        .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 9))
+        .overlay { RoundedRectangle(cornerRadius: 9).stroke(EvidenceStyle.separator) }
+      }
+    }
+    .padding(16)
+    .background(EvidenceStyle.inspector, in: RoundedRectangle(cornerRadius: 12))
+    .overlay { RoundedRectangle(cornerRadius: 12).stroke(EvidenceStyle.separator) }
+  }
+
+  private func repositoryQueryStatus(_ receipt: RepositoryQueryReceipt) -> some View {
+    HStack(spacing: 8) {
+      StatusPill(
+        label: receipt.status == "ready" ? "\(receipt.resultCount) matches" : "index unavailable",
+        color: receipt.status == "ready" ? EvidenceStyle.success : EvidenceStyle.warning
+      )
+      StatusPill(
+        label: receipt.domain == .graph
+          ? (receipt.graphStatus.stale ? "graph stale" : "graph current")
+          : (receipt.historyStatus.stale ? "history stale" : "history current"),
+        color: (receipt.domain == .graph ? receipt.graphStatus.stale : receipt.historyStatus.stale)
+          ? EvidenceStyle.warning : EvidenceStyle.success
+      )
+      Text(receipt.authority.replacingOccurrences(of: "_", with: " "))
+        .font(.system(size: 8, weight: .bold, design: .monospaced))
+        .foregroundStyle(.secondary)
+      Spacer()
+      Text(
+        receipt.domain == .graph
+          ? "\(receipt.graphStatus.nodeCount) nodes · \(receipt.graphStatus.edgeCount) edges"
+          : "\(receipt.historyStatus.eventCount) events · \(receipt.historyStatus.checkpointCount) checkpoints"
+      )
+      .font(.system(size: 8, design: .monospaced))
+      .foregroundStyle(.secondary)
+    }
+  }
+
+  private func graphHitDetail(_ hit: RepositoryGraphSearchHit) -> String {
+    let source = hit.node.sources.first?.path ?? hit.node.path ?? "no source anchor"
+    return
+      "\(hit.node.kind) · \(hit.node.trust) · score \(hit.score) · \(hit.matchedBy) · \(source)"
+  }
+
+  private func historyHitDetail(_ item: RepositoryHistorySearchItem) -> String {
+    let timestamp = item.recordedAt ?? "time unavailable"
+    let source = item.sourceIDs.first ?? "no source anchor"
+    return "\(item.kind) · \(item.trust) · \(timestamp) · \(item.summary) · \(source)"
+  }
+
+  private func historyIcon(_ kind: String) -> String {
+    switch kind {
+    case "release": "tag"
+    case "commit": "point.topleft.down.to.point.bottomright.curvepath"
+    case "entity": "cube.transparent"
+    case "event": "waveform.path.ecg"
+    default: "note.text"
+    }
+  }
+
+  private func analysisDesk(_ inventory: UnpackInventory) -> some View {
+    ScrollView {
+      LazyVStack(alignment: .leading, spacing: 12) {
+        UnpackDeskHeader(
+          eyebrow: "ANALYSIS / DETERMINISTIC LEADS",
+          title: "Health signals stay separate from proof",
+          detail: inventory.health.summary
+        )
+        HStack(spacing: 8) {
+          UnpackMetric(
+            value: String(format: "%.1f", inventory.health.averageScore),
+            label: "AVERAGE HEALTH", detail: "heuristic score")
+          UnpackMetric(
+            value: "\(inventory.health.hotspotCount)", label: "HOTSPOTS",
+            detail: "review leads")
+          UnpackMetric(
+            value: "\(inventory.health.filesWithTestSignal)", label: "TEST SIGNALS",
+            detail: "\(inventory.health.filesAnalyzed) analyzed")
+        }
+        UnpackListPanel(title: "HEALTH LEADS", count: inventory.health.topFiles.count) {
+          ForEach(inventory.health.topFiles.prefix(80)) { file in
+            UnpackEvidenceRow(
+              icon: "waveform.path.ecg",
+              title: file.path,
+              detail:
+                "\(file.bucket) · score \(String(format: "%.1f", file.score)) · churn \(file.churn) · \(file.hasTestSignal ? "test signal" : "no adjacent test")"
+            )
+          }
+        }
+        HStack(alignment: .top, spacing: 12) {
+          UnpackListPanel(title: "COVERAGE LIMITS", count: inventory.coverage.notes.count) {
+            ForEach(inventory.coverage.notes, id: \.self) { note in
+              UnpackEvidenceRow(icon: "scope", title: note, detail: inventory.coverage.strategy)
+            }
+          }
+          UnpackListPanel(title: "VERIFICATION LEADS", count: inventory.history.testHints.count) {
+            ForEach(inventory.history.testHints.prefix(40)) { hint in
+              UnpackEvidenceRow(icon: "checkmark.diamond", title: hint.path, detail: hint.reason)
+            }
+          }
+        }
+      }
+      .padding(18)
+    }
+  }
+
+  private func rulesDesk(_ inventory: UnpackInventory) -> some View {
+    ScrollView {
+      LazyVStack(alignment: .leading, spacing: 12) {
+        UnpackDeskHeader(
+          eyebrow: "RULES / OBSERVED CONFIGURATION",
+          title: "Files and scripts, not invented policy",
+          detail:
+            "This desk points to observed manifests, configuration, and documentation. Read the cited source before treating any convention as binding."
+        )
+        HStack(alignment: .top, spacing: 12) {
+          UnpackListPanel(title: "MANIFEST SCRIPTS", count: inventory.manifests.count) {
+            ForEach(inventory.manifests.prefix(40)) { manifest in
+              UnpackEvidenceRow(
+                icon: "terminal",
+                title: manifest.path,
+                detail:
+                  manifest.scripts.isEmpty
+                  ? "No declared scripts observed"
+                  : manifest.scripts.prefix(6).joined(separator: " · ")
+              )
+            }
+          }
+          UnpackListPanel(title: "CONFIGURATION", count: inventory.configFiles.count) {
+            ForEach(inventory.configFiles.prefix(80), id: \.self) { path in
+              UnpackEvidenceRow(
+                icon: "gearshape.2", title: path,
+                detail: "Observed file · inspect before editing")
+            }
+          }
+        }
+        UnpackListPanel(title: "DOCUMENTATION SOURCES", count: inventory.documents.count) {
+          ForEach(inventory.documents.prefix(50)) { document in
+            UnpackEvidenceRow(
+              icon: "doc.text",
+              title: document.path,
+              detail:
+                "\(ByteCountFormatter.string(fromByteCount: Int64(document.bytes), countStyle: .file)) · bounded preview available"
+            )
+          }
+        }
+      }
+      .padding(18)
+    }
+  }
+
+  private func handoffDesk(_ inventory: UnpackInventory, report: UnpackReport?) -> some View {
+    ScrollView {
+      LazyVStack(alignment: .leading, spacing: 12) {
+        UnpackDeskHeader(
+          eyebrow: "HANDOFF / SOURCE-QUALIFIED CONTEXT",
+          title: report?.agentHandoff?.title ?? "Deterministic starting map",
+          detail:
+            report?.agentHandoff?.summary
+            ?? "No model-labelled handoff is attached. The starting points below come directly from the stored inventory and history leads."
+        )
+        if let handoff = report?.agentHandoff {
+          UnpackBriefSectionCard(sectionID: "agent-handoff-desk", section: handoff)
+        }
+        HStack(alignment: .top, spacing: 12) {
+          UnpackListPanel(title: "START HERE", count: inventory.entrypoints.count) {
+            ForEach(inventory.entrypoints.prefix(40)) { entry in
+              UnpackEvidenceRow(icon: "arrow.right.square", title: entry.path, detail: entry.reason)
+            }
+          }
+          UnpackListPanel(title: "VERIFY NEXT", count: inventory.history.testHints.count) {
+            ForEach(inventory.history.testHints.prefix(40)) { hint in
+              UnpackEvidenceRow(icon: "checkmark.diamond", title: hint.path, detail: hint.reason)
+            }
+          }
+        }
+        if let prompt = report?.agentPrompt, !prompt.isEmpty {
+          VStack(alignment: .leading, spacing: 9) {
+            PremiumFieldLabel("RECORDED AGENT PROMPT")
+            Text(prompt)
+              .font(.system(size: 9, design: .monospaced))
+              .textSelection(.enabled)
+          }
+          .padding(16)
+          .background(EvidenceStyle.inspector, in: RoundedRectangle(cornerRadius: 12))
+          .overlay { RoundedRectangle(cornerRadius: 12).stroke(EvidenceStyle.separator) }
+        }
+      }
+      .padding(18)
+    }
+  }
+
+  @ViewBuilder
+  private func deltaDesk(_ snapshot: UnpackSnapshotRecord) -> some View {
+    if let comparison = model.unpackComparison {
+      ScrollView {
+        LazyVStack(alignment: .leading, spacing: 12) {
+          UnpackDeskHeader(
+            eyebrow: "DELTA / BOUNDED GIT EVIDENCE",
+            title: "\(comparison.commitCount) commits between retained snapshots",
+            detail:
+              "\(String(comparison.baseCommit.prefix(12))) → \(String(comparison.headCommit.prefix(12))). Commit subjects and numstat are leads, not proof that behavior changed correctly."
+          )
+          HStack(spacing: 8) {
+            UnpackMetric(
+              value: "\(comparison.commitCount)", label: "COMMITS",
+              detail: comparison.truncated ? "first 24 shown" : "complete recorded range")
+            UnpackMetric(
+              value: compactCount(comparison.commits.reduce(0) { $0 + Int($1.additions) }),
+              label: "ADDITIONS", detail: "git numstat")
+            UnpackMetric(
+              value: compactCount(comparison.commits.reduce(0) { $0 + Int($1.deletions) }),
+              label: "DELETIONS", detail: "git numstat")
+          }
+          UnpackListPanel(title: "COMMITS", count: comparison.commits.count) {
+            ForEach(comparison.commits) { commit in
+              UnpackEvidenceRow(
+                icon: "arrow.triangle.branch",
+                title: commit.subject,
+                detail:
+                  "\(String(commit.sha.prefix(10))) · \(commit.date) · +\(commit.additions) −\(commit.deletions) · \(commit.files.count) files"
+              )
+            }
+          }
+        }
+        .padding(18)
+      }
+    } else {
+      ContentUnavailableView {
+        Label("Compare retained snapshots", systemImage: "arrow.left.arrow.right")
+      } description: {
+        Text(
+          model.unpackComparisonCandidate == nil
+            ? "No older snapshot for this repository records a different concrete commit."
+            : "Build a bounded Git range from the selected snapshot and its previous retained commit."
+        )
+      } actions: {
+        Button("Compare with previous snapshot") { model.compareUnpackWithPrevious() }
+          .buttonStyle(.borderedProminent)
+          .tint(EvidenceStyle.amber)
+          .foregroundStyle(Color.black)
+          .disabled(!model.canCompareUnpackSnapshot)
+          .accessibilityIdentifier("repo-unpack-compare")
+      }
+    }
+  }
+
+  private func chooseExport(_ format: UnpackExportFormat) {
+    guard let snapshot = model.unpackSnapshot else { return }
+    let panel = NSSavePanel()
+    panel.allowedContentTypes = [UTType(filenameExtension: format.pathExtension) ?? .data]
+    panel.canCreateDirectories = true
+    panel.isExtensionHidden = false
+    panel.nameFieldStringValue =
+      "\(snapshot.repoName)-\(String(snapshot.id.prefix(8))).\(format.pathExtension)"
+    panel.message = "Save the Rust-rendered snapshot export without reinterpreting its evidence."
+    guard panel.runModal() == .OK, let destination = panel.url else { return }
+    model.exportUnpackSnapshot(format, to: destination)
+  }
+}
+
+private struct UnpackDeskHeader: View {
+  let eyebrow: String
+  let title: String
+  let detail: String
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 6) {
+      Text(eyebrow)
+        .font(.system(size: 8, weight: .bold, design: .monospaced))
+        .tracking(0.9)
+        .foregroundStyle(EvidenceStyle.amberForeground)
+      Text(title).font(.system(size: 20, weight: .semibold))
+      Text(detail).font(.system(size: 10)).foregroundStyle(.secondary)
+    }
+    .padding(18)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 14))
+    .overlay { RoundedRectangle(cornerRadius: 14).stroke(EvidenceStyle.separator) }
+  }
+}
+
+private struct UnpackListPanel<Content: View>: View {
+  let title: String
+  let count: Int
+  let content: Content
+
+  init(title: String, count: Int, @ViewBuilder content: () -> Content) {
+    self.title = title
+    self.count = count
+    self.content = content()
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      HStack {
+        PremiumFieldLabel(title)
+        Spacer()
+        Text("\(count)")
+          .font(.system(size: 8, weight: .semibold, design: .monospaced))
+          .foregroundStyle(.secondary)
+      }
+      .padding(14)
+      Divider()
+      if count == 0 {
+        Text("No recorded evidence in this bounded snapshot.")
+          .font(.system(size: 9))
+          .foregroundStyle(.secondary)
+          .padding(14)
+      } else {
+        LazyVStack(alignment: .leading, spacing: 0) { content }
+      }
+    }
+    .frame(maxWidth: .infinity, alignment: .topLeading)
+    .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 12))
+    .clipShape(RoundedRectangle(cornerRadius: 12))
+    .overlay { RoundedRectangle(cornerRadius: 12).stroke(EvidenceStyle.separator) }
+  }
+}
+
+private struct UnpackEvidenceRow: View {
+  let icon: String
+  let title: String
+  let detail: String
+
+  var body: some View {
+    HStack(alignment: .top, spacing: 10) {
+      Image(systemName: icon)
+        .font(.system(size: 10, weight: .semibold))
+        .foregroundStyle(EvidenceStyle.amberForeground)
+        .frame(width: 17)
+      VStack(alignment: .leading, spacing: 3) {
+        Text(title)
+          .font(.system(size: 9, weight: .medium))
+          .lineLimit(2)
+        Text(detail)
+          .font(.system(size: 8, design: .monospaced))
+          .foregroundStyle(.secondary)
+          .lineLimit(2)
+      }
+      Spacer(minLength: 0)
+    }
+    .padding(.horizontal, 14)
+    .padding(.vertical, 10)
+    .overlay(alignment: .bottom) { Rectangle().fill(EvidenceStyle.separator).frame(height: 1) }
+  }
+}
+
+private struct UnpackBriefSectionCard: View {
+  let sectionID: String
+  let section: UnpackReportSection
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      HStack {
+        PremiumFieldLabel(sectionID.replacingOccurrences(of: "-", with: " ").uppercased())
+        Spacer()
+        Text("\(section.claims.count) claims")
+          .font(.system(size: 8, design: .monospaced))
+          .foregroundStyle(.secondary)
+      }
+      Text(section.title).font(.system(size: 15, weight: .semibold))
+      Text(section.summary).font(.system(size: 10)).foregroundStyle(.secondary)
+      ForEach(section.claims.prefix(30)) { claim in
+        VStack(alignment: .leading, spacing: 4) {
+          Text(claim.claim).font(.system(size: 9, weight: .medium))
+          Text(claim.sources.prefix(4).joined(separator: " · "))
+            .font(.system(size: 8, design: .monospaced))
+            .foregroundStyle(EvidenceStyle.amberForeground)
+            .lineLimit(2)
+        }
+        .padding(11)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(EvidenceStyle.inspector, in: RoundedRectangle(cornerRadius: 9))
+        .overlay { RoundedRectangle(cornerRadius: 9).stroke(EvidenceStyle.separator) }
+      }
+    }
+    .padding(16)
+    .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 12))
+    .overlay { RoundedRectangle(cornerRadius: 12).stroke(EvidenceStyle.separator) }
+  }
+}
+
+private struct UnpackSnapshotRow: View {
+  let snapshot: UnpackSnapshotSummary
+  let selected: Bool
+
+  var body: some View {
+    HStack(spacing: 10) {
+      RoundedRectangle(cornerRadius: 2)
+        .fill(selected ? EvidenceStyle.amber : Color.primary.opacity(0.12))
+        .frame(width: 3, height: 38)
+      VStack(alignment: .leading, spacing: 3) {
+        HStack {
+          Text(snapshot.repoName).font(.system(size: 10, weight: .semibold))
+          Spacer()
+          Text(snapshot.status.replacingOccurrences(of: "_", with: " "))
+            .font(.system(size: 7, weight: .bold, design: .monospaced))
+            .foregroundStyle(
+              snapshot.errorMessage == nil ? EvidenceStyle.success : EvidenceStyle.warning)
+        }
+        Text(snapshot.repoPath)
+          .font(.system(size: 8, design: .monospaced))
+          .foregroundStyle(.secondary)
+          .lineLimit(1)
+        HStack {
+          Text("\(snapshot.filesScanned) files")
+          Spacer()
+          Text(snapshot.commitSHA.map { String($0.prefix(7)) } ?? "no commit")
+        }
+        .font(.system(size: 7, design: .monospaced))
+        .foregroundStyle(.secondary)
+      }
+    }
+    .padding(10)
+    .background(
+      selected ? EvidenceStyle.amber.opacity(0.08) : Color.clear,
+      in: RoundedRectangle(cornerRadius: 10)
+    )
+    .overlay {
+      RoundedRectangle(cornerRadius: 10).stroke(
+        selected ? EvidenceStyle.amber.opacity(0.24) : EvidenceStyle.separator)
+    }
+  }
+}
+
+private struct UnpackMetric: View {
+  let value: String
+  let label: String
+  let detail: String
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 6) {
+      Text(value).font(.system(size: 23, weight: .medium, design: .rounded))
+      PremiumFieldLabel(label)
+      Text(detail).font(.system(size: 8)).foregroundStyle(.secondary).lineLimit(1)
+    }
+    .padding(16)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 12))
+    .overlay { RoundedRectangle(cornerRadius: 12).stroke(EvidenceStyle.separator) }
+  }
+}
+
+private struct UnpackIdentity: View {
+  let label: String
+  let value: String
+
+  var body: some View {
+    VStack(alignment: .trailing, spacing: 3) {
+      PremiumFieldLabel(label)
+      Text(value).font(.system(size: 9, weight: .medium, design: .monospaced))
+    }
+  }
+}
+
+private func compactCount(_ value: Int) -> String {
+  value >= 1_000 ? String(format: "%.1fK", Double(value) / 1_000) : String(value)
+}
+
+private func byteCount(_ value: Int) -> String {
+  ByteCountFormatter.string(fromByteCount: Int64(value), countStyle: .file)
+}

--- a/apps/macos/CodeVetterPackage/Sources/CodeVetterFeature/PremiumUsageView.swift
+++ b/apps/macos/CodeVetterPackage/Sources/CodeVetterFeature/PremiumUsageView.swift
@@ -1,0 +1,730 @@
+import SwiftUI
+
+struct PremiumUsageView: View {
+  @Bindable var model: WorkbenchModel
+
+  var body: some View {
+    VStack(spacing: 0) {
+      header
+      Rectangle().fill(EvidenceStyle.separator).frame(height: 1)
+      sourceBoundary(model.usageReport)
+        .padding(.horizontal, 18)
+        .padding(.top, 14)
+      Group {
+        if let report = model.usageReport {
+          reportDesk(report)
+        } else if model.usageLoading {
+          loadingDesk
+        } else {
+          unavailableDesk
+        }
+      }
+      .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+    .background(EvidenceStyle.canvas)
+  }
+
+  private var header: some View {
+    HStack(alignment: .top, spacing: 18) {
+      VStack(alignment: .leading, spacing: 5) {
+        Text("LOCAL COMPUTE LEDGER")
+          .font(.system(size: 9, weight: .bold, design: .monospaced))
+          .tracking(1.1)
+          .foregroundStyle(EvidenceStyle.amberForeground)
+        Text("Usage").font(.system(size: 25, weight: .semibold))
+        Text("Token, cache, cost, model, and session evidence from local agent logs")
+          .font(.system(size: 10))
+          .foregroundStyle(.secondary)
+      }
+      Spacer()
+      if let report = model.usageReport {
+        StatusPill(label: report.status.label, color: report.status.color)
+      }
+      Button {
+        model.loadUsage(refresh: true)
+      } label: {
+        Label(model.usageLoading ? "Refreshing" : "Refresh", systemImage: "arrow.clockwise")
+      }
+      .buttonStyle(.bordered)
+      .disabled(model.usageLoading)
+      .accessibilityLabel("Usage refresh")
+    }
+    .padding(.horizontal, 22)
+    .padding(.vertical, 18)
+    .background(EvidenceStyle.chrome)
+  }
+
+  private func reportDesk(_ report: LocalUsageReport) -> some View {
+    ScrollView {
+      LazyVStack(alignment: .leading, spacing: 14) {
+        metrics(report)
+        if let devin = report.devin {
+          devinPanel(devin)
+        }
+        HStack(alignment: .top, spacing: 14) {
+          trendPanel(report)
+            .frame(maxWidth: .infinity)
+          adapterHealth(report)
+            .frame(width: 285)
+        }
+        HStack(alignment: .top, spacing: 14) {
+          modelPanel(report)
+          sessionsPanel(report)
+        }
+      }
+      .padding(.horizontal, 18)
+      .padding(.vertical, 14)
+    }
+  }
+
+  private func sourceBoundary(_ report: LocalUsageReport?) -> some View {
+    HStack(spacing: 8) {
+      UsageBoundaryCard(
+        eyebrow: "ACCOUNTED HERE",
+        title: "Claude · Codex · Grok",
+        detail: "ccusage \(report?.provenance.version ?? "20.0.20") · offline local logs",
+        icon: "checkmark.seal.fill",
+        color: EvidenceStyle.success
+      )
+      UsageBoundaryCard(
+        eyebrow: "SEPARATE SOURCE",
+        title: "Devin activity",
+        detail: devinBoundaryDetail(report?.devin),
+        icon: "arrow.triangle.branch",
+        color: EvidenceStyle.amber
+      )
+      UsageBoundaryCard(
+        eyebrow: "SEPARATE TELEMETRY",
+        title: "Provider quotas",
+        detail: "Live limits never inferred from spend",
+        icon: "gauge.open.with.lines.needle.33percent",
+        color: EvidenceStyle.amber
+      )
+    }
+    .accessibilityElement(children: .contain)
+    .accessibilityLabel("Usage provider boundaries")
+  }
+
+  private func devinBoundaryDetail(_ summary: DevinUsageSummary?) -> String {
+    guard let summary else { return "Local history unavailable · never folded into ccusage" }
+    guard summary.status == "ready" else {
+      return "No indexed sessions · never folded into ccusage"
+    }
+    let projection = summary.projection(for: model.usageWindow)
+    let cost = currency(projection.costUSD)
+    return "\(projection.sessions) sessions · \(cost) \(model.usageWindow.rawValue) · separate"
+  }
+
+  private func devinPanel(_ summary: DevinUsageSummary) -> some View {
+    let projection = summary.projection(for: model.usageWindow)
+    let title =
+      projection.sessions > 0
+      ? "Indexed Devin activity" : "No Devin activity \(model.usageWindow.description)"
+    return VStack(alignment: .leading, spacing: 12) {
+      HStack(alignment: .center, spacing: 18) {
+        VStack(alignment: .leading, spacing: 4) {
+          PremiumFieldLabel("DEVIN · SEPARATE LOCAL SOURCE")
+          Text(title)
+            .font(.system(size: 15, weight: .semibold))
+          Text(summary.source)
+            .font(.system(size: 9, design: .monospaced))
+            .foregroundStyle(.secondary)
+        }
+        .frame(width: 260, alignment: .leading)
+        Divider().frame(height: 48)
+        devinMetric(
+          value: compact(UInt64(max(projection.sessions, 0))),
+          label: "SESSIONS"
+        )
+        devinMetric(
+          value: compact(UInt64(max(projection.generatedTokens, 0))),
+          label: "GENERATED"
+        )
+        devinMetric(
+          value: compact(UInt64(max(projection.cacheReadTokens, 0))),
+          label: "CACHE READ"
+        )
+        devinMetric(
+          value: currency(projection.costUSD),
+          label: "LOCAL COST"
+        )
+        Spacer(minLength: 0)
+        StatusPill(
+          label: projection.sessions > 0 ? "\(model.usageWindow.rawValue) local history" : "empty",
+          color: projection.sessions > 0 ? EvidenceStyle.success : EvidenceStyle.warning
+        )
+      }
+
+      HStack(spacing: 6) {
+        if !projection.models.isEmpty {
+          ForEach(projection.models.prefix(6)) { model in
+            HStack(spacing: 6) {
+              Text(model.model)
+              Text(compact(UInt64(max(model.generatedTokens, 0))))
+                .foregroundStyle(.secondary)
+            }
+            .font(.system(size: 9, weight: .semibold, design: .monospaced))
+            .padding(.horizontal, 9)
+            .frame(height: 27)
+            .background(EvidenceStyle.inspector, in: Capsule())
+            .overlay { Capsule().stroke(EvidenceStyle.separator) }
+          }
+        }
+        Spacer(minLength: 10)
+        Text(summary.limitations.joined(separator: " · "))
+          .font(.system(size: 8, design: .monospaced))
+          .foregroundStyle(.secondary)
+          .lineLimit(2)
+          .multilineTextAlignment(.trailing)
+      }
+    }
+    .padding(18)
+    .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 14))
+    .overlay { RoundedRectangle(cornerRadius: 14).stroke(EvidenceStyle.separator) }
+    .accessibilityElement(children: .contain)
+    .accessibilityLabel("Separate Devin local usage")
+  }
+
+  private func devinMetric(value: String, label: String) -> some View {
+    VStack(alignment: .leading, spacing: 3) {
+      Text(value)
+        .font(.system(size: 16, weight: .semibold, design: .monospaced))
+      Text(label)
+        .font(.system(size: 8, weight: .bold, design: .monospaced))
+        .tracking(0.8)
+        .foregroundStyle(.secondary)
+    }
+    .frame(minWidth: 88, alignment: .leading)
+  }
+
+  private func metrics(_ report: LocalUsageReport) -> some View {
+    let totals = selectedTotals(report)
+    let sessions = filteredSessions(report)
+    let activeDays = report.periods(for: .day, window: model.usageWindow).count
+    return HStack(spacing: 8) {
+      UsageMetric(
+        value: compact(totals.generatedTokens),
+        label: "GENERATED TOKENS",
+        detail: model.usageWindow.description
+      )
+      UsageMetric(
+        value: compact(totals.cacheReadTokens),
+        label: "CACHE READ",
+        detail: cacheShare(totals)
+      )
+      UsageMetric(
+        value: currency(totals.costUSD),
+        label: "LOCAL LOG COST",
+        detail: report.provenance.pricingComplete ? "priced models complete" : "pricing has gaps"
+      )
+      UsageMetric(
+        value: compact(UInt64(sessions.count)),
+        label: "SESSIONS",
+        detail: "\(activeDays) active days"
+      )
+    }
+  }
+
+  private func trendPanel(_ report: LocalUsageReport) -> some View {
+    VStack(alignment: .leading, spacing: 14) {
+      HStack(alignment: .top) {
+        VStack(alignment: .leading, spacing: 4) {
+          PremiumFieldLabel("LOCAL ACTIVITY")
+          Text("Generated token trend")
+            .font(.system(size: 15, weight: .semibold))
+          Text("Selected agents only · cache reads remain a separate efficiency signal")
+            .font(.system(size: 9))
+            .foregroundStyle(.secondary)
+        }
+        Spacer()
+        VStack(alignment: .trailing, spacing: 6) {
+          UsageWindowSwitch(selection: $model.usageWindow, scale: $model.usageScale)
+          UsageScaleSwitch(selection: $model.usageScale)
+        }
+      }
+
+      HStack(spacing: 6) {
+        ForEach(report.provenance.detectedAgents, id: \.self) { agent in
+          let selected = model.usageSelectedAgents.contains(agent)
+          Button {
+            model.toggleUsageAgent(agent)
+          } label: {
+            HStack(spacing: 5) {
+              Circle().fill(agentColor(agent)).frame(width: 6, height: 6)
+              Text(agent.capitalized)
+            }
+            .font(.system(size: 9, weight: .semibold))
+            .foregroundStyle(selected ? Color.primary : Color.secondary)
+            .padding(.horizontal, 10)
+            .frame(height: 28)
+            .background(selected ? EvidenceStyle.amber.opacity(0.12) : Color.clear, in: Capsule())
+            .overlay {
+              Capsule().stroke(
+                selected ? EvidenceStyle.amber.opacity(0.34) : EvidenceStyle.separator)
+            }
+          }
+          .buttonStyle(.plain)
+          .accessibilityLabel("Filter \(agent.capitalized)")
+          .accessibilityValue(selected ? "Included" : "Excluded")
+        }
+      }
+
+      UsageTrendChart(
+        periods: boundedPeriods(report),
+        selectedAgents: model.usageSelectedAgents,
+        scale: model.usageScale
+      )
+      .frame(height: 190)
+    }
+    .padding(18)
+    .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 14))
+    .overlay { RoundedRectangle(cornerRadius: 14).stroke(EvidenceStyle.separator) }
+  }
+
+  private func adapterHealth(_ report: LocalUsageReport) -> some View {
+    VStack(alignment: .leading, spacing: 14) {
+      HStack {
+        PremiumFieldLabel("ADAPTER HEALTH")
+        Spacer()
+        Circle().fill(report.status.color).frame(width: 7, height: 7)
+      }
+      UsageFact(label: "ENGINE", value: "\(report.provenance.engine) \(report.provenance.version)")
+      UsageFact(label: "TIMEZONE", value: report.provenance.timezone)
+      UsageFact(label: "WINDOW", value: report.provenance.window)
+      UsageFact(
+        label: "PRICING",
+        value: report.provenance.pricingComplete ? "Complete" : "Review gaps",
+        color: report.provenance.pricingComplete ? EvidenceStyle.success : EvidenceStyle.warning
+      )
+      UsageFact(
+        label: "SOURCE",
+        value: report.provenance.sourceFingerprint.isEmpty
+          ? "Unavailable" : String(report.provenance.sourceFingerprint.prefix(22)) + "…"
+      )
+      if !report.provenance.fallbackModels.isEmpty {
+        Divider()
+        PremiumFieldLabel("FALLBACK PRICING")
+        Text(report.provenance.fallbackModels.joined(separator: " · "))
+          .font(.system(size: 9, design: .monospaced))
+          .foregroundStyle(EvidenceStyle.warning)
+          .lineLimit(3)
+      }
+      if let error = report.error {
+        Divider()
+        Label(error.message, systemImage: "exclamationmark.triangle.fill")
+          .font(.system(size: 9))
+          .foregroundStyle(EvidenceStyle.warning)
+      }
+      Spacer(minLength: 0)
+      Text("Read-only · offline · no quota inference")
+        .font(.system(size: 8, weight: .semibold, design: .monospaced))
+        .foregroundStyle(.secondary)
+    }
+    .padding(18)
+    .frame(minHeight: 286, alignment: .topLeading)
+    .background(EvidenceStyle.inspector, in: RoundedRectangle(cornerRadius: 14))
+    .overlay { RoundedRectangle(cornerRadius: 14).stroke(EvidenceStyle.separator) }
+  }
+
+  private func modelPanel(_ report: LocalUsageReport) -> some View {
+    VStack(alignment: .leading, spacing: 0) {
+      HStack {
+        VStack(alignment: .leading, spacing: 3) {
+          PremiumFieldLabel("MODEL MIX")
+          Text("Work by model").font(.system(size: 14, weight: .semibold))
+        }
+        Spacer()
+        Text("generated")
+          .font(.system(size: 8, design: .monospaced))
+          .foregroundStyle(.secondary)
+      }
+      .padding(16)
+      Divider()
+      let rows = aggregateModels(report)
+      if rows.isEmpty {
+        Text("No model activity in this local report.")
+          .font(.system(size: 10))
+          .foregroundStyle(.secondary)
+          .padding(18)
+      } else {
+        ForEach(rows.prefix(8)) { row in
+          HStack(spacing: 10) {
+            Circle().fill(row.priced ? EvidenceStyle.success : EvidenceStyle.warning)
+              .frame(width: 6, height: 6)
+            Text(row.model)
+              .font(.system(size: 10, weight: .medium, design: .monospaced))
+              .lineLimit(1)
+            if row.fallback {
+              Text("FALLBACK")
+                .font(.system(size: 7, weight: .bold, design: .monospaced))
+                .foregroundStyle(EvidenceStyle.warning)
+            }
+            Spacer()
+            Text(compact(row.totals.generatedTokens))
+              .font(.system(size: 10, weight: .semibold, design: .monospaced))
+          }
+          .padding(.horizontal, 16)
+          .frame(height: 34)
+          .overlay(alignment: .bottom) {
+            Rectangle().fill(EvidenceStyle.separator).frame(height: 1)
+          }
+        }
+      }
+    }
+    .frame(maxWidth: .infinity, alignment: .topLeading)
+    .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 14))
+    .clipShape(RoundedRectangle(cornerRadius: 14))
+    .overlay { RoundedRectangle(cornerRadius: 14).stroke(EvidenceStyle.separator) }
+  }
+
+  private func sessionsPanel(_ report: LocalUsageReport) -> some View {
+    VStack(alignment: .leading, spacing: 0) {
+      HStack {
+        VStack(alignment: .leading, spacing: 3) {
+          PremiumFieldLabel("RECENT SESSIONS")
+          Text("Local agent activity").font(.system(size: 14, weight: .semibold))
+        }
+        Spacer()
+        Text("showing \(min(filteredSessions(report).count, 8))")
+          .font(.system(size: 8, design: .monospaced))
+          .foregroundStyle(.secondary)
+      }
+      .padding(16)
+      Divider()
+      let sessions = Array(filteredSessions(report).prefix(8))
+      if sessions.isEmpty {
+        Text("No sessions match the selected agents.")
+          .font(.system(size: 10))
+          .foregroundStyle(.secondary)
+          .padding(18)
+      } else {
+        ForEach(sessions) { session in
+          HStack(spacing: 10) {
+            Circle().fill(agentColor(session.agent)).frame(width: 6, height: 6)
+            VStack(alignment: .leading, spacing: 2) {
+              Text(session.agent.capitalized)
+                .font(.system(size: 9, weight: .semibold))
+              Text(session.lastActivity ?? session.sessionID)
+                .font(.system(size: 8, design: .monospaced))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+            }
+            Spacer()
+            Text(compact(session.totals.generatedTokens))
+              .font(.system(size: 10, weight: .semibold, design: .monospaced))
+          }
+          .padding(.horizontal, 16)
+          .frame(height: 42)
+          .overlay(alignment: .bottom) {
+            Rectangle().fill(EvidenceStyle.separator).frame(height: 1)
+          }
+        }
+      }
+    }
+    .frame(maxWidth: .infinity, alignment: .topLeading)
+    .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 14))
+    .clipShape(RoundedRectangle(cornerRadius: 14))
+    .overlay { RoundedRectangle(cornerRadius: 14).stroke(EvidenceStyle.separator) }
+  }
+
+  private var loadingDesk: some View {
+    VStack(spacing: 14) {
+      ProgressView().controlSize(.small)
+      Text("Reading local usage evidence…")
+        .font(.system(size: 12, weight: .medium))
+      Text("The Rust adapter is normalizing pinned ccusage output offline.")
+        .font(.system(size: 10))
+        .foregroundStyle(.secondary)
+    }
+  }
+
+  private var unavailableDesk: some View {
+    ContentUnavailableView(
+      "Local usage unavailable",
+      systemImage: "chart.bar.xaxis",
+      description: Text(
+        model.usageIssue
+          ?? "Refresh to read Claude, Codex, and Grok activity from the pinned local adapter."
+      )
+    )
+  }
+
+  private func boundedPeriods(_ report: LocalUsageReport) -> [LocalUsagePeriod] {
+    let limit =
+      switch model.usageScale {
+      case .day: 180
+      case .week: 24
+      case .month: 18
+      }
+    return Array(
+      report.periods(for: model.usageScale, window: model.usageWindow).suffix(limit)
+    )
+  }
+
+  private func aggregateModels(_ report: LocalUsageReport) -> [LocalUsageModel] {
+    var models: [String: LocalUsageModel] = [:]
+    for period in report.periods(for: .day, window: model.usageWindow) {
+      for agent in period.agents where model.usageSelectedAgents.contains(agent.agent) {
+        for item in agent.models {
+          if let current = models[item.model] {
+            models[item.model] = LocalUsageModel(
+              model: item.model,
+              totals: current.totals.adding(item.totals),
+              fallback: current.fallback || item.fallback,
+              priced: current.priced && item.priced
+            )
+          } else {
+            models[item.model] = item
+          }
+        }
+      }
+    }
+    return models.values.sorted { $0.totals.generatedTokens > $1.totals.generatedTokens }
+  }
+
+  private func filteredSessions(_ report: LocalUsageReport) -> [LocalUsageSession] {
+    report.sessions(for: model.usageSelectedAgents, window: model.usageWindow)
+  }
+
+  private func selectedTotals(_ report: LocalUsageReport) -> LocalUsageTotals {
+    report.totals(for: model.usageSelectedAgents, window: model.usageWindow)
+  }
+}
+
+private struct UsageBoundaryCard: View {
+  let eyebrow: String
+  let title: String
+  let detail: String
+  let icon: String
+  let color: Color
+
+  var body: some View {
+    HStack(spacing: 11) {
+      Image(systemName: icon)
+        .font(.system(size: 12, weight: .semibold))
+        .foregroundStyle(color)
+        .frame(width: 28, height: 28)
+        .background(color.opacity(0.11), in: RoundedRectangle(cornerRadius: 8))
+      VStack(alignment: .leading, spacing: 2) {
+        Text(eyebrow)
+          .font(.system(size: 7, weight: .bold, design: .monospaced))
+          .tracking(0.7)
+          .foregroundStyle(color)
+        Text(title).font(.system(size: 10, weight: .semibold))
+        Text(detail).font(.system(size: 8)).foregroundStyle(.secondary).lineLimit(1)
+      }
+      Spacer(minLength: 0)
+    }
+    .padding(12)
+    .frame(maxWidth: .infinity)
+    .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 12))
+    .overlay { RoundedRectangle(cornerRadius: 12).stroke(EvidenceStyle.separator) }
+  }
+}
+
+private struct UsageMetric: View {
+  let value: String
+  let label: String
+  let detail: String
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 6) {
+      Text(value).font(.system(size: 24, weight: .medium, design: .rounded))
+      PremiumFieldLabel(label)
+      Text(detail).font(.system(size: 8)).foregroundStyle(.secondary).lineLimit(1)
+    }
+    .padding(16)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 12))
+    .overlay { RoundedRectangle(cornerRadius: 12).stroke(EvidenceStyle.separator) }
+  }
+}
+
+private struct UsageFact: View {
+  let label: String
+  let value: String
+  var color: Color = .primary
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 3) {
+      PremiumFieldLabel(label)
+      Text(value)
+        .font(.system(size: 9, weight: .medium, design: .monospaced))
+        .foregroundStyle(color)
+        .lineLimit(1)
+    }
+  }
+}
+
+private struct UsageScaleSwitch: View {
+  @Binding var selection: UsageScale
+
+  var body: some View {
+    HStack(spacing: 3) {
+      ForEach(UsageScale.allCases) { scale in
+        Button {
+          selection = scale
+        } label: {
+          Text(scale.rawValue)
+            .font(.system(size: 9, weight: .semibold))
+            .foregroundStyle(selection == scale ? EvidenceStyle.ink : Color.secondary)
+            .frame(width: 58, height: 26)
+            .background(
+              selection == scale ? EvidenceStyle.amber : Color.clear,
+              in: RoundedRectangle(cornerRadius: 7)
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityValue(selection == scale ? "Selected" : "")
+        .accessibilityAddTraits(selection == scale ? .isSelected : [])
+      }
+    }
+    .padding(3)
+    .background(Color.primary.opacity(0.055), in: RoundedRectangle(cornerRadius: 9))
+    .overlay { RoundedRectangle(cornerRadius: 9).stroke(EvidenceStyle.separator) }
+    .accessibilityElement(children: .contain)
+    .accessibilityLabel("Usage scale")
+  }
+}
+
+private struct UsageWindowSwitch: View {
+  @Binding var selection: UsageWindow
+  @Binding var scale: UsageScale
+
+  var body: some View {
+    HStack(spacing: 3) {
+      ForEach(UsageWindow.allCases) { window in
+        Button {
+          selection = window
+          if window == .oneWeek { scale = .day }
+        } label: {
+          Text(window.rawValue)
+            .font(.system(size: 9, weight: .semibold))
+            .foregroundStyle(selection == window ? EvidenceStyle.ink : Color.secondary)
+            .frame(minWidth: 34, minHeight: 24)
+            .padding(.horizontal, 3)
+            .background(
+              selection == window ? EvidenceStyle.amber : Color.clear,
+              in: RoundedRectangle(cornerRadius: 7)
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(window.description)
+        .accessibilityValue(selection == window ? "Selected" : "")
+        .accessibilityAddTraits(selection == window ? .isSelected : [])
+      }
+    }
+    .padding(3)
+    .background(Color.primary.opacity(0.055), in: RoundedRectangle(cornerRadius: 9))
+    .overlay { RoundedRectangle(cornerRadius: 9).stroke(EvidenceStyle.separator) }
+    .accessibilityElement(children: .contain)
+    .accessibilityLabel("Usage time range")
+  }
+}
+
+private struct UsageTrendChart: View {
+  let periods: [LocalUsagePeriod]
+  let selectedAgents: Set<String>
+  let scale: UsageScale
+
+  var body: some View {
+    if periods.isEmpty {
+      ContentUnavailableView("No local activity", systemImage: "chart.bar")
+    } else {
+      GeometryReader { geometry in
+        let values = periods.map { $0.totals(for: selectedAgents).generatedTokens }
+        let maximum = max(values.max() ?? 0, 1)
+        ZStack(alignment: .bottom) {
+          HStack(alignment: .bottom, spacing: scale == .day ? 3 : 7) {
+            ForEach(Array(zip(periods.indices, periods)), id: \.1.id) { index, period in
+              let value = period.totals(for: selectedAgents).generatedTokens
+              RoundedRectangle(cornerRadius: 3)
+                .fill(
+                  index == periods.indices.last
+                    ? EvidenceStyle.amber : EvidenceStyle.amber.opacity(0.34)
+                )
+                .frame(
+                  height: max(
+                    3,
+                    (geometry.size.height - 22) * CGFloat(Double(value) / Double(maximum))
+                  )
+                )
+                .help("\(period.period): \(compact(value)) generated tokens")
+                .frame(maxWidth: .infinity)
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel(period.period)
+                .accessibilityValue("\(value) generated tokens")
+            }
+          }
+          .padding(.bottom, 18)
+          .overlay(alignment: .bottom) {
+            Rectangle().fill(EvidenceStyle.separator).frame(height: 1).offset(y: -17)
+          }
+          HStack {
+            Text(shortLabel(periods.first?.period ?? ""))
+            Spacer()
+            Text(shortLabel(periods.last?.period ?? ""))
+          }
+          .font(.system(size: 7, design: .monospaced))
+          .foregroundStyle(.secondary)
+        }
+      }
+    }
+  }
+
+  private func shortLabel(_ value: String) -> String {
+    if value.count > 7 { return String(value.suffix(5)) }
+    return value
+  }
+}
+
+extension LocalUsageStatus {
+  fileprivate var label: String {
+    switch self {
+    case .ready: "Local data ready"
+    case .stale: "Showing stale data"
+    case .unavailable: "Adapter unavailable"
+    }
+  }
+
+  fileprivate var color: Color {
+    switch self {
+    case .ready: EvidenceStyle.success
+    case .stale: EvidenceStyle.warning
+    case .unavailable: EvidenceStyle.failure
+    }
+  }
+}
+
+private func compact(_ value: UInt64) -> String {
+  switch value {
+  case 1_000_000_000...: String(format: "%.1fB", Double(value) / 1_000_000_000)
+  case 1_000_000...: String(format: "%.1fM", Double(value) / 1_000_000)
+  case 1_000...: String(format: "%.1fK", Double(value) / 1_000)
+  default: String(value)
+  }
+}
+
+private func currency(_ value: Double) -> String {
+  if value >= 1_000 {
+    return String(format: "$%.1fK", value / 1_000)
+  }
+  return String(format: "$%.2f", value)
+}
+
+private func cacheShare(_ totals: LocalUsageTotals) -> String {
+  guard totals.totalTokens > 0 else { return "no token activity" }
+  return String(
+    format: "%.0f%% of all tokens",
+    Double(totals.cacheReadTokens) / Double(totals.totalTokens) * 100
+  )
+}
+
+private func agentColor(_ agent: String) -> Color {
+  switch agent {
+  case "claude": Color(red: 0.91, green: 0.47, blue: 0.28)
+  case "codex": EvidenceStyle.success
+  case "grok": Color(red: 0.43, green: 0.63, blue: 0.96)
+  default: EvidenceStyle.amber
+  }
+}

--- a/apps/macos/CodeVetterPackage/Sources/CodeVetterFeature/PremiumWarmVerificationView.swift
+++ b/apps/macos/CodeVetterPackage/Sources/CodeVetterFeature/PremiumWarmVerificationView.swift
@@ -1,0 +1,550 @@
+import SwiftUI
+
+private enum WarmReceiptMode: String, CaseIterable, Identifiable {
+  case evidence = "Evidence"
+  case json = "JSON"
+
+  var id: String { rawValue }
+}
+
+struct PremiumWarmVerificationView: View {
+  @Bindable var model: WorkbenchModel
+  @Environment(\.dismiss) private var dismiss
+  @State private var mode: WarmReceiptMode = .evidence
+
+  var body: some View {
+    VStack(spacing: 0) {
+      header
+      Rectangle().fill(EvidenceStyle.separator).frame(height: 1)
+      if let receipt = model.warmReceipt {
+        receiptDesk(receipt)
+      } else {
+        setupDesk
+      }
+    }
+    .background(EvidenceStyle.canvas)
+    .onAppear {
+      if model.warmHealth == nil, model.warmState == .ready, !model.repositoryPath.isEmpty {
+        model.inspectWarmVerifier()
+      }
+    }
+    .accessibilityElement(children: .contain)
+    .accessibilityIdentifier("warm-verification-workspace")
+  }
+
+  private var header: some View {
+    HStack(spacing: 16) {
+      VStack(alignment: .leading, spacing: 4) {
+        Text("WARM / CHANGED PROOF")
+          .font(.system(size: 9, weight: .bold, design: .monospaced))
+          .tracking(1.15)
+          .foregroundStyle(EvidenceStyle.amberForeground)
+        Text("Keep the browser hot. Re-prove only what changed.")
+          .font(.system(size: 20, weight: .semibold))
+          .tracking(-0.3)
+        Text("One repository-owned daemon · deterministic scenario selection · zero model calls")
+          .font(.system(size: 9, design: .monospaced))
+          .foregroundStyle(.secondary)
+      }
+      Spacer()
+      StatusPill(label: model.warmState.rawValue, color: stateColor)
+      Button("Done") { dismiss() }.buttonStyle(.bordered)
+    }
+    .padding(.horizontal, 24)
+    .frame(height: 88)
+    .background(EvidenceStyle.chrome)
+  }
+
+  private var setupDesk: some View {
+    HStack(spacing: 0) {
+      ScrollView {
+        VStack(alignment: .leading, spacing: 22) {
+          VStack(alignment: .leading, spacing: 8) {
+            PremiumFieldLabel("EXACT REPOSITORY")
+            Label(repositoryLabel, systemImage: "folder.fill")
+              .font(.system(size: 12, weight: .semibold, design: .monospaced))
+              .foregroundStyle(model.repositoryPath.isEmpty ? .secondary : .primary)
+              .padding(15)
+              .frame(maxWidth: .infinity, alignment: .leading)
+              .premiumField()
+            Text(
+              "The Rust bridge discovers exactly one repository-owned verify script and rejects ambiguous package-manager lockfiles."
+            )
+            .font(.system(size: 10))
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+          }
+
+          VStack(alignment: .leading, spacing: 10) {
+            PremiumFieldLabel("CHANGE CONTRACT")
+            contractRow("Scope", "Current Git worktree", icon: "arrow.triangle.branch")
+            contractRow("Selection", "Changed paths + mandatory smoke", icon: "scope")
+            contractRow("Authority", "Repository verify manifest", icon: "checkmark.seal")
+            contractRow("Network", "Owned local runtime only", icon: "lock.shield")
+          }
+
+          Toggle(isOn: $model.warmDetailedCapture) {
+            VStack(alignment: .leading, spacing: 4) {
+              Text("Retain bounded detailed artifacts")
+                .font(.system(size: 12, weight: .semibold))
+              Text(
+                "Keep redacted screenshots, traces, network, console, and report artifacts under the verifier retention policy."
+              )
+              .font(.system(size: 10))
+              .foregroundStyle(.secondary)
+              .fixedSize(horizontal: false, vertical: true)
+            }
+          }
+          .toggleStyle(.checkbox)
+          .tint(EvidenceStyle.amber)
+          .padding(15)
+          .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 12))
+          .overlay { RoundedRectangle(cornerRadius: 12).stroke(EvidenceStyle.separator) }
+
+          if let issue = model.warmIssue {
+            Label(issue, systemImage: "xmark.octagon.fill")
+              .font(.system(size: 10, weight: .medium))
+              .foregroundStyle(EvidenceStyle.failure)
+              .padding(14)
+              .frame(maxWidth: .infinity, alignment: .leading)
+              .background(
+                EvidenceStyle.failure.opacity(0.08), in: RoundedRectangle(cornerRadius: 12))
+          }
+        }
+        .padding(28)
+        .frame(maxWidth: 620, alignment: .leading)
+      }
+
+      Rectangle().fill(EvidenceStyle.separator).frame(width: 1)
+
+      daemonInspector
+        .frame(width: 330)
+    }
+    .safeAreaInset(edge: .bottom, spacing: 0) {
+      actionBar
+    }
+  }
+
+  private var daemonInspector: some View {
+    ScrollView {
+      VStack(alignment: .leading, spacing: 18) {
+        HStack {
+          PremiumFieldLabel("OWNED RUNTIME")
+          Spacer()
+          Button {
+            model.inspectWarmVerifier()
+          } label: {
+            Image(systemName: "arrow.clockwise")
+          }
+          .buttonStyle(.borderless)
+          .disabled(model.warmState == .running || model.repositoryPath.isEmpty)
+          .accessibilityLabel("Refresh warm verifier health")
+        }
+
+        if let health = model.warmHealth {
+          Label(
+            health.warm ? "Warm and ready" : "Runtime reported cold",
+            systemImage: health.warm ? "flame.fill" : "snowflake"
+          )
+          .font(.system(size: 13, weight: .semibold))
+          .foregroundStyle(health.warm ? EvidenceStyle.amberForeground : .secondary)
+          telemetry("DAEMON", "PID \(health.daemonPID)")
+          telemetry("SERVER", runtimeLabel(health.server))
+          telemetry("BROWSER", runtimeLabel(health.browser))
+          telemetry("ACTIVE RUNS", "\(health.activeRunIDs.count)")
+          Divider()
+          PremiumFieldLabel("RESOURCE SNAPSHOT")
+          telemetry("RSS", byteLabel(health.resources.rssBytes))
+          telemetry("HEAP", byteLabel(health.resources.heapUsedBytes))
+          telemetry("CONTEXTS", "\(health.resources.activeContexts)")
+          telemetry("ARTIFACTS", byteLabel(health.resources.retainedArtifactBytes))
+          Divider()
+          PremiumFieldLabel("TARGET SHA")
+          Text(String(health.targetSHA.prefix(16)))
+            .font(.system(size: 10, design: .monospaced))
+            .textSelection(.enabled)
+        } else {
+          Label("Verifier is cold", systemImage: "moon.stars")
+            .font(.system(size: 13, weight: .semibold))
+          Text(
+            "No owned daemon is reachable. A changed-proof run may start one, warm its declared server and browser, then return a versioned receipt."
+          )
+          .font(.system(size: 10))
+          .foregroundStyle(.secondary)
+          .fixedSize(horizontal: false, vertical: true)
+        }
+
+        Divider()
+        Label("codevetter warm", systemImage: "terminal.fill")
+          .font(.system(size: 10, weight: .semibold, design: .monospaced))
+          .foregroundStyle(EvidenceStyle.success)
+        Text(
+          "Swift never recreates daemon, scenario, observation, retention, or outcome semantics. Agents use this same CLI contract."
+        )
+        .font(.system(size: 9))
+        .foregroundStyle(.secondary)
+        .fixedSize(horizontal: false, vertical: true)
+      }
+      .padding(24)
+    }
+    .background(EvidenceStyle.inspector)
+  }
+
+  private var actionBar: some View {
+    HStack(spacing: 12) {
+      if model.warmState == .running {
+        ProgressView().controlSize(.small).tint(EvidenceStyle.amber)
+      }
+      Text(model.warmStatusMessage)
+        .font(.system(size: 10, weight: .medium))
+        .foregroundStyle(.secondary)
+        .lineLimit(2)
+      Spacer()
+      if model.warmState == .running {
+        Button("Cancel", role: .destructive) { model.cancelWarmVerification() }
+          .buttonStyle(.bordered)
+      } else {
+        Button("Run changed proof") { model.runWarmVerification() }
+          .buttonStyle(PremiumPrimaryButtonStyle())
+          .disabled(!model.canRunWarmVerification)
+          .keyboardShortcut(.return, modifiers: [.command])
+      }
+    }
+    .padding(.horizontal, 22)
+    .frame(minHeight: 68)
+    .background(EvidenceStyle.chrome)
+    .overlay(alignment: .top) { Rectangle().fill(EvidenceStyle.separator).frame(height: 1) }
+  }
+
+  private func receiptDesk(_ receipt: WarmVerificationRunReceipt) -> some View {
+    let result = receipt.result
+    return VStack(spacing: 0) {
+      HStack(spacing: 12) {
+        VStack(alignment: .leading, spacing: 4) {
+          Text(result.outcome == .passed ? "CHANGED SCOPE QUALIFIED" : "CHANGED SCOPE EVIDENCE")
+            .font(.system(size: 9, weight: .bold, design: .monospaced))
+            .tracking(1)
+            .foregroundStyle(outcomeColor(result.outcome))
+          Text(model.warmStatusMessage)
+            .font(.system(size: 16, weight: .semibold))
+            .lineLimit(1)
+          Text(
+            "\(result.selection.changedPaths.count) paths · \(result.scenarios.count) scenarios · \(result.observations.count) observations"
+          )
+          .font(.system(size: 9, design: .monospaced))
+          .foregroundStyle(.secondary)
+        }
+        Spacer()
+        StatusPill(label: outcomeLabel(result.outcome), color: outcomeColor(result.outcome))
+        Button("Open in Runs") {
+          model.showingWarmVerifier = false
+          model.section = .runs
+          model.loadRuns()
+        }
+        .buttonStyle(.bordered)
+        Button("New proof") { model.resetWarmVerification() }.buttonStyle(.bordered)
+      }
+      .padding(.horizontal, 22)
+      .frame(height: 76)
+      .background(EvidenceStyle.chrome)
+      .overlay(alignment: .bottom) { Rectangle().fill(EvidenceStyle.separator).frame(height: 1) }
+
+      HStack(spacing: 0) {
+        scenarioIndex(result).frame(width: 250)
+        Rectangle().fill(EvidenceStyle.separator).frame(width: 1)
+        VStack(spacing: 0) {
+          HStack {
+            PremiumFieldLabel("RUNTIME EVIDENCE")
+            Spacer()
+            Picker("Receipt mode", selection: $mode) {
+              ForEach(WarmReceiptMode.allCases) { value in
+                Text(value.rawValue).tag(value)
+              }
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            .frame(width: 166)
+            .tint(EvidenceStyle.amber)
+          }
+          .padding(.horizontal, 16)
+          .frame(height: 46)
+          .background(EvidenceStyle.surface)
+          .overlay(alignment: .bottom) {
+            Rectangle().fill(EvidenceStyle.separator).frame(height: 1)
+          }
+
+          if mode == .json {
+            ScrollView([.horizontal, .vertical]) {
+              Text(model.warmReceiptJSON)
+                .font(.system(size: 9, design: .monospaced))
+                .foregroundStyle(.secondary)
+                .textSelection(.enabled)
+                .padding(18)
+                .frame(maxWidth: .infinity, alignment: .topLeading)
+            }
+          } else {
+            evidenceColumn(result)
+          }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        Rectangle().fill(EvidenceStyle.separator).frame(width: 1)
+        receiptInspector(result).frame(width: 290)
+      }
+    }
+  }
+
+  private func scenarioIndex(_ result: WarmVerificationResult) -> some View {
+    VStack(alignment: .leading, spacing: 0) {
+      PremiumFieldLabel("SELECTED SCENARIOS").padding(16)
+      Rectangle().fill(EvidenceStyle.separator).frame(height: 1)
+      ScrollView {
+        LazyVStack(alignment: .leading, spacing: 2) {
+          if result.scenarios.isEmpty {
+            Text("No scenarios selected")
+              .font(.system(size: 10))
+              .foregroundStyle(.secondary)
+              .padding(16)
+          }
+          ForEach(result.scenarios) { scenario in
+            HStack(spacing: 9) {
+              Circle().fill(outcomeColor(scenario.outcome)).frame(width: 7, height: 7)
+              VStack(alignment: .leading, spacing: 3) {
+                Text(scenario.scenarioID)
+                  .font(.system(size: 9, weight: .semibold, design: .monospaced))
+                  .lineLimit(2)
+                Text("\(Int(scenario.durationMS)) ms")
+                  .font(.system(size: 8, design: .monospaced))
+                  .foregroundStyle(.secondary)
+              }
+              Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 9)
+          }
+        }
+      }
+      Divider()
+      VStack(alignment: .leading, spacing: 6) {
+        PremiumFieldLabel("SELECTION")
+        Text(result.selection.explanation)
+          .font(.system(size: 9))
+          .foregroundStyle(.secondary)
+          .fixedSize(horizontal: false, vertical: true)
+        Label(
+          result.selection.complete ? "Selection complete" : "Selection incomplete",
+          systemImage: result.selection.complete
+            ? "checkmark.circle.fill" : "exclamationmark.triangle.fill"
+        )
+        .font(.system(size: 9, weight: .semibold))
+        .foregroundStyle(result.selection.complete ? EvidenceStyle.success : EvidenceStyle.warning)
+      }
+      .padding(16)
+    }
+    .background(EvidenceStyle.chrome)
+  }
+
+  private func evidenceColumn(_ result: WarmVerificationResult) -> some View {
+    ScrollView {
+      LazyVStack(alignment: .leading, spacing: 14) {
+        HStack(spacing: 10) {
+          metricCard("SCENARIOS", "\(result.scenarios.count)")
+          metricCard("OBSERVATIONS", "\(result.observations.count)")
+          metricCard("ARTIFACTS", "\(result.artifacts.count)")
+          metricCard("MODEL CALLS", "\(result.modelCallCount)")
+        }
+
+        if result.observations.isEmpty {
+          Label("No policy observations were recorded", systemImage: "checkmark.circle")
+            .font(.system(size: 11, weight: .medium))
+            .foregroundStyle(EvidenceStyle.success)
+            .padding(15)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(EvidenceStyle.success.opacity(0.07), in: RoundedRectangle(cornerRadius: 12))
+        } else {
+          PremiumFieldLabel("POLICY OBSERVATIONS")
+          ForEach(result.observations) { observation in
+            VStack(alignment: .leading, spacing: 8) {
+              HStack {
+                Label(
+                  observation.kind.replacingOccurrences(of: "_", with: " "),
+                  systemImage: observationIcon(observation.disposition)
+                )
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(observationColor(observation.disposition))
+                Spacer()
+                Text(observation.scenarioID)
+                  .font(.system(size: 8, design: .monospaced))
+                  .foregroundStyle(.secondary)
+              }
+              Text(observation.message)
+                .font(.system(size: 10))
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+              Text(observation.policyID)
+                .font(.system(size: 8, design: .monospaced))
+                .foregroundStyle(.tertiary)
+            }
+            .padding(14)
+            .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 12))
+            .overlay { RoundedRectangle(cornerRadius: 12).stroke(EvidenceStyle.separator) }
+          }
+        }
+
+        if !result.artifacts.isEmpty {
+          PremiumFieldLabel("REDACTED ARTIFACTS")
+          ForEach(result.artifacts) { artifact in
+            HStack(spacing: 10) {
+              Image(systemName: "doc.badge.lock").foregroundStyle(EvidenceStyle.amberForeground)
+              VStack(alignment: .leading, spacing: 3) {
+                Text(artifact.relativePath)
+                  .font(.system(size: 9, weight: .medium, design: .monospaced))
+                  .lineLimit(2)
+                Text(
+                  "\(artifact.kind) · \(byteLabel(artifact.bytes)) · retained until \(artifact.retainedUntil)"
+                )
+                .font(.system(size: 8))
+                .foregroundStyle(.secondary)
+              }
+              Spacer(minLength: 0)
+            }
+            .padding(12)
+            .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 10))
+          }
+        }
+      }
+      .padding(16)
+    }
+  }
+
+  private func receiptInspector(_ result: WarmVerificationResult) -> some View {
+    ScrollView {
+      VStack(alignment: .leading, spacing: 17) {
+        PremiumFieldLabel("PROOF IDENTITY")
+        telemetry("RUN", result.runID)
+        telemetry("TARGET", String(result.source.targetSHA.prefix(14)))
+        telemetry("CHANGE", result.source.changeSetKind)
+        telemetry("POLICY", result.observationPolicy.profileID)
+        telemetry("WARM", result.warm ? "yes" : "no")
+        telemetry("STALE", result.stale ? "yes" : "no")
+        Divider()
+        PremiumFieldLabel("TIMINGS")
+        ForEach(result.timings.filter { $0.scenarioID == nil }.prefix(12)) { timing in
+          telemetry(timing.stage.uppercased(), "\(Int(timing.durationMS)) ms")
+        }
+        Divider()
+        PremiumFieldLabel("LIMITATIONS")
+        if result.limitations.isEmpty {
+          Label("No limitations recorded", systemImage: "checkmark.circle.fill")
+            .font(.system(size: 9, weight: .semibold))
+            .foregroundStyle(EvidenceStyle.success)
+        } else {
+          ForEach(result.limitations) { limitation in
+            VStack(alignment: .leading, spacing: 4) {
+              Label(limitation.code, systemImage: "exclamationmark.triangle")
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundStyle(limitation.affectsConfidence ? EvidenceStyle.warning : .secondary)
+              Text(limitation.message)
+                .font(.system(size: 9))
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            }
+          }
+        }
+        Divider()
+        Label("Rust validated + persisted", systemImage: "checkmark.seal.fill")
+          .font(.system(size: 10, weight: .semibold))
+          .foregroundStyle(EvidenceStyle.success)
+      }
+      .padding(20)
+    }
+    .background(EvidenceStyle.inspector)
+  }
+
+  private func contractRow(_ label: String, _ value: String, icon: String) -> some View {
+    HStack(spacing: 11) {
+      Image(systemName: icon).foregroundStyle(EvidenceStyle.amberForeground).frame(width: 16)
+      Text(label).font(.system(size: 10, weight: .semibold))
+      Spacer()
+      Text(value).font(.system(size: 9, design: .monospaced)).foregroundStyle(.secondary)
+    }
+    .padding(12)
+    .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 10))
+    .overlay { RoundedRectangle(cornerRadius: 10).stroke(EvidenceStyle.separator) }
+  }
+
+  private func metricCard(_ label: String, _ value: String) -> some View {
+    VStack(alignment: .leading, spacing: 5) {
+      PremiumFieldLabel(label)
+      Text(value).font(.system(size: 17, weight: .semibold, design: .monospaced))
+    }
+    .padding(12)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 10))
+    .overlay { RoundedRectangle(cornerRadius: 10).stroke(EvidenceStyle.separator) }
+  }
+
+  private func telemetry(_ label: String, _ value: String) -> some View {
+    VStack(alignment: .leading, spacing: 4) {
+      PremiumFieldLabel(label)
+      Text(value)
+        .font(.system(size: 9, weight: .medium, design: .monospaced))
+        .foregroundStyle(.secondary)
+        .textSelection(.enabled)
+        .lineLimit(2)
+    }
+  }
+
+  private var repositoryLabel: String {
+    model.repositoryPath.isEmpty
+      ? "No repository selected"
+      : URL(fileURLWithPath: model.repositoryPath).lastPathComponent
+  }
+
+  private var stateColor: Color {
+    switch model.warmState {
+    case .running: EvidenceStyle.amber
+    case .completed, .planned: EvidenceStyle.success
+    case .limited: EvidenceStyle.warning
+    case .failed: EvidenceStyle.failure
+    case .ready, .planning, .cancelled: .secondary
+    }
+  }
+
+  private func outcomeLabel(_ outcome: WarmVerificationOutcome) -> String {
+    outcome.rawValue.replacingOccurrences(of: "_", with: " ")
+  }
+
+  private func outcomeColor(_ outcome: WarmVerificationOutcome) -> Color {
+    switch outcome {
+    case .passed: EvidenceStyle.success
+    case .regression: EvidenceStyle.failure
+    case .noConfidence: EvidenceStyle.warning
+    }
+  }
+
+  private func observationColor(_ disposition: String) -> Color {
+    switch disposition {
+    case "passed": EvidenceStyle.success
+    case "regression": EvidenceStyle.failure
+    case "no_confidence": EvidenceStyle.warning
+    default: .secondary
+    }
+  }
+
+  private func observationIcon(_ disposition: String) -> String {
+    switch disposition {
+    case "passed": "checkmark.circle.fill"
+    case "regression": "xmark.octagon.fill"
+    case "no_confidence": "exclamationmark.triangle.fill"
+    default: "info.circle.fill"
+    }
+  }
+
+  private func runtimeLabel(_ runtime: WarmRuntimeHealth) -> String {
+    "\(runtime.state) · \(runtime.owned ? "owned" : "unowned")"
+  }
+
+  private func byteLabel(_ bytes: UInt64) -> String {
+    ByteCountFormatter.string(fromByteCount: Int64(clamping: bytes), countStyle: .memory)
+  }
+}


### PR DESCRIPTION
Part 3/40 of the dependency-ordered native macOS evidence-workbench stack.

Base: `stack/02-native-settings`
Head: `stack/03-native-workflows`

This layer stays within the repository's 40-file, 4,000-addition, and 6,000-gross-line limits. Merge only in stack order.
The top tree is byte-identical to the snapshot qualified in draft PR #203; protected signing, notarization, release, and Tauri cutover remain owner-approval gates.
Tracks #193, #194, #199, #200, #201, and #202 without auto-closing them before the full stack lands.