### PR TITLE
[stack 04/40] Native scenario and test support

### DIFF
--- a/apps/macos/CodeVetterPackage/Sources/CodeVetterFeature/ContentView.swift
+++ b/apps/macos/CodeVetterPackage/Sources/CodeVetterFeature/ContentView.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+public struct ContentView: View {
+  @State private var model = WorkbenchModel()
+
+  public var body: some View {
+    EvidenceWorkbenchView(model: model)
+  }
+
+  public init() {}
+}

--- a/apps/macos/CodeVetterPackage/Sources/CodeVetterFeature/PremiumScenarioCompilerView.swift
+++ b/apps/macos/CodeVetterPackage/Sources/CodeVetterFeature/PremiumScenarioCompilerView.swift
@@ -1,0 +1,302 @@
+import SwiftUI
+
+struct PremiumScenarioCompilerView: View {
+  @Bindable var model: WorkbenchModel
+  @Environment(\.dismiss) private var dismiss
+
+  var body: some View {
+    VStack(spacing: 0) {
+      header
+      Rectangle().fill(EvidenceStyle.separator).frame(height: 1)
+      HStack(spacing: 0) {
+        authoringPanel.frame(width: 310)
+        Rectangle().fill(EvidenceStyle.separator).frame(width: 1)
+        candidateList.frame(width: 250)
+        Rectangle().fill(EvidenceStyle.separator).frame(width: 1)
+        candidateInspector
+      }
+      Rectangle().fill(EvidenceStyle.separator).frame(height: 1)
+      actionBar
+    }
+    .background(EvidenceStyle.canvas)
+    .onAppear {
+      if model.scenarioCandidates.isEmpty, model.scenarioState == .ready {
+        model.inspectScenarioCandidates()
+      }
+    }
+    .accessibilityElement(children: .contain)
+    .accessibilityIdentifier("scenario-compiler-workspace")
+  }
+
+  private var header: some View {
+    HStack(spacing: 16) {
+      VStack(alignment: .leading, spacing: 4) {
+        Text("SCENARIO FOUNDRY")
+          .font(.system(size: 9, weight: .bold, design: .monospaced))
+          .tracking(1.15).foregroundStyle(EvidenceStyle.amberForeground)
+        Text("Turn intent into executable journeys—safely.")
+          .font(.system(size: 20, weight: .semibold)).tracking(-0.3)
+        Text("Generate · inspect · validate · dry-run · explicitly accept")
+          .font(.system(size: 9, design: .monospaced)).foregroundStyle(.secondary)
+      }
+      Spacer()
+      StatusPill(label: model.scenarioState.rawValue, color: stateColor)
+      Button("Done") { dismiss() }.buttonStyle(.bordered)
+    }
+    .padding(.horizontal, 24).frame(height: 88).background(EvidenceStyle.chrome)
+  }
+
+  private var authoringPanel: some View {
+    ScrollView {
+      VStack(alignment: .leading, spacing: 17) {
+        PremiumFieldLabel("LOCAL GENERATION")
+        PremiumInput(
+          label: "SPECIFICATION", icon: "doc.text",
+          placeholder: "docs/checkout.md", text: $model.scenarioSpecPath)
+        PremiumInput(
+          label: "SECTION (OPTIONAL)", icon: "text.quote",
+          placeholder: "Checkout", text: $model.scenarioSpecSection)
+        PremiumInput(
+          label: "LOCAL MODEL", icon: "cpu",
+          placeholder: "qwen2.5-coder:7b", text: $model.scenarioModel)
+        PremiumInput(
+          label: "ROUTES", icon: "point.topleft.down.to.point.bottomright.curvepath",
+          placeholder: "/checkout, /receipt", text: $model.scenarioRoutes)
+        Toggle("Include request policy", isOn: $model.scenarioIncludeRequestPolicy)
+          .toggleStyle(.checkbox).tint(EvidenceStyle.amber)
+          .font(.system(size: 10, weight: .semibold))
+        Text(
+          "Generation is free/local only. It creates an expiring candidate, never project files."
+        )
+        .font(.system(size: 9)).foregroundStyle(.secondary)
+        .fixedSize(horizontal: false, vertical: true)
+        if let issue = model.scenarioIssue ?? model.scenarioInputIssue {
+          Label(issue, systemImage: "exclamationmark.triangle.fill")
+            .font(.system(size: 9)).foregroundStyle(EvidenceStyle.warning)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+        Button("Generate candidate") { model.generateScenarioCandidate() }
+          .buttonStyle(PremiumPrimaryButtonStyle())
+          .disabled(!model.canGenerateScenario)
+          .frame(maxWidth: .infinity, alignment: .trailing)
+        Divider()
+        PremiumFieldLabel("SAFETY BOUNDARY")
+        boundary("No provider spend", true)
+        boundary("No evidence persistence in dry-run", true)
+        boundary("No baseline updates in dry-run", true)
+        boundary("Hash-bound acceptance", true)
+        boundary("Per-file destination choice", true)
+      }.padding(22)
+    }.background(EvidenceStyle.inspector)
+  }
+
+  private var candidateList: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      HStack {
+        PremiumFieldLabel("CANDIDATES")
+        Spacer()
+        Button {
+          model.inspectScenarioCandidates()
+        } label: {
+          Image(systemName: "arrow.clockwise")
+        }
+        .buttonStyle(.borderless).disabled(model.scenarioState == .running)
+        .accessibilityLabel("Refresh scenario candidates")
+      }.padding(16)
+      Rectangle().fill(EvidenceStyle.separator).frame(height: 1)
+      ScrollView {
+        LazyVStack(alignment: .leading, spacing: 4) {
+          if model.scenarioCandidates.isEmpty {
+            Text("No candidates")
+              .font(.system(size: 10)).foregroundStyle(.secondary).padding(16)
+          }
+          ForEach(model.scenarioCandidates) { candidate in
+            Button {
+              model.selectScenarioCandidate(candidate.candidateID)
+            } label: {
+              VStack(alignment: .leading, spacing: 6) {
+                HStack {
+                  Circle().fill(candidateColor(candidate)).frame(width: 7, height: 7)
+                  Text(candidate.status.uppercased())
+                    .font(.system(size: 8, weight: .bold, design: .monospaced))
+                  Spacer()
+                  if candidate.cacheHit {
+                    Image(systemName: "bolt.fill").font(.system(size: 8)).foregroundStyle(
+                      EvidenceStyle.amberForeground)
+                  }
+                }
+                Text(candidate.specSourcePath)
+                  .font(.system(size: 10, weight: .semibold, design: .monospaced)).lineLimit(2)
+                Text("\(candidate.files.count) files · \(candidate.dryRun.status)")
+                  .font(.system(size: 8, design: .monospaced)).foregroundStyle(.secondary)
+              }
+              .padding(12).frame(maxWidth: .infinity, alignment: .leading)
+              .background(
+                model.selectedScenarioCandidateID == candidate.candidateID
+                  ? EvidenceStyle.amber.opacity(0.09) : Color.clear,
+                in: RoundedRectangle(cornerRadius: 10)
+              )
+              .overlay {
+                RoundedRectangle(cornerRadius: 10).stroke(
+                  model.selectedScenarioCandidateID == candidate.candidateID
+                    ? EvidenceStyle.amber.opacity(0.45) : EvidenceStyle.separator)
+              }
+            }.buttonStyle(.plain)
+          }
+        }.padding(12)
+      }
+    }.background(EvidenceStyle.chrome)
+  }
+
+  @ViewBuilder private var candidateInspector: some View {
+    if let candidate = model.selectedScenarioCandidate {
+      ScrollView {
+        VStack(alignment: .leading, spacing: 16) {
+          HStack {
+            VStack(alignment: .leading, spacing: 4) {
+              PremiumFieldLabel("CANDIDATE PROOF")
+              Text(candidate.candidateID)
+                .font(.system(size: 11, weight: .semibold, design: .monospaced))
+            }
+            Spacer()
+            StatusPill(label: candidate.dryRun.status, color: dryRunColor(candidate.dryRun.status))
+          }
+          HStack(spacing: 10) {
+            metric("VALID", candidate.validation.qualified ? "YES" : "NO")
+            metric("FILES", "\(candidate.files.count)")
+            metric("UNRESOLVED", "\(candidate.unresolvedRequirements.count)")
+            metric(
+              "COST", candidate.usage.actualCostUSD.map { String(format: "$%.4f", $0) } ?? "$0")
+          }
+          if !candidate.validation.issues.isEmpty {
+            PremiumFieldLabel("VALIDATION")
+            ForEach(candidate.validation.issues) { issue in
+              Label(
+                "\(issue.path): \(issue.message)",
+                systemImage: issue.severity == "error"
+                  ? "xmark.octagon.fill" : "exclamationmark.triangle.fill"
+              )
+              .font(.system(size: 9)).foregroundStyle(
+                issue.severity == "error" ? EvidenceStyle.failure : EvidenceStyle.warning
+              )
+              .fixedSize(horizontal: false, vertical: true)
+            }
+          }
+          PremiumFieldLabel("CANDIDATE FILES")
+          ForEach(candidate.files) { file in
+            VStack(alignment: .leading, spacing: 9) {
+              Toggle(isOn: destinationBinding(file.destination)) {
+                HStack {
+                  Image(systemName: file.replacesExisting ? "doc.badge.ellipsis" : "doc.badge.plus")
+                    .foregroundStyle(
+                      file.replacesExisting ? EvidenceStyle.warning : EvidenceStyle.success)
+                  VStack(alignment: .leading, spacing: 3) {
+                    Text(file.destination)
+                      .font(.system(size: 10, weight: .semibold, design: .monospaced)).lineLimit(2)
+                    Text(
+                      "\(file.kind) · \(file.replacesExisting ? "replaces existing" : "new file")"
+                    )
+                    .font(.system(size: 8)).foregroundStyle(.secondary)
+                  }
+                }
+              }.toggleStyle(.checkbox).tint(EvidenceStyle.amber)
+              if !file.diff.isEmpty {
+                Text(String(file.diff.prefix(12_000)))
+                  .font(.system(size: 8, design: .monospaced)).foregroundStyle(.secondary)
+                  .textSelection(.enabled).padding(10)
+                  .frame(maxWidth: .infinity, alignment: .leading)
+                  .background(Color.black, in: RoundedRectangle(cornerRadius: 8))
+              }
+            }
+            .padding(13).background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 12))
+            .overlay { RoundedRectangle(cornerRadius: 12).stroke(EvidenceStyle.separator) }
+          }
+          if candidate.files.contains(where: {
+            $0.replacesExisting && model.selectedScenarioDestinations.contains($0.destination)
+          }) {
+            Toggle("Approve selected replacements", isOn: $model.scenarioReplacementApproved)
+              .toggleStyle(.checkbox).tint(EvidenceStyle.warning)
+              .font(.system(size: 10, weight: .semibold))
+          }
+          Text(
+            "Acceptance writes only checked destinations and revalidates the candidate hash. Dry-run evidence is never promoted into product proof."
+          )
+          .font(.system(size: 9)).foregroundStyle(.secondary)
+          .fixedSize(horizontal: false, vertical: true)
+        }.padding(20)
+      }
+    } else {
+      ContentUnavailableView(
+        "No candidate selected", systemImage: "doc.badge.gearshape",
+        description: Text("Generate or inspect a bounded candidate."))
+    }
+  }
+
+  private var actionBar: some View {
+    HStack(spacing: 10) {
+      if model.scenarioState == .running {
+        ProgressView().controlSize(.small).tint(EvidenceStyle.amber)
+      }
+      Text(model.scenarioStatusMessage).font(.system(size: 10, weight: .medium)).foregroundStyle(
+        .secondary
+      ).lineLimit(2)
+      Spacer()
+      if model.scenarioState == .running {
+        Button("Cancel", role: .destructive) { model.cancelScenarioAction() }.buttonStyle(.bordered)
+      } else if model.selectedScenarioCandidate != nil {
+        Button("Reject", role: .destructive) { model.rejectScenarioCandidate() }.buttonStyle(
+          .bordered)
+        Button("Validate") { model.validateScenarioCandidate() }.buttonStyle(.bordered)
+        Button("Dry-run") { model.dryRunScenarioCandidate() }.buttonStyle(.bordered)
+        Button("Accept selected") { model.acceptScenarioCandidate() }
+          .buttonStyle(PremiumPrimaryButtonStyle()).disabled(!model.canAcceptScenario)
+      }
+    }.padding(.horizontal, 20).frame(minHeight: 68).background(EvidenceStyle.chrome)
+  }
+
+  private func destinationBinding(_ destination: String) -> Binding<Bool> {
+    Binding(
+      get: { model.selectedScenarioDestinations.contains(destination) },
+      set: { _ in model.toggleScenarioDestination(destination) })
+  }
+
+  private func boundary(_ label: String, _ satisfied: Bool) -> some View {
+    Label(label, systemImage: satisfied ? "checkmark.circle.fill" : "circle")
+      .font(.system(size: 9, weight: .medium)).foregroundStyle(
+        satisfied ? EvidenceStyle.success : .secondary)
+  }
+
+  private func metric(_ label: String, _ value: String) -> some View {
+    VStack(alignment: .leading, spacing: 4) {
+      PremiumFieldLabel(label)
+      Text(value).font(.system(size: 14, weight: .semibold, design: .monospaced))
+    }
+    .padding(11).frame(maxWidth: .infinity, alignment: .leading)
+    .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 10))
+    .overlay { RoundedRectangle(cornerRadius: 10).stroke(EvidenceStyle.separator) }
+  }
+
+  private var stateColor: Color {
+    switch model.scenarioState {
+    case .running, .planning: EvidenceStyle.amber
+    case .completed, .planned: EvidenceStyle.success
+    case .limited: EvidenceStyle.warning
+    case .failed: EvidenceStyle.failure
+    case .ready, .cancelled: .secondary
+    }
+  }
+
+  private func candidateColor(_ candidate: ScenarioCandidate) -> Color {
+    if candidate.status != "candidate" { return .secondary }
+    return candidate.validation.qualified && candidate.dryRun.status == "passed"
+      ? EvidenceStyle.success : EvidenceStyle.warning
+  }
+
+  private func dryRunColor(_ value: String) -> Color {
+    switch value {
+    case "passed": EvidenceStyle.success
+    case "failed": EvidenceStyle.failure
+    default: .secondary
+    }
+  }
+}

--- a/apps/macos/CodeVetterPackage/Sources/CodeVetterFeature/PremiumScopePlanner.swift
+++ b/apps/macos/CodeVetterPackage/Sources/CodeVetterFeature/PremiumScopePlanner.swift
@@ -1,0 +1,156 @@
+import SwiftUI
+
+struct PremiumScopePlanner: View {
+  let title: String
+  let subtitle: String
+  @Binding var kind: EvidenceScopeKind
+  @Binding var value: String
+  let plan: EvidenceScopePlan?
+  let loading: Bool
+  let issue: String?
+  let canResolve: Bool
+  let selectedCandidateID: String?
+  let compact: Bool
+  let accessibilityID: String
+  let onResolve: () -> Void
+  let onSelect: (EvidenceScopeCandidate) -> Void
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: compact ? 11 : 14) {
+      HStack(alignment: .top, spacing: 12) {
+        VStack(alignment: .leading, spacing: 3) {
+          Text(title.uppercased())
+            .font(.system(size: 9, weight: .bold, design: .monospaced))
+            .tracking(0.9)
+            .foregroundStyle(EvidenceStyle.amberForeground)
+          Text(subtitle)
+            .font(.system(size: compact ? 10 : 11))
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+        Spacer(minLength: 8)
+        if loading {
+          ProgressView().controlSize(.small).tint(EvidenceStyle.amber)
+        }
+      }
+
+      Picker("Discovery scope", selection: $kind) {
+        Text("Flow").tag(EvidenceScopeKind.flow)
+        Text("Change").tag(EvidenceScopeKind.change)
+        Text("Codebase").tag(EvidenceScopeKind.codebase)
+      }
+      .pickerStyle(.segmented)
+      .labelsHidden()
+      .tint(EvidenceStyle.amber)
+
+      if kind != .codebase {
+        HStack(spacing: 9) {
+          Image(
+            systemName: kind == .flow
+              ? "point.3.connected.trianglepath.dotted" : "arrow.triangle.branch"
+          )
+          .font(.system(size: 11))
+          .foregroundStyle(EvidenceStyle.amberForeground)
+          TextField(
+            kind == .flow ? "checkout, authentication, search…" : "main...HEAD or pull request URL",
+            text: $value
+          )
+          .textFieldStyle(.plain)
+          .font(.system(size: 11, design: kind == .change ? .monospaced : .default))
+        }
+        .padding(.horizontal, 12)
+        .frame(height: 38)
+        .premiumField()
+      }
+
+      HStack(spacing: 10) {
+        Button(plan == nil ? "Discover targets" : "Refresh targets", action: onResolve)
+          .buttonStyle(.bordered)
+          .disabled(!canResolve)
+          .accessibilityIdentifier("\(accessibilityID)-resolve")
+        if let plan {
+          Text("\(plan.candidates.count) runnable · \(plan.uncoveredPaths.count) uncovered")
+            .font(.system(size: 9, weight: .medium, design: .monospaced))
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+        }
+      }
+
+      if let issue {
+        Label(issue, systemImage: "exclamationmark.triangle.fill")
+          .font(.system(size: 9, weight: .medium))
+          .foregroundStyle(EvidenceStyle.failure)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+
+      if let plan {
+        if plan.candidates.isEmpty {
+          Text("No closed runnable target matched this scope. CodeVetter did not invent one.")
+            .font(.system(size: 10, weight: .medium))
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+        } else {
+          VStack(spacing: 7) {
+            ForEach(plan.candidates.prefix(compact ? 3 : 5)) { candidate in
+              Button {
+                onSelect(candidate)
+              } label: {
+                HStack(alignment: .top, spacing: 9) {
+                  Image(
+                    systemName: selectedCandidateID == candidate.id
+                      ? "checkmark.circle.fill" : "circle"
+                  )
+                  .font(.system(size: 12, weight: .semibold))
+                  .foregroundStyle(
+                    selectedCandidateID == candidate.id
+                      ? EvidenceStyle.amberForeground : Color.secondary
+                  )
+                  VStack(alignment: .leading, spacing: 3) {
+                    Text(candidate.name ?? candidate.target)
+                      .font(.system(size: 10, weight: .semibold, design: .monospaced))
+                      .foregroundStyle(.primary)
+                      .lineLimit(1)
+                      .truncationMode(.middle)
+                    Text(
+                      "\(candidate.adapter) · \(candidate.confidenceLabel) · \(candidate.reason)"
+                    )
+                    .font(.system(size: 9))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(compact ? 1 : 2)
+                  }
+                  Spacer(minLength: 0)
+                }
+                .padding(9)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(
+                  selectedCandidateID == candidate.id
+                    ? EvidenceStyle.amber.opacity(0.08) : EvidenceStyle.canvas.opacity(0.65),
+                  in: RoundedRectangle(cornerRadius: 9)
+                )
+                .overlay {
+                  RoundedRectangle(cornerRadius: 9).stroke(
+                    selectedCandidateID == candidate.id
+                      ? EvidenceStyle.amber.opacity(0.45) : EvidenceStyle.separator
+                  )
+                }
+              }
+              .buttonStyle(.plain)
+            }
+          }
+        }
+
+        if let limitation = plan.limitations.first {
+          Text(limitation)
+            .font(.system(size: 8.5))
+            .foregroundStyle(.tertiary)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+      }
+    }
+    .padding(compact ? 13 : 15)
+    .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 12))
+    .overlay { RoundedRectangle(cornerRadius: 12).stroke(EvidenceStyle.separator) }
+    .accessibilityElement(children: .contain)
+    .accessibilityIdentifier(accessibilityID)
+  }
+}

--- a/apps/macos/CodeVetterPackage/Sources/CodeVetterFeature/PremiumTrexWatcherView.swift
+++ b/apps/macos/CodeVetterPackage/Sources/CodeVetterFeature/PremiumTrexWatcherView.swift
@@ -1,0 +1,420 @@
+import SwiftUI
+
+struct PremiumTrexWatcherView: View {
+  @Bindable var model: WorkbenchModel
+  @Environment(\.dismiss) private var dismiss
+  @State private var showingEnableConsent = false
+  @State private var showingRawReceipt = false
+
+  var body: some View {
+    VStack(spacing: 0) {
+      header
+      Rectangle().fill(EvidenceStyle.separator).frame(height: 1)
+      HStack(spacing: 0) {
+        scheduleDesk.frame(width: 310)
+        Rectangle().fill(EvidenceStyle.separator).frame(width: 1)
+        runLedger.frame(maxWidth: .infinity, maxHeight: .infinity)
+        Rectangle().fill(EvidenceStyle.separator).frame(width: 1)
+        authorityRail.frame(width: 270)
+      }
+      Rectangle().fill(EvidenceStyle.separator).frame(height: 1)
+      actionBar
+    }
+    .background(EvidenceStyle.canvas)
+    .task(id: model.repositoryPath) {
+      if model.currentTrexWatcher == nil, model.trexWatcherState == .ready {
+        model.loadTrexWatcher()
+      }
+    }
+    .alert("Allow incoming PR verification?", isPresented: $showingEnableConsent) {
+      Button("Not now", role: .cancel) {}
+        .accessibilityIdentifier("cancel-watcher-consent")
+      Button(model.currentTrexWatcher?.enabled == true ? "Allow this session" : "Enable watcher") {
+        if model.currentTrexWatcher?.enabled == true {
+          model.resumeTrexWatcherSession()
+        } else {
+          model.enableTrexWatcher(confirmRun: true)
+        }
+      }
+    } message: {
+      Text(
+        "Each poll may contact GitHub, execute untrusted project code in an isolated worktree, invoke the configured agent, and post a commit status. Consent lasts only for this native app session."
+      )
+    }
+    .accessibilityElement(children: .contain)
+    .accessibilityIdentifier("trex-watcher-workspace")
+  }
+
+  private var header: some View {
+    HStack(alignment: .top, spacing: 18) {
+      VStack(alignment: .leading, spacing: 5) {
+        Text("PR AUTOMATION")
+          .font(.system(size: 9, weight: .bold, design: .monospaced))
+          .tracking(1.15)
+          .foregroundStyle(EvidenceStyle.amberForeground)
+        Text("Incoming PR Watcher").font(.system(size: 25, weight: .semibold))
+        Text("Watch new and updated pull requests while CodeVetter is open")
+          .font(.system(size: 10))
+          .foregroundStyle(.secondary)
+      }
+      Spacer()
+      StatusPill(label: watcherStatusLabel, color: watcherStatusColor)
+      Button("Done") { dismiss() }
+        .buttonStyle(.bordered)
+    }
+    .padding(.horizontal, 22)
+    .padding(.vertical, 17)
+    .background(EvidenceStyle.chrome)
+  }
+
+  private var scheduleDesk: some View {
+    ScrollView {
+      VStack(alignment: .leading, spacing: 18) {
+        VStack(alignment: .leading, spacing: 5) {
+          PremiumFieldLabel("SCHEDULE")
+          Text(repositoryName)
+            .font(.system(size: 17, weight: .semibold))
+          Text(model.repositoryPath)
+            .font(.system(size: 8, design: .monospaced))
+            .foregroundStyle(.secondary)
+            .lineLimit(2)
+            .truncationMode(.middle)
+        }
+
+        VStack(alignment: .leading, spacing: 8) {
+          PremiumFieldLabel("POLL INTERVAL")
+          HStack {
+            TextField(
+              "Seconds",
+              value: $model.trexWatcherIntervalSeconds,
+              format: .number
+            )
+            .textFieldStyle(.plain)
+            .font(.system(size: 12, weight: .medium, design: .monospaced))
+            Stepper(
+              "",
+              value: $model.trexWatcherIntervalSeconds,
+              in: 60...86_400,
+              step: 60
+            )
+            .labelsHidden()
+          }
+          .padding(.horizontal, 12)
+          .frame(height: 42)
+          .premiumField()
+          Text("60 seconds minimum · 24 hours maximum")
+            .font(.system(size: 8))
+            .foregroundStyle(.secondary)
+        }
+
+        PremiumInput(
+          label: "BASE BRANCH",
+          icon: "arrow.triangle.branch",
+          placeholder: "Auto-detect from pull request",
+          text: $model.trexWatcherBaseBranch
+        )
+
+        VStack(alignment: .leading, spacing: 9) {
+          HStack {
+            Image(
+              systemName: model.trexWatcherSessionConfirmed
+                ? "checkmark.shield.fill" : "shield.lefthalf.filled"
+            )
+            .foregroundStyle(
+              model.trexWatcherSessionConfirmed ? EvidenceStyle.success : EvidenceStyle.warning)
+            Text(
+              model.trexWatcherSessionConfirmed
+                ? "Execution allowed this session" : "Execution consent required"
+            )
+            .font(.system(size: 10, weight: .semibold))
+          }
+          Text(
+            "The native app owns timing only while it is open. Rust owns repository discovery, worktree isolation, project execution, agent synthesis, GitHub statuses, and SQLite history."
+          )
+          .font(.system(size: 9))
+          .foregroundStyle(.secondary)
+          .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(13)
+        .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 11))
+        .overlay { RoundedRectangle(cornerRadius: 11).stroke(EvidenceStyle.separator) }
+
+        if let watcher = model.currentTrexWatcher {
+          VStack(alignment: .leading, spacing: 9) {
+            watcherFact("PERSISTED", watcher.enabled ? "Enabled" : "Disabled")
+            watcherFact("EVERY", "\(watcher.intervalSeconds)s")
+            watcherFact("LAST POLL", watcher.lastPolledAt ?? "Never")
+            if let error = watcher.lastError {
+              Text(error)
+                .font(.system(size: 8, design: .monospaced))
+                .foregroundStyle(EvidenceStyle.failure)
+                .textSelection(.enabled)
+            }
+          }
+          .padding(13)
+          .background(EvidenceStyle.inspector, in: RoundedRectangle(cornerRadius: 11))
+          .overlay { RoundedRectangle(cornerRadius: 11).stroke(EvidenceStyle.separator) }
+        }
+      }
+      .padding(18)
+    }
+    .background(EvidenceStyle.inspector)
+  }
+
+  private var runLedger: some View {
+    VStack(spacing: 0) {
+      HStack {
+        VStack(alignment: .leading, spacing: 3) {
+          PremiumFieldLabel("RECENT RUNS")
+          Text("New & updated PR receipts").font(.system(size: 15, weight: .semibold))
+        }
+        Spacer()
+        Text("\(model.trexWatcherRuns.count) retained")
+          .font(.system(size: 8, weight: .semibold, design: .monospaced))
+          .foregroundStyle(.secondary)
+      }
+      .padding(18)
+      .background(EvidenceStyle.surface)
+      Rectangle().fill(EvidenceStyle.separator).frame(height: 1)
+
+      if model.trexWatcherRuns.isEmpty {
+        ContentUnavailableView(
+          "No incoming PR receipts",
+          systemImage: "dot.radiowaves.left.and.right",
+          description: Text(
+            "A receipt appears when a new open pull request arrives or an existing pull request receives a head SHA that has not been verified."
+          )
+        )
+      } else {
+        ScrollView {
+          LazyVStack(spacing: 8) {
+            ForEach(model.trexWatcherRuns) { run in
+              watcherRunRow(run)
+            }
+            if !model.trexWatcherReceiptJSON.isEmpty {
+              DisclosureGroup("Latest canonical receipt", isExpanded: $showingRawReceipt) {
+                ScrollView(.horizontal) {
+                  Text(model.trexWatcherReceiptJSON)
+                    .font(.system(size: 8, design: .monospaced))
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.top, 10)
+                }
+              }
+              .font(.system(size: 9, weight: .semibold))
+              .padding(14)
+              .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 11))
+              .overlay { RoundedRectangle(cornerRadius: 11).stroke(EvidenceStyle.separator) }
+            }
+          }
+          .padding(16)
+        }
+      }
+    }
+  }
+
+  private var authorityRail: some View {
+    VStack(alignment: .leading, spacing: 18) {
+      PremiumFieldLabel("AUTHORITY CONTRACT")
+      authorityStep(
+        "01", "Native schedule",
+        "A cancellable app-lifetime task waits for the persisted interval.")
+      authorityStep(
+        "02", "Foreground poll",
+        "The CLI requires explicit confirmation and stays supervised.")
+      authorityStep(
+        "03", "Incoming PR discovery",
+        "Rust finds new or updated open PRs, then owns sandboxing, agent synthesis, and persistence."
+      )
+      authorityStep(
+        "04", "GitHub receipt",
+        "Commit status errors stay attached to the run instead of hiding evidence.")
+      Spacer()
+      VStack(alignment: .leading, spacing: 7) {
+        Label("No hidden daemon", systemImage: "checkmark.seal.fill")
+          .foregroundStyle(EvidenceStyle.success)
+        Text(
+          "Closing the native app stops its schedule. Saved configuration and run history remain."
+        )
+        .foregroundStyle(.secondary)
+      }
+      .font(.system(size: 8))
+    }
+    .padding(18)
+    .background(EvidenceStyle.chrome)
+  }
+
+  private var actionBar: some View {
+    HStack(spacing: 12) {
+      if model.trexWatcherState == .running || model.trexWatcherState == .planning {
+        ProgressView().controlSize(.small).tint(EvidenceStyle.amber)
+      }
+      VStack(alignment: .leading, spacing: 3) {
+        Text(model.trexWatcherStatusMessage)
+          .font(.system(size: 10, weight: .medium))
+          .foregroundStyle(model.trexWatcherIssue == nil ? .secondary : EvidenceStyle.failure)
+          .lineLimit(2)
+        if !model.canConfigureTrexWatcher,
+          model.trexWatcherIntervalSeconds < 60
+            || model.trexWatcherIntervalSeconds > 86_400
+        {
+          Text("Choose an interval from 60 to 86,400 seconds.")
+            .font(.system(size: 8))
+            .foregroundStyle(EvidenceStyle.warning)
+        }
+      }
+      Spacer()
+      Button("Refresh") { model.loadTrexWatcher() }
+        .buttonStyle(.bordered)
+        .disabled(model.isBusy)
+      if model.trexWatcherState == .running {
+        Button("Cancel", role: .destructive) { model.cancelTrexWatcherAction() }
+          .buttonStyle(.bordered)
+      } else {
+        if let watcher = model.currentTrexWatcher, watcher.enabled {
+          Button("Disable", role: .destructive) { model.disableTrexWatcher() }
+            .buttonStyle(.bordered)
+            .disabled(model.isBusy)
+          Button(model.trexWatcherSessionConfirmed ? "Poll now" : "Allow session") {
+            if model.trexWatcherSessionConfirmed {
+              model.pollTrexWatcher(confirmRun: false)
+            } else {
+              showingEnableConsent = true
+            }
+          }
+          .buttonStyle(PremiumPrimaryButtonStyle())
+          .disabled(model.isBusy)
+        } else {
+          Button("Enable watcher") { showingEnableConsent = true }
+            .buttonStyle(PremiumPrimaryButtonStyle())
+            .disabled(!model.canConfigureTrexWatcher)
+        }
+      }
+    }
+    .padding(.horizontal, 20)
+    .frame(minHeight: 68)
+    .background(EvidenceStyle.chrome)
+  }
+
+  private func watcherRunRow(_ run: TrexWatcherRun) -> some View {
+    HStack(alignment: .top, spacing: 13) {
+      ZStack {
+        RoundedRectangle(cornerRadius: 8)
+          .fill(verdictColor(run.verdict).opacity(0.12))
+        Image(systemName: verdictIcon(run.verdict))
+          .foregroundStyle(verdictColor(run.verdict))
+      }
+      .frame(width: 38, height: 38)
+      VStack(alignment: .leading, spacing: 5) {
+        HStack {
+          Text("PR #\(run.prNumber)")
+            .font(.system(size: 11, weight: .semibold, design: .monospaced))
+          Text(String(run.headSHA.prefix(8)))
+            .font(.system(size: 8, design: .monospaced))
+            .foregroundStyle(.secondary)
+          Spacer()
+          StatusPill(label: run.verdict, color: verdictColor(run.verdict))
+        }
+        Text(run.summary)
+          .font(.system(size: 10))
+          .lineLimit(2)
+        HStack(spacing: 12) {
+          Text("\(run.durationMS)ms")
+          Text("\(Int((run.confidence * 100).rounded()))% confidence")
+          Text(run.statusState ?? "status not posted")
+          Spacer()
+          Text(run.ranAt)
+          if retryRecommended(run) {
+            Button("Retry") { model.retryTrexWatcherRun(run) }
+              .buttonStyle(.borderless)
+              .foregroundStyle(EvidenceStyle.amberForeground)
+              .disabled(model.isBusy || !model.trexWatcherSessionConfirmed)
+              .help("Rerun this exact open PR after an infrastructure-limited attempt")
+          }
+        }
+        .font(.system(size: 8, design: .monospaced))
+        .foregroundStyle(.secondary)
+        if let error = run.statusError {
+          Text(error)
+            .font(.system(size: 8))
+            .foregroundStyle(EvidenceStyle.warning)
+            .lineLimit(2)
+        }
+      }
+    }
+    .padding(14)
+    .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 12))
+    .overlay { RoundedRectangle(cornerRadius: 12).stroke(EvidenceStyle.separator) }
+  }
+
+  private func watcherFact(_ label: String, _ value: String) -> some View {
+    HStack {
+      Text(label)
+        .font(.system(size: 7, weight: .bold, design: .monospaced))
+        .foregroundStyle(.secondary)
+      Spacer()
+      Text(value)
+        .font(.system(size: 8, weight: .medium, design: .monospaced))
+    }
+  }
+
+  private func authorityStep(_ number: String, _ title: String, _ detail: String) -> some View {
+    HStack(alignment: .top, spacing: 11) {
+      Text(number)
+        .font(.system(size: 8, weight: .bold, design: .monospaced))
+        .foregroundStyle(EvidenceStyle.amberForeground)
+        .frame(width: 24, height: 24)
+        .background(EvidenceStyle.amber.opacity(0.1), in: RoundedRectangle(cornerRadius: 6))
+      VStack(alignment: .leading, spacing: 4) {
+        Text(title).font(.system(size: 10, weight: .semibold))
+        Text(detail)
+          .font(.system(size: 8))
+          .foregroundStyle(.secondary)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+    }
+  }
+
+  private var repositoryName: String {
+    guard !model.repositoryPath.isEmpty else { return "No repository selected" }
+    return URL(fileURLWithPath: model.repositoryPath).lastPathComponent
+  }
+
+  private var watcherStatusLabel: String {
+    if model.trexWatcherState == .running { return "Executing" }
+    if model.trexWatcherSessionConfirmed { return "Session active" }
+    if model.currentTrexWatcher?.enabled == true { return "Consent paused" }
+    if model.currentTrexWatcher != nil { return "Disabled" }
+    return "Not configured"
+  }
+
+  private var watcherStatusColor: Color {
+    if model.trexWatcherState == .failed { return EvidenceStyle.failure }
+    if model.trexWatcherState == .running { return EvidenceStyle.amber }
+    if model.trexWatcherSessionConfirmed { return EvidenceStyle.success }
+    return .secondary
+  }
+
+  private func verdictColor(_ verdict: String) -> Color {
+    switch verdict {
+    case "APPROVE": EvidenceStyle.success
+    case "NEEDS_REVIEW": EvidenceStyle.warning
+    default: EvidenceStyle.failure
+    }
+  }
+
+  private func verdictIcon(_ verdict: String) -> String {
+    switch verdict {
+    case "APPROVE": "checkmark.shield.fill"
+    case "NEEDS_REVIEW": "exclamationmark.shield.fill"
+    default: "xmark.shield.fill"
+    }
+  }
+
+  private func retryRecommended(_ run: TrexWatcherRun) -> Bool {
+    run.statusError != nil || run.confidence == 0
+      || run.summary.localizedCaseInsensitiveContains("sandbox didn't complete")
+      || run.summary.localizedCaseInsensitiveContains("could not be materialized")
+  }
+}

--- a/apps/macos/CodeVetterPackage/Sources/CodeVetterFeature/QaJourneyWorkspaceView.swift
+++ b/apps/macos/CodeVetterPackage/Sources/CodeVetterFeature/QaJourneyWorkspaceView.swift
@@ -1,0 +1,353 @@
+import SwiftUI
+
+struct QaJourneyWorkspaceView: View {
+  @Bindable var model: WorkbenchModel
+
+  var body: some View {
+    VStack(spacing: 0) {
+      header
+      Rectangle().fill(EvidenceStyle.separator).frame(height: 1)
+      HStack(spacing: 0) {
+        workflowIndex
+          .frame(width: 258)
+        Rectangle().fill(EvidenceStyle.separator).frame(width: 1)
+        editor
+      }
+      Rectangle().fill(EvidenceStyle.separator).frame(height: 1)
+      actionBar
+    }
+    .background(EvidenceStyle.canvas)
+    .accessibilityElement(children: .contain)
+    .accessibilityIdentifier("qa-journey-workspace")
+  }
+
+  private var header: some View {
+    HStack(spacing: 14) {
+      VStack(alignment: .leading, spacing: 4) {
+        Text("TESTING / JOURNEY SETUP")
+          .font(.system(size: 9, weight: .bold, design: .monospaced))
+          .tracking(1.1)
+          .foregroundStyle(EvidenceStyle.amberForeground)
+        Text("Reuse the flow. Keep execution honest.")
+          .font(.system(size: 20, weight: .semibold))
+        Text("Rust owns saved targets, spec discovery, and post-fix comparison identity.")
+          .font(.system(size: 10))
+          .foregroundStyle(.secondary)
+      }
+      Spacer()
+      if model.qaWorkspaceLoading {
+        ProgressView().controlSize(.small).tint(EvidenceStyle.amber)
+      }
+      Button("Refresh") { model.loadQaWorkspace() }
+        .buttonStyle(.bordered)
+        .disabled(model.qaWorkspaceLoading)
+      Button("Done") { model.showingQaWorkspace = false }
+        .buttonStyle(.bordered)
+    }
+    .padding(.horizontal, 22)
+    .frame(height: 84)
+    .background(EvidenceStyle.chrome)
+  }
+
+  private var workflowIndex: some View {
+    VStack(spacing: 0) {
+      HStack {
+        PremiumFieldLabel("SAVED WORKFLOWS")
+        Spacer()
+        Button {
+          model.newQaWorkflow()
+        } label: {
+          Image(systemName: "plus")
+        }
+        .buttonStyle(.borderless)
+        .help("New workflow")
+      }
+      .padding(.horizontal, 14)
+      .frame(height: 44)
+
+      ScrollView {
+        LazyVStack(spacing: 6) {
+          ForEach(model.qaWorkspaceReceipt?.workflows ?? []) { workflow in
+            Button {
+              model.selectQaWorkflow(workflow.id)
+            } label: {
+              VStack(alignment: .leading, spacing: 5) {
+                HStack(spacing: 6) {
+                  Image(
+                    systemName: workflow.editable
+                      ? "point.3.filled.connected.trianglepath.dotted" : "lock.fill"
+                  )
+                  .font(.system(size: 9, weight: .semibold))
+                  .foregroundStyle(
+                    workflow.id == model.qaSelectedWorkflowID
+                      ? EvidenceStyle.amberForeground : Color.secondary)
+                  Text(workflow.name)
+                    .font(.system(size: 11, weight: .semibold))
+                    .lineLimit(1)
+                  Spacer()
+                }
+                Text("\(workflow.runnerType) · \(workflow.targets.count) targets")
+                  .font(.system(size: 8, design: .monospaced))
+                  .foregroundStyle(.secondary)
+                  .lineLimit(1)
+              }
+              .padding(11)
+              .frame(maxWidth: .infinity, alignment: .leading)
+              .background(
+                workflow.id == model.qaSelectedWorkflowID
+                  ? EvidenceStyle.amber.opacity(0.09) : EvidenceStyle.surface,
+                in: RoundedRectangle(cornerRadius: 10)
+              )
+              .overlay {
+                RoundedRectangle(cornerRadius: 10)
+                  .stroke(
+                    workflow.id == model.qaSelectedWorkflowID
+                      ? EvidenceStyle.amber.opacity(0.45) : EvidenceStyle.separator)
+              }
+            }
+            .buttonStyle(.plain)
+          }
+        }
+        .padding(10)
+      }
+
+      VStack(alignment: .leading, spacing: 5) {
+        Label("Secret-safe projection", systemImage: "key.slash")
+          .font(.system(size: 9, weight: .semibold))
+        Text("Storage-state paths and arbitrary commands never enter this native receipt.")
+          .font(.system(size: 8))
+          .foregroundStyle(.secondary)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+      .padding(12)
+      .background(EvidenceStyle.surface)
+    }
+    .background(EvidenceStyle.chrome)
+  }
+
+  private var editor: some View {
+    ScrollView {
+      VStack(alignment: .leading, spacing: 20) {
+        if let postFix = model.qaWorkspaceReceipt?.postFix {
+          postFixBanner(postFix)
+        }
+
+        if let issue = model.qaWorkspaceIssue {
+          Label(issue, systemImage: "exclamationmark.triangle.fill")
+            .font(.system(size: 10, weight: .medium))
+            .foregroundStyle(EvidenceStyle.failure)
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(EvidenceStyle.failure.opacity(0.08), in: RoundedRectangle(cornerRadius: 10))
+        }
+
+        HStack(alignment: .top, spacing: 18) {
+          VStack(alignment: .leading, spacing: 14) {
+            PremiumInput(
+              label: "WORKFLOW NAME", icon: "bookmark",
+              placeholder: "Checkout confidence", text: workflowBinding(\.name)
+            )
+            PremiumInput(
+              label: "PREVIEW", icon: "safari", placeholder: "http://localhost:1420",
+              text: workflowBinding(\.baseURL)
+            )
+            PremiumInput(
+              label: "LOOP ID", icon: "arrow.triangle.2.circlepath",
+              placeholder: "checkout", text: workflowBinding(\.loopID)
+            )
+            VStack(alignment: .leading, spacing: 7) {
+              PremiumFieldLabel("RUNNER")
+              Picker("Runner", selection: workflowBinding(\.runnerType)) {
+                Text("Built-in browser").tag("playwright_builtin")
+                Text("Repository Playwright").tag("repo_playwright")
+              }
+              .pickerStyle(.segmented)
+              .labelsHidden()
+              .tint(.secondary)
+            }
+          }
+          VStack(alignment: .leading, spacing: 14) {
+            PremiumInput(
+              label: "PRIMARY ROUTE", icon: "point.topleft.down.curvedto.point.bottomright.up",
+              placeholder: "/checkout", text: workflowBinding(\.targetRoute)
+            )
+            PremiumInput(
+              label: "JOURNEY GOAL", icon: "scope", placeholder: "Complete checkout",
+              text: workflowBinding(\.goal)
+            )
+            VStack(alignment: .leading, spacing: 7) {
+              PremiumFieldLabel("REPOSITORY SPEC")
+              Menu {
+                Button("No repository spec") { model.chooseQaSpec("") }
+                ForEach(model.qaWorkspaceReceipt?.specs ?? []) { spec in
+                  Button(spec.path) { model.chooseQaSpec(spec.path) }
+                }
+              } label: {
+                HStack {
+                  Image(systemName: "doc.text.magnifyingglass")
+                    .foregroundStyle(EvidenceStyle.amberForeground)
+                  Text(
+                    model.qaWorkflowDraft.repoSpecPath.isEmpty
+                      ? "Choose discovered spec…" : model.qaWorkflowDraft.repoSpecPath
+                  )
+                  .font(.system(size: 10, design: .monospaced))
+                  .lineLimit(1)
+                  .truncationMode(.middle)
+                  Spacer()
+                  Image(systemName: "chevron.up.chevron.down")
+                    .font(.system(size: 8, weight: .bold))
+                    .foregroundStyle(.secondary)
+                }
+                .padding(.horizontal, 12)
+                .frame(height: 42)
+                .premiumField()
+              }
+              .menuStyle(.borderlessButton)
+            }
+            Toggle(
+              "Permit an explicitly confirmed remote preview",
+              isOn: workflowBinding(\.allowRemoteTarget)
+            )
+            .toggleStyle(.checkbox)
+            .tint(EvidenceStyle.amber)
+            .font(.system(size: 10, weight: .medium))
+          }
+        }
+
+        targetDesk
+
+        if let limitation = model.selectedQaWorkflow?.limitation {
+          Label(limitation, systemImage: "lock.fill")
+            .font(.system(size: 9))
+            .foregroundStyle(.secondary)
+        }
+      }
+      .padding(24)
+      .frame(maxWidth: 820, alignment: .leading)
+    }
+  }
+
+  private var targetDesk: some View {
+    VStack(alignment: .leading, spacing: 11) {
+      HStack {
+        VStack(alignment: .leading, spacing: 3) {
+          PremiumFieldLabel("SAVED TARGETS")
+          Text("A selected target becomes an explicit route and goal in the T-REX receipt.")
+            .font(.system(size: 9))
+            .foregroundStyle(.secondary)
+        }
+        Spacer()
+        Menu("Select target") {
+          ForEach(model.selectedQaWorkflow?.targets ?? []) { target in
+            Button(target.name) { model.selectQaTarget(target.id) }
+          }
+        }
+        .disabled(model.selectedQaWorkflow == nil)
+      }
+
+      HStack(spacing: 10) {
+        CompactQaField(placeholder: "Target name", text: $model.qaTargetName)
+        CompactQaField(placeholder: "/route", text: $model.qaTargetRoute)
+        CompactQaField(placeholder: "User goal", text: $model.qaTargetGoal)
+        Button("Save target") { model.saveQaTarget() }
+          .buttonStyle(.bordered)
+          .disabled(
+            model.qaSelectedWorkflowID == nil || model.qaWorkspaceLoading
+              || model.selectedQaWorkflow?.editable == false)
+        Button {
+          model.deleteQaTarget()
+        } label: {
+          Image(systemName: "trash")
+        }
+        .buttonStyle(.bordered)
+        .disabled(
+          model.qaSelectedTargetID == nil || model.qaWorkspaceLoading
+            || model.selectedQaWorkflow?.editable == false
+        )
+        .accessibilityLabel("Delete selected target")
+      }
+    }
+    .padding(14)
+    .background(EvidenceStyle.surface, in: RoundedRectangle(cornerRadius: 12))
+    .overlay { RoundedRectangle(cornerRadius: 12).stroke(EvidenceStyle.separator) }
+  }
+
+  private func postFixBanner(_ preparation: QaPostFixPreparation) -> some View {
+    HStack(spacing: 12) {
+      Image(
+        systemName: preparation.status == "needs_rerun"
+          ? "arrow.clockwise.circle.fill" : "checkmark.seal.fill"
+      )
+      .foregroundStyle(
+        preparation.status == "needs_rerun"
+          ? EvidenceStyle.amberForeground : EvidenceStyle.success)
+      VStack(alignment: .leading, spacing: 3) {
+        Text(preparation.status == "needs_rerun" ? "POST-FIX RERUN READY" : "POST-FIX COMPARISON")
+          .font(.system(size: 9, weight: .bold, design: .monospaced))
+          .tracking(0.8)
+        Text(preparation.summary)
+          .font(.system(size: 10))
+          .foregroundStyle(.secondary)
+      }
+      Spacer()
+      if preparation.status == "needs_rerun" {
+        Button("Use prior flow") {
+          model.applyPostFixQaPreparation(preparation)
+        }
+        .buttonStyle(.bordered)
+      }
+    }
+    .padding(14)
+    .background(EvidenceStyle.amber.opacity(0.07), in: RoundedRectangle(cornerRadius: 12))
+    .overlay { RoundedRectangle(cornerRadius: 12).stroke(EvidenceStyle.amber.opacity(0.25)) }
+  }
+
+  private var actionBar: some View {
+    HStack(spacing: 10) {
+      Text("\(model.qaWorkspaceReceipt?.specs.count ?? 0) specs discovered")
+        .font(.system(size: 9, design: .monospaced))
+        .foregroundStyle(.secondary)
+      Spacer()
+      Button("Delete workflow", role: .destructive) { model.deleteQaWorkflow() }
+        .buttonStyle(.bordered)
+        .disabled(
+          model.qaSelectedWorkflowID == nil || model.qaWorkspaceLoading
+            || model.selectedQaWorkflow?.editable == false)
+      Button("Save workflow") { model.saveQaWorkflow() }
+        .buttonStyle(.bordered)
+        .disabled(model.qaWorkspaceLoading || model.selectedQaWorkflow?.editable == false)
+      Button("Apply to Testing") {
+        model.applyQaWorkflowToTesting()
+        model.showingQaWorkspace = false
+      }
+      .buttonStyle(PremiumPrimaryButtonStyle())
+      .disabled(model.selectedQaWorkflow == nil)
+    }
+    .padding(.horizontal, 20)
+    .frame(height: 66)
+    .background(EvidenceStyle.chrome)
+  }
+
+  private func workflowBinding<Value>(_ keyPath: WritableKeyPath<QaWorkflowDraft, Value>)
+    -> Binding<Value>
+  {
+    Binding(
+      get: { model.qaWorkflowDraft[keyPath: keyPath] },
+      set: { model.qaWorkflowDraft[keyPath: keyPath] = $0 }
+    )
+  }
+}
+
+private struct CompactQaField: View {
+  let placeholder: String
+  @Binding var text: String
+
+  var body: some View {
+    TextField(placeholder, text: $text)
+      .textFieldStyle(.plain)
+      .font(.system(size: 10))
+      .padding(.horizontal, 10)
+      .frame(height: 36)
+      .premiumField()
+  }
+}

--- a/apps/macos/CodeVetterPackage/Sources/NativeBridgeBenchmark/main.swift
+++ b/apps/macos/CodeVetterPackage/Sources/NativeBridgeBenchmark/main.swift
@@ -1,0 +1,181 @@
+import Darwin
+import Foundation
+
+struct Statistics: Codable {
+  let iterations: Int
+  let minimumMicroseconds: Double
+  let medianMicroseconds: Double
+  let p95Microseconds: Double
+  let averageMicroseconds: Double
+
+  enum CodingKeys: String, CodingKey {
+    case iterations
+    case minimumMicroseconds = "minimum_us"
+    case medianMicroseconds = "median_us"
+    case p95Microseconds = "p95_us"
+    case averageMicroseconds = "average_us"
+  }
+}
+
+struct BridgeBenchmarkReceipt: Codable {
+  let schemaVersion = "codevetter.native-bridge-benchmark/v1"
+  let payloadBytes: Int
+  let ffiTransfer: Statistics
+  let ffiTransferAndDecode: Statistics
+  let workerRoundTrip: Statistics
+  let semanticParity: Bool
+  let selectedBoundary: String
+  let limitations: [String]
+
+  enum CodingKeys: String, CodingKey {
+    case schemaVersion = "schema_version"
+    case payloadBytes = "payload_bytes"
+    case ffiTransfer = "ffi_transfer"
+    case ffiTransferAndDecode = "ffi_transfer_and_decode"
+    case workerRoundTrip = "worker_round_trip"
+    case semanticParity = "semantic_parity"
+    case selectedBoundary = "selected_boundary"
+    case limitations
+  }
+}
+
+typealias PointerFunction = @convention(c) () -> UnsafePointer<UInt8>?
+typealias LengthFunction = @convention(c) () -> Int
+
+let arguments = CommandLine.arguments
+guard arguments.count == 3 else {
+  FileHandle.standardError.write(
+    Data("usage: NativeBridgeBenchmark <bridge.dylib> <codevetter-cli>\n".utf8))
+  exit(2)
+}
+
+let dynamicLibraryPath = arguments[1]
+let cliPath = arguments[2]
+guard let handle = dlopen(dynamicLibraryPath, RTLD_NOW | RTLD_LOCAL) else {
+  let message = dlerror().map { String(cString: $0) } ?? "unknown dynamic loader error"
+  FileHandle.standardError.write(Data("load bridge: \(message)\n".utf8))
+  exit(2)
+}
+defer { dlclose(handle) }
+
+guard let pointerSymbol = dlsym(handle, "codevetter_capabilities_pointer"),
+  let lengthSymbol = dlsym(handle, "codevetter_capabilities_length")
+else {
+  FileHandle.standardError.write(Data("bridge symbols are unavailable\n".utf8))
+  exit(2)
+}
+
+let capabilityPointer = unsafeBitCast(pointerSymbol, to: PointerFunction.self)
+let capabilityLength = unsafeBitCast(lengthSymbol, to: LengthFunction.self)
+guard let bytes = capabilityPointer(), capabilityLength() > 0 else {
+  FileHandle.standardError.write(Data("bridge returned an empty payload\n".utf8))
+  exit(2)
+}
+
+let payloadLength = capabilityLength()
+let ffiPayload = Data(bytes: bytes, count: payloadLength)
+let ffiObject = try JSONSerialization.jsonObject(with: ffiPayload)
+guard JSONSerialization.isValidJSONObject(ffiObject) else {
+  FileHandle.standardError.write(Data("bridge payload is not canonical JSON\n".utf8))
+  exit(2)
+}
+
+for _ in 0..<100 {
+  _ = Data(bytes: bytes, count: payloadLength)
+}
+
+let transfer = measure(iterations: 10_000) {
+  _ = Data(bytes: bytes, count: payloadLength)
+}
+let transferAndDecode = measure(iterations: 1_000) {
+  let data = Data(bytes: bytes, count: payloadLength)
+  _ = try! JSONSerialization.jsonObject(with: data)
+}
+
+for _ in 0..<3 {
+  _ = try runWorker(at: cliPath)
+}
+var latestWorkerPayload = Data()
+let worker = measure(iterations: 20) {
+  latestWorkerPayload = try! runWorker(at: cliPath)
+}
+
+let workerObject = try JSONSerialization.jsonObject(with: latestWorkerPayload)
+let ffiCanonical = try JSONSerialization.data(withJSONObject: ffiObject, options: [.sortedKeys])
+let workerCanonical = try JSONSerialization.data(
+  withJSONObject: workerObject,
+  options: [.sortedKeys]
+)
+let parity = ffiCanonical == workerCanonical
+guard parity else {
+  FileHandle.standardError.write(Data("worker and FFI payloads differ semantically\n".utf8))
+  exit(1)
+}
+
+let receipt = BridgeBenchmarkReceipt(
+  payloadBytes: payloadLength,
+  ffiTransfer: transfer,
+  ffiTransferAndDecode: transferAndDecode,
+  workerRoundTrip: worker,
+  semanticParity: parity,
+  selectedBoundary:
+    "hybrid: in-process for bounded read-only projections; supervised worker for verification execution",
+  limitations: [
+    "The FFI probe measures a deterministic read-only projection, not long-running verification.",
+    "Debug and release application integration overhead is not included.",
+    "Process startup is intentionally included in the worker round trip.",
+  ]
+)
+let encoder = JSONEncoder()
+encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+FileHandle.standardOutput.write(try encoder.encode(receipt))
+FileHandle.standardOutput.write(Data("\n".utf8))
+
+func measure(iterations: Int, operation: () -> Void) -> Statistics {
+  var samples: [Double] = []
+  samples.reserveCapacity(iterations)
+  for _ in 0..<iterations {
+    let started = DispatchTime.now().uptimeNanoseconds
+    operation()
+    let elapsed = DispatchTime.now().uptimeNanoseconds - started
+    samples.append(Double(elapsed) / 1_000)
+  }
+  samples.sort()
+  let average = samples.reduce(0, +) / Double(samples.count)
+  return Statistics(
+    iterations: iterations,
+    minimumMicroseconds: samples[0],
+    medianMicroseconds: percentile(samples, 0.5),
+    p95Microseconds: percentile(samples, 0.95),
+    averageMicroseconds: average
+  )
+}
+
+func percentile(_ sorted: [Double], _ value: Double) -> Double {
+  let index = min(sorted.count - 1, Int((Double(sorted.count - 1) * value).rounded(.up)))
+  return sorted[index]
+}
+
+func runWorker(at path: String) throws -> Data {
+  let process = Process()
+  let output = Pipe()
+  let errors = Pipe()
+  process.executableURL = URL(fileURLWithPath: path)
+  process.arguments = ["capabilities", "--json"]
+  process.standardOutput = output
+  process.standardError = errors
+  try process.run()
+  let data = output.fileHandleForReading.readDataToEndOfFile()
+  let errorData = errors.fileHandleForReading.readDataToEndOfFile()
+  process.waitUntilExit()
+  guard process.terminationStatus == 0 else {
+    throw NSError(
+      domain: "CodeVetterBridgeBenchmark",
+      code: Int(process.terminationStatus),
+      userInfo: [
+        NSLocalizedDescriptionKey: String(data: errorData, encoding: .utf8) ?? "worker failed"
+      ]
+    )
+  }
+  return data
+}

--- a/apps/macos/CodeVetterPackage/Tests/CodeVetterFeatureTests/CodeVetterFeatureTestSupport.swift
+++ b/apps/macos/CodeVetterPackage/Tests/CodeVetterFeatureTests/CodeVetterFeatureTestSupport.swift
@@ -1,0 +1,1688 @@
+import AppKit
+import Darwin
+import Foundation
+import SwiftUI
+import Testing
+
+@testable import CodeVetterFeature
+
+func resolveNativeColor(_ color: NSColor, in appearance: NSAppearance) -> NSColor? {
+  var resolved: NSColor?
+  appearance.performAsCurrentDrawingAppearance {
+    resolved = color.usingColorSpace(.sRGB) ?? color
+  }
+  return resolved
+}
+
+func nativeContrastRatio(_ foreground: NSColor, against backgroundHex: UInt32) -> Double {
+  let converted = foreground.usingColorSpace(.sRGB) ?? foreground
+  let background = NSColor(
+    srgbRed: CGFloat((backgroundHex >> 16) & 0xFF) / 255,
+    green: CGFloat((backgroundHex >> 8) & 0xFF) / 255,
+    blue: CGFloat(backgroundHex & 0xFF) / 255,
+    alpha: 1
+  )
+  let foregroundLuminance = nativeRelativeLuminance(converted)
+  let backgroundLuminance = nativeRelativeLuminance(background)
+  return (max(foregroundLuminance, backgroundLuminance) + 0.05)
+    / (min(foregroundLuminance, backgroundLuminance) + 0.05)
+}
+
+func nativeRelativeLuminance(_ color: NSColor) -> Double {
+  func linearize(_ component: CGFloat) -> Double {
+    let value = Double(component)
+    return value <= 0.03928 ? value / 12.92 : pow((value + 0.055) / 1.055, 2.4)
+  }
+  return 0.2126 * linearize(color.redComponent)
+    + 0.7152 * linearize(color.greenComponent)
+    + 0.0722 * linearize(color.blueComponent)
+}
+
+final class LockedProgress: @unchecked Sendable {
+  private let lock = NSLock()
+  private var storage: [VerificationProgress] = []
+
+  var values: [VerificationProgress] {
+    lock.lock()
+    defer { lock.unlock() }
+    return storage
+  }
+
+  func append(_ progress: VerificationProgress) {
+    lock.lock()
+    storage.append(progress)
+    lock.unlock()
+  }
+}
+
+@Test
+func supervisedRunnerLoadsPersistedCanonicalRunHistory() async throws {
+  let fixtureDirectory = FileManager.default.temporaryDirectory
+    .appending(path: "codevetter-runs-\(UUID().uuidString)")
+  try FileManager.default.createDirectory(at: fixtureDirectory, withIntermediateDirectories: true)
+  defer { try? FileManager.default.removeItem(at: fixtureDirectory) }
+
+  let executable = fixtureDirectory.appending(path: "codevetter")
+  let history = #"""
+    {
+      "schema_version": "codevetter.run-history/v1",
+      "generated_at": "2026-08-31T00:00:02Z",
+      "repo_path": null,
+      "limit": 12,
+      "returned": 4,
+      "runs": [
+        {
+          "schema_version": "codevetter.run-record/v1",
+          "id": "synthetic-fixture",
+          "kind": "synthetic_qa",
+          "repo_path": "/fixture/repo",
+          "recorded_at": "2026-08-31T00:00:03Z",
+          "title": "Verify the review flow",
+          "outcome": "failed",
+          "receipt_schema": "codevetter.synthetic-qa-run/v1",
+          "source_label": "playwright_builtin",
+          "limitations": ["Expected evidence was missing"],
+          "receipt": {
+            "schema_version": "codevetter.synthetic-qa-run/v1",
+            "artifacts": ["trace.zip", "failure.png"],
+            "pass": false
+          }
+        },
+        {
+          "schema_version": "codevetter.run-record/v1",
+          "id": "audience-fixture",
+          "kind": "audience_validation",
+          "repo_path": "/fixture/repo",
+          "recorded_at": "2026-08-31T00:00:02Z",
+          "title": "Compare the evidence",
+          "outcome": "complete",
+          "receipt_schema": "codevetter.audience-validation-run/v1",
+          "source_label": "maintainers",
+          "limitations": [],
+          "receipt": {
+            "schema_version": "codevetter.audience-validation-run/v1",
+            "responses": [{
+              "id": "response-fixture",
+              "participant_id": "maintainer-1",
+              "provenance": "human",
+              "criterion": "correctness",
+              "preferred_candidate": "a",
+              "confidence": 0.9,
+              "task_passed": true,
+              "feedback": "The receipt is inspectable.",
+              "created_at": "2026-08-31T00:00:02Z"
+            }]
+          }
+        },
+        {
+          "schema_version": "codevetter.run-record/v1",
+          "id": "preview-fixture",
+          "kind": "preview",
+          "repo_path": "/fixture/repo",
+          "recorded_at": "2026-08-31T00:00:01Z",
+          "title": "Preview journey",
+          "outcome": "no_confidence",
+          "receipt_schema": "codevetter.trex-preview/v1",
+          "source_label": "cccccccccccc",
+          "limitations": ["No browser evidence"],
+          "receipt": {"schema_version": 1, "verdict": "no_confidence"}
+        },
+        {
+          "schema_version": "codevetter.run-record/v1",
+          "id": "local-check-fixture",
+          "kind": "local_check",
+          "repo_path": "/fixture/repo",
+          "recorded_at": "2026-08-31T00:00:00Z",
+          "title": "Persist evidence",
+          "outcome": "passed_with_limits",
+          "receipt_schema": "codevetter.local-check/v1",
+          "source_label": "bbbbbbbbbbbb",
+          "limitations": ["Fixture limitation"],
+          "receipt": {
+            "schema_version": "codevetter.local-check/v1",
+            "run_id": "local-check-fixture",
+            "ran_at": "2026-08-31T00:00:00Z",
+            "repo_path": "/fixture/repo",
+            "task": "Persist evidence",
+            "source": {
+              "kind": "range",
+              "input": "main...HEAD",
+              "base_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              "head_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+              "changed_paths": ["src/main.rs"]
+            },
+            "stages": {"correctness": {"status": "passed"}},
+            "verdict": "passed_with_limits",
+            "limitations": ["Fixture limitation"]
+          }
+        }
+      ]
+    }
+    """#
+  try "#!/bin/sh\nprintf '%s\\n' '\(history)'\n".write(
+    to: executable,
+    atomically: true,
+    encoding: .utf8
+  )
+  try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+
+  let runs = try await CodeVetterProcessRunner(executableURL: executable).listRuns(limit: 12)
+  #expect(runs.count == 4)
+  #expect(runs[0].id == "synthetic-fixture")
+  #expect(runs[0].artifacts == ["trace.zip", "failure.png"])
+  #expect(runs[1].kind == "audience_validation")
+  #expect(runs[1].audienceResponses.first?.participantID == "maintainer-1")
+  #expect(runs[1].audienceResponses.first?.taskPassed == true)
+  #expect(runs[2].id == "preview-fixture")
+  #expect(runs[2].localCheckReceipt == nil)
+  #expect(runs[2].limitations == ["No browser evidence"])
+  #expect(runs[3].outcome == "passed_with_limits")
+  #expect(runs[3].kind == "local_check")
+  #expect(runs[3].localCheckReceipt?.verdict == "passed_with_limits")
+  #expect(runs[3].rawJSON.contains("\"stages\""))
+}
+
+@MainActor
+@Test
+func runLedgerSelectionMovesWithinTheBoundedHistory() throws {
+  let history = #"""
+    {
+      "schema_version": "codevetter.run-history/v1",
+      "runs": [
+        {"id":"one","kind":"preview","repo_path":"/repo","recorded_at":"3","title":"One","outcome":"passed","receipt_schema":"one/v1","source_label":null,"limitations":[],"receipt":{}},
+        {"id":"two","kind":"preview","repo_path":"/repo","recorded_at":"2","title":"Two","outcome":"passed","receipt_schema":"two/v1","source_label":null,"limitations":[],"receipt":{}},
+        {"id":"three","kind":"preview","repo_path":"/repo","recorded_at":"1","title":"Three","outcome":"passed","receipt_schema":"three/v1","source_label":null,"limitations":[],"receipt":{}}
+      ]
+    }
+    """#
+  let model = WorkbenchModel()
+  model.runs = try CodeVetterProcessRunner.decodeRunHistory(Data(history.utf8))
+  model.selectedRunID = "one"
+
+  model.moveRunSelection(by: 1)
+  #expect(model.selectedRunID == "two")
+  #expect(model.selectedRunPosition == "2 of 3")
+  model.moveRunSelection(by: 20)
+  #expect(model.selectedRunID == "three")
+  model.moveRunSelection(by: -20)
+  #expect(model.selectedRunID == "one")
+}
+
+@Test
+func runLedgerExportPreservesTheSelectedCanonicalReceipt() throws {
+  let history = #"""
+    {
+      "schema_version": "codevetter.run-history/v1",
+      "runs": [
+        {"id":"export","kind":"synthetic_qa","repo_path":"/repo","recorded_at":"1","title":"Export","outcome":"failed","receipt_schema":"codevetter.synthetic-qa-run/v1","source_label":"fixture","limitations":["bounded"],"receipt":{"schema_version":"codevetter.synthetic-qa-run/v1","pass":false,"artifacts":["failure.png"]}}
+      ]
+    }
+    """#
+  let run = try #require(
+    CodeVetterProcessRunner.decodeRunHistory(Data(history.utf8)).first)
+  let destination = FileManager.default.temporaryDirectory
+    .appending(path: "codevetter-export-\(UUID().uuidString).json")
+  defer { try? FileManager.default.removeItem(at: destination) }
+
+  try run.exportCanonicalReceipt(to: destination)
+
+  let exported = try String(contentsOf: destination, encoding: .utf8)
+  #expect(exported == "\(run.rawJSON)\n")
+  let object = try #require(
+    JSONSerialization.jsonObject(with: Data(exported.utf8)) as? [String: Any])
+  #expect(object["schema_version"] as? String == "codevetter.synthetic-qa-run/v1")
+}
+
+@MainActor
+@Test
+func hundredRunLedgerDecodesAndRendersWithinTheNativeGate() throws {
+  let responseRows: [[String: Any]] = (0..<100).map { index in
+    [
+      "id": "response-\(index)",
+      "participant_id": "participant-\(index)",
+      "provenance": "human",
+      "criterion": "correctness",
+      "preferred_candidate": index.isMultiple(of: 2) ? "a" : "b",
+      "confidence": 0.9,
+      "task_passed": true,
+      "feedback": "Inspectable response \(index)",
+      "created_at": "2026-08-31T00:00:00Z",
+    ]
+  }
+  let runRows: [[String: Any]] = (0..<100).map { index in
+    let audience = index == 0
+    return [
+      "schema_version": "codevetter.run-record/v1",
+      "id": "run-\(index)",
+      "kind": audience ? "audience_validation" : "preview",
+      "repo_path": "/fixture/repo",
+      "recorded_at": String(format: "2026-08-31T00:%02d:%02dZ", index / 60, index % 60),
+      "title": audience ? "Audience evidence" : "Preview \(index)",
+      "outcome": audience ? "complete" : "passed_with_limits",
+      "receipt_schema": audience
+        ? "codevetter.audience-validation-run/v1" : "codevetter.trex-preview/v1",
+      "source_label": audience ? "maintainers" : "fixture",
+      "limitations": [],
+      "receipt": audience
+        ? [
+          "schema_version": "codevetter.audience-validation-run/v1",
+          "responses": responseRows,
+        ]
+        : ["schema_version": 1, "limitations": []],
+    ]
+  }
+  let payload = try JSONSerialization.data(withJSONObject: [
+    "schema_version": "codevetter.run-history/v1",
+    "generated_at": "2026-08-31T00:00:00Z",
+    "repo_path": NSNull(),
+    "limit": 100,
+    "returned": 100,
+    "runs": runRows,
+  ])
+
+  for _ in 0..<10 {
+    _ = try CodeVetterProcessRunner.decodeRunHistory(payload)
+  }
+  var decodeSamples = [UInt64]()
+  for _ in 0..<100 {
+    let started = DispatchTime.now().uptimeNanoseconds
+    _ = try CodeVetterProcessRunner.decodeRunHistory(payload)
+    decodeSamples.append((DispatchTime.now().uptimeNanoseconds - started) / 1_000)
+  }
+  let runs = try CodeVetterProcessRunner.decodeRunHistory(payload)
+  let model = WorkbenchModel()
+  model.section = .runs
+  model.runs = runs
+  model.selectedRunID = runs.first?.id
+
+  for _ in 0..<3 {
+    renderLedger(model)
+  }
+  var renderSamples = [UInt64]()
+  for _ in 0..<20 {
+    let started = DispatchTime.now().uptimeNanoseconds
+    renderLedger(model)
+    renderSamples.append((DispatchTime.now().uptimeNanoseconds - started) / 1_000)
+  }
+
+  let decodeP95 = percentile95(decodeSamples)
+  let renderP95 = percentile95(renderSamples)
+  #expect(decodeP95 < 25_000, "100-run decoding must stay below 25 ms p95")
+  #expect(renderP95 < 150_000, "100-run/100-response host rendering must stay below 150 ms p95")
+  print(
+    "NATIVE_RUN_LEDGER_BENCHMARK_JSON "
+      + "{\"decode_p95_us\":\(decodeP95),\"render_p95_us\":\(renderP95),"
+      + "\"runs\":100,\"selected_responses\":100,\"decode_samples\":100,\"render_samples\":20}"
+  )
+  if let screenshotPath = ProcessInfo.processInfo.environment[
+    "CODEVETTER_RUNS_SCREENSHOT_PATH"
+  ] {
+    try captureLedger(model, at: URL(fileURLWithPath: screenshotPath))
+  }
+  if let screenshotPath = ProcessInfo.processInfo.environment[
+    "CODEVETTER_RUNS_LIGHT_SCREENSHOT_PATH"
+  ] {
+    try captureLedger(
+      model,
+      at: URL(fileURLWithPath: screenshotPath),
+      appearance: .aqua
+    )
+  }
+}
+
+@MainActor
+func renderLedger(_ model: WorkbenchModel) {
+  autoreleasepool {
+    let host = NSHostingView(rootView: PremiumWorkbenchRootView(model: model))
+    host.frame = NSRect(x: 0, y: 0, width: 1_280, height: 800)
+    host.layoutSubtreeIfNeeded()
+    host.displayIfNeeded()
+  }
+}
+
+@MainActor
+func renderCapabilities(_ model: WorkbenchModel) {
+  autoreleasepool {
+    let host = NSHostingView(rootView: PremiumWorkbenchRootView(model: model))
+    host.appearance = NSAppearance(named: .darkAqua)
+    host.frame = NSRect(x: 0, y: 0, width: 1_280, height: 800)
+    host.layoutSubtreeIfNeeded()
+    host.displayIfNeeded()
+  }
+}
+
+@MainActor
+func captureCapabilities(_ model: WorkbenchModel, at destination: URL) throws {
+  let host = NSHostingView(rootView: PremiumWorkbenchRootView(model: model))
+  host.appearance = NSAppearance(named: .darkAqua)
+  host.frame = NSRect(x: 0, y: 0, width: 1_280, height: 800)
+  for _ in 0..<3 {
+    host.layoutSubtreeIfNeeded()
+    host.displayIfNeeded()
+    RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.03))
+  }
+  try captureHost(host, at: destination)
+}
+
+@MainActor
+func captureLedger(
+  _ model: WorkbenchModel,
+  at destination: URL,
+  appearance: NSAppearance.Name = .darkAqua
+) throws {
+  let host = NSHostingView(rootView: PremiumWorkbenchRootView(model: model))
+  host.appearance = NSAppearance(named: appearance)
+  host.frame = NSRect(x: 0, y: 0, width: 1_280, height: 800)
+  for _ in 0..<3 {
+    host.layoutSubtreeIfNeeded()
+    host.displayIfNeeded()
+    RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.03))
+  }
+  try captureHost(host, at: destination)
+}
+
+@MainActor
+func renderReview(_ model: WorkbenchModel) {
+  autoreleasepool {
+    let host = NSHostingView(rootView: PremiumWorkbenchRootView(model: model))
+    host.frame = NSRect(x: 0, y: 0, width: 1_280, height: 800)
+    host.layoutSubtreeIfNeeded()
+    _ = host.fittingSize
+  }
+}
+
+@MainActor
+func renderReviewProof(_ evidence: PerformanceJSONValue) {
+  autoreleasepool {
+    let host = NSHostingView(rootView: ReviewProofMapView(evidence: evidence))
+    host.appearance = NSAppearance(named: .darkAqua)
+    host.frame = NSRect(x: 0, y: 0, width: 760, height: 800)
+    host.layoutSubtreeIfNeeded()
+    host.displayIfNeeded()
+  }
+}
+
+@MainActor
+func renderReviewIntent(_ evidence: PerformanceJSONValue) {
+  autoreleasepool {
+    let host = NSHostingView(
+      rootView: ReviewIntentDiagnosticView(evidence: evidence, onVerifyInTesting: {})
+    )
+    host.appearance = NSAppearance(named: .darkAqua)
+    host.frame = NSRect(x: 0, y: 0, width: 760, height: 800)
+    host.layoutSubtreeIfNeeded()
+    host.displayIfNeeded()
+  }
+}
+
+@MainActor
+func renderXray(_ model: WorkbenchModel, receipt: VerificationReceipt) {
+  autoreleasepool {
+    let host = NSHostingView(rootView: XrayExportView(model: model, receipt: receipt))
+    host.appearance = NSAppearance(named: .darkAqua)
+    host.frame = NSRect(x: 0, y: 0, width: 860, height: 640)
+    host.layoutSubtreeIfNeeded()
+    host.displayIfNeeded()
+  }
+}
+
+@MainActor
+func renderFixPacket(_ model: WorkbenchModel, receipt: VerificationReceipt) {
+  autoreleasepool {
+    let host = NSHostingView(rootView: AgentFixPacketView(model: model, receipt: receipt))
+    host.appearance = NSAppearance(named: .darkAqua)
+    host.frame = NSRect(x: 0, y: 0, width: 860, height: 640)
+    host.layoutSubtreeIfNeeded()
+    host.displayIfNeeded()
+  }
+}
+
+@MainActor
+func renderTesting(_ model: WorkbenchModel) {
+  autoreleasepool {
+    let host = NSHostingView(rootView: PremiumWorkbenchRootView(model: model))
+    host.appearance = NSAppearance(named: .darkAqua)
+    host.frame = NSRect(x: 0, y: 0, width: 980, height: 640)
+    host.layoutSubtreeIfNeeded()
+    host.displayIfNeeded()
+  }
+}
+
+@MainActor
+func renderWarmVerification(_ model: WorkbenchModel) {
+  autoreleasepool {
+    let host = NSHostingView(rootView: PremiumWarmVerificationView(model: model))
+    host.appearance = NSAppearance(named: .darkAqua)
+    host.frame = NSRect(x: 0, y: 0, width: 1_100, height: 720)
+    host.layoutSubtreeIfNeeded()
+    host.displayIfNeeded()
+  }
+}
+
+@MainActor
+func renderDifferential(_ model: WorkbenchModel) {
+  autoreleasepool {
+    let host = NSHostingView(rootView: PremiumDifferentialVerificationView(model: model))
+    host.appearance = NSAppearance(named: .darkAqua)
+    host.frame = NSRect(x: 0, y: 0, width: 1_100, height: 720)
+    host.layoutSubtreeIfNeeded()
+    host.displayIfNeeded()
+  }
+}
+
+@MainActor
+func renderScenarioCompiler(_ model: WorkbenchModel) {
+  autoreleasepool {
+    let host = NSHostingView(rootView: PremiumScenarioCompilerView(model: model))
+    host.appearance = NSAppearance(named: .darkAqua)
+    host.frame = NSRect(x: 0, y: 0, width: 1_180, height: 760)
+    host.layoutSubtreeIfNeeded()
+    host.displayIfNeeded()
+  }
+}
+
+@MainActor
+func renderTrexWatcher(_ model: WorkbenchModel) {
+  autoreleasepool {
+    let host = NSHostingView(rootView: PremiumTrexWatcherView(model: model))
+    host.appearance = NSAppearance(named: .darkAqua)
+    host.frame = NSRect(x: 0, y: 0, width: 1_180, height: 760)
+    host.layoutSubtreeIfNeeded()
+    host.displayIfNeeded()
+  }
+}
+
+@MainActor
+func renderPerformance(_ model: WorkbenchModel) {
+  autoreleasepool {
+    let host = NSHostingView(rootView: PremiumWorkbenchRootView(model: model))
+    host.appearance = NSAppearance(named: .darkAqua)
+    host.frame = NSRect(x: 0, y: 0, width: 980, height: 640)
+    host.layoutSubtreeIfNeeded()
+    host.displayIfNeeded()
+  }
+}
+
+@MainActor
+func renderUsage(_ model: WorkbenchModel) {
+  autoreleasepool {
+    let host = NSHostingView(rootView: PremiumWorkbenchRootView(model: model))
+    host.appearance = NSAppearance(named: .darkAqua)
+    host.frame = NSRect(x: 0, y: 0, width: 980, height: 640)
+    host.layoutSubtreeIfNeeded()
+    host.displayIfNeeded()
+  }
+}
+
+@MainActor
+func renderUnpack(_ model: WorkbenchModel) {
+  autoreleasepool {
+    let host = NSHostingView(rootView: PremiumWorkbenchRootView(model: model))
+    host.appearance = NSAppearance(named: .darkAqua)
+    host.frame = NSRect(x: 0, y: 0, width: 1_280, height: 800)
+    host.layoutSubtreeIfNeeded()
+    host.displayIfNeeded()
+  }
+}
+
+@MainActor
+func renderUnpackQuery(_ model: WorkbenchModel) {
+  autoreleasepool {
+    let host = NSHostingView(
+      rootView: PremiumUnpackView(model: model, startsInQueryDesk: true)
+        .preferredColorScheme(.dark))
+    host.appearance = NSAppearance(named: .darkAqua)
+    host.frame = NSRect(x: 0, y: 0, width: 1_520, height: 980)
+    host.layoutSubtreeIfNeeded()
+    host.displayIfNeeded()
+  }
+}
+
+@MainActor
+func renderSettings(_ model: WorkbenchModel) {
+  autoreleasepool {
+    let host = NSHostingView(rootView: PremiumWorkbenchRootView(model: model))
+    host.appearance = NSAppearance(named: .darkAqua)
+    host.frame = NSRect(x: 0, y: 0, width: 1_280, height: 800)
+    host.layoutSubtreeIfNeeded()
+    host.displayIfNeeded()
+  }
+}
+
+@MainActor
+func captureSettings(
+  _ model: WorkbenchModel,
+  at destination: URL,
+  appearance: NSAppearance.Name
+) throws {
+  let host = NSHostingView(rootView: PremiumWorkbenchRootView(model: model))
+  host.appearance = NSAppearance(named: appearance)
+  host.frame = NSRect(x: 0, y: 0, width: 1_280, height: 800)
+  host.layoutSubtreeIfNeeded()
+  host.displayIfNeeded()
+  guard let bitmap = host.bitmapImageRepForCachingDisplay(in: host.bounds) else {
+    throw CocoaError(.fileWriteUnknown)
+  }
+  host.cacheDisplay(in: host.bounds, to: bitmap)
+  guard let data = bitmap.representation(using: .png, properties: [:]) else {
+    throw CocoaError(.fileWriteUnknown)
+  }
+  try data.write(to: destination, options: .atomic)
+}
+
+@MainActor
+func captureHost<Content: View>(_ host: NSHostingView<Content>, at destination: URL) throws
+{
+  guard let bitmap = host.bitmapImageRepForCachingDisplay(in: host.bounds) else {
+    throw CocoaError(.fileWriteUnknown)
+  }
+  host.cacheDisplay(in: host.bounds, to: bitmap)
+  guard let data = bitmap.representation(using: .png, properties: [:]) else {
+    throw CocoaError(.fileWriteUnknown)
+  }
+  try data.write(to: destination, options: .atomic)
+}
+
+@MainActor
+func captureUnpack(
+  _ model: WorkbenchModel,
+  at destination: URL,
+  appearance: NSAppearance.Name
+) throws {
+  let host = NSHostingView(rootView: PremiumWorkbenchRootView(model: model))
+  host.appearance = NSAppearance(named: appearance)
+  host.frame = NSRect(x: 0, y: 0, width: 1_280, height: 800)
+  host.layoutSubtreeIfNeeded()
+  host.displayIfNeeded()
+  guard let bitmap = host.bitmapImageRepForCachingDisplay(in: host.bounds) else {
+    throw CocoaError(.fileWriteUnknown)
+  }
+  host.cacheDisplay(in: host.bounds, to: bitmap)
+  guard let data = bitmap.representation(using: .png, properties: [:]) else {
+    throw CocoaError(.fileWriteUnknown)
+  }
+  try data.write(to: destination, options: .atomic)
+}
+
+@MainActor
+func captureUnpackQuery(
+  _ model: WorkbenchModel,
+  at destination: URL,
+  appearance: NSAppearance.Name
+) throws {
+  let host = NSHostingView(
+    rootView: PremiumUnpackView(model: model, startsInQueryDesk: true)
+      .preferredColorScheme(appearance == .darkAqua ? .dark : .light))
+  host.appearance = NSAppearance(named: appearance)
+  host.frame = NSRect(x: 0, y: 0, width: 1_520, height: 980)
+  host.layoutSubtreeIfNeeded()
+  host.displayIfNeeded()
+  guard let bitmap = host.bitmapImageRepForCachingDisplay(in: host.bounds) else {
+    throw CocoaError(.fileWriteUnknown)
+  }
+  host.cacheDisplay(in: host.bounds, to: bitmap)
+  guard let data = bitmap.representation(using: .png, properties: [:]) else {
+    throw CocoaError(.fileWriteUnknown)
+  }
+  try data.write(to: destination, options: .atomic)
+}
+
+@MainActor
+func captureUsage(
+  _ model: WorkbenchModel,
+  at destination: URL,
+  appearance: NSAppearance.Name
+) throws {
+  let host = NSHostingView(rootView: PremiumWorkbenchRootView(model: model))
+  host.appearance = NSAppearance(named: appearance)
+  host.frame = NSRect(x: 0, y: 0, width: 1_280, height: 800)
+  host.layoutSubtreeIfNeeded()
+  host.displayIfNeeded()
+  guard let bitmap = host.bitmapImageRepForCachingDisplay(in: host.bounds) else {
+    throw CocoaError(.fileWriteUnknown)
+  }
+  host.cacheDisplay(in: host.bounds, to: bitmap)
+  guard let data = bitmap.representation(using: .png, properties: [:]) else {
+    throw CocoaError(.fileWriteUnknown)
+  }
+  try data.write(to: destination, options: .atomic)
+}
+
+@MainActor
+func capturePerformance(
+  _ model: WorkbenchModel,
+  at destination: URL,
+  appearance: NSAppearance.Name = .darkAqua
+) throws {
+  let host = NSHostingView(rootView: PremiumWorkbenchRootView(model: model))
+  host.appearance = NSAppearance(named: appearance)
+  host.frame = NSRect(x: 0, y: 0, width: 980, height: 640)
+  host.layoutSubtreeIfNeeded()
+  host.displayIfNeeded()
+  guard let bitmap = host.bitmapImageRepForCachingDisplay(in: host.bounds) else {
+    throw CocoaError(.fileWriteUnknown)
+  }
+  host.cacheDisplay(in: host.bounds, to: bitmap)
+  guard let data = bitmap.representation(using: .png, properties: [:]) else {
+    throw CocoaError(.fileWriteUnknown)
+  }
+  try data.write(to: destination, options: .atomic)
+}
+
+@MainActor
+func captureReview(
+  _ model: WorkbenchModel,
+  at destination: URL,
+  appearance: NSAppearance.Name = .darkAqua
+) throws {
+  let host = NSHostingView(rootView: PremiumWorkbenchRootView(model: model))
+  host.appearance = NSAppearance(named: appearance)
+  host.frame = NSRect(x: 0, y: 0, width: 1_280, height: 800)
+  host.layoutSubtreeIfNeeded()
+  host.displayIfNeeded()
+  guard let bitmap = host.bitmapImageRepForCachingDisplay(in: host.bounds) else {
+    throw CocoaError(.fileWriteUnknown)
+  }
+  host.cacheDisplay(in: host.bounds, to: bitmap)
+  guard let data = bitmap.representation(using: .png, properties: [:]) else {
+    throw CocoaError(.fileWriteUnknown)
+  }
+  try data.write(to: destination, options: .atomic)
+}
+
+@MainActor
+func captureReviewProof(_ evidence: PerformanceJSONValue, at destination: URL) throws {
+  let host = NSHostingView(rootView: ReviewProofMapView(evidence: evidence))
+  host.appearance = NSAppearance(named: .darkAqua)
+  host.frame = NSRect(x: 0, y: 0, width: 760, height: 800)
+  host.layoutSubtreeIfNeeded()
+  host.displayIfNeeded()
+  guard let bitmap = host.bitmapImageRepForCachingDisplay(in: host.bounds) else {
+    throw CocoaError(.fileWriteUnknown)
+  }
+  host.cacheDisplay(in: host.bounds, to: bitmap)
+  guard let data = bitmap.representation(using: .png, properties: [:]) else {
+    throw CocoaError(.fileWriteUnknown)
+  }
+  try data.write(to: destination, options: .atomic)
+}
+
+@MainActor
+func captureReviewIntent(_ evidence: PerformanceJSONValue, at destination: URL) throws {
+  let host = NSHostingView(
+    rootView: ReviewIntentDiagnosticView(evidence: evidence, onVerifyInTesting: {})
+  )
+  host.appearance = NSAppearance(named: .darkAqua)
+  host.frame = NSRect(x: 0, y: 0, width: 760, height: 800)
+  host.layoutSubtreeIfNeeded()
+  host.displayIfNeeded()
+  guard let bitmap = host.bitmapImageRepForCachingDisplay(in: host.bounds) else {
+    throw CocoaError(.fileWriteUnknown)
+  }
+  host.cacheDisplay(in: host.bounds, to: bitmap)
+  guard let data = bitmap.representation(using: .png, properties: [:]) else {
+    throw CocoaError(.fileWriteUnknown)
+  }
+  try data.write(to: destination, options: .atomic)
+}
+
+@MainActor
+func captureXray(
+  _ model: WorkbenchModel,
+  receipt: VerificationReceipt,
+  at destination: URL
+) throws {
+  let host = NSHostingView(rootView: XrayExportView(model: model, receipt: receipt))
+  host.appearance = NSAppearance(named: .darkAqua)
+  host.frame = NSRect(x: 0, y: 0, width: 860, height: 640)
+  host.layoutSubtreeIfNeeded()
+  host.displayIfNeeded()
+  guard let bitmap = host.bitmapImageRepForCachingDisplay(in: host.bounds) else {
+    throw CocoaError(.fileWriteUnknown)
+  }
+  host.cacheDisplay(in: host.bounds, to: bitmap)
+  guard let data = bitmap.representation(using: .png, properties: [:]) else {
+    throw CocoaError(.fileWriteUnknown)
+  }
+  try data.write(to: destination, options: .atomic)
+}
+
+@MainActor
+func captureFixPacket(
+  _ model: WorkbenchModel,
+  receipt: VerificationReceipt,
+  at destination: URL
+) throws {
+  let host = NSHostingView(rootView: AgentFixPacketView(model: model, receipt: receipt))
+  host.appearance = NSAppearance(named: .darkAqua)
+  host.frame = NSRect(x: 0, y: 0, width: 860, height: 640)
+  host.layoutSubtreeIfNeeded()
+  host.displayIfNeeded()
+  guard let bitmap = host.bitmapImageRepForCachingDisplay(in: host.bounds) else {
+    throw CocoaError(.fileWriteUnknown)
+  }
+  host.cacheDisplay(in: host.bounds, to: bitmap)
+  guard let data = bitmap.representation(using: .png, properties: [:]) else {
+    throw CocoaError(.fileWriteUnknown)
+  }
+  try data.write(to: destination, options: .atomic)
+}
+
+@MainActor
+func captureTesting(
+  _ model: WorkbenchModel,
+  at destination: URL,
+  appearance: NSAppearance.Name = .darkAqua
+) throws {
+  let host = NSHostingView(rootView: PremiumWorkbenchRootView(model: model))
+  host.appearance = NSAppearance(named: appearance)
+  host.frame = NSRect(x: 0, y: 0, width: 980, height: 640)
+  host.layoutSubtreeIfNeeded()
+  host.displayIfNeeded()
+  guard let bitmap = host.bitmapImageRepForCachingDisplay(in: host.bounds) else {
+    throw CocoaError(.fileWriteUnknown)
+  }
+  host.cacheDisplay(in: host.bounds, to: bitmap)
+  guard let data = bitmap.representation(using: .png, properties: [:]) else {
+    throw CocoaError(.fileWriteUnknown)
+  }
+  try data.write(to: destination, options: .atomic)
+}
+
+@MainActor
+func captureQaWorkspace(_ model: WorkbenchModel, at destination: URL) throws {
+  let host = NSHostingView(rootView: QaJourneyWorkspaceView(model: model))
+  host.appearance = NSAppearance(named: .darkAqua)
+  host.frame = NSRect(x: 0, y: 0, width: 1_180, height: 760)
+  host.layoutSubtreeIfNeeded()
+  host.displayIfNeeded()
+  guard let bitmap = host.bitmapImageRepForCachingDisplay(in: host.bounds) else {
+    throw CocoaError(.fileWriteUnknown)
+  }
+  host.cacheDisplay(in: host.bounds, to: bitmap)
+  guard let data = bitmap.representation(using: .png, properties: [:]) else {
+    throw CocoaError(.fileWriteUnknown)
+  }
+  try data.write(to: destination, options: .atomic)
+}
+
+@MainActor
+func captureWarmVerification(_ model: WorkbenchModel, at destination: URL) throws {
+  let host = NSHostingView(rootView: PremiumWarmVerificationView(model: model))
+  host.appearance = NSAppearance(named: .darkAqua)
+  host.frame = NSRect(x: 0, y: 0, width: 1_100, height: 720)
+  host.layoutSubtreeIfNeeded()
+  host.displayIfNeeded()
+  guard let bitmap = host.bitmapImageRepForCachingDisplay(in: host.bounds) else {
+    throw CocoaError(.fileWriteUnknown)
+  }
+  host.cacheDisplay(in: host.bounds, to: bitmap)
+  guard let data = bitmap.representation(using: .png, properties: [:]) else {
+    throw CocoaError(.fileWriteUnknown)
+  }
+  try data.write(to: destination, options: .atomic)
+}
+
+@MainActor
+func captureDifferential(_ model: WorkbenchModel, at destination: URL) throws {
+  let host = NSHostingView(rootView: PremiumDifferentialVerificationView(model: model))
+  host.appearance = NSAppearance(named: .darkAqua)
+  host.frame = NSRect(x: 0, y: 0, width: 1_100, height: 720)
+  host.layoutSubtreeIfNeeded()
+  host.displayIfNeeded()
+  guard let bitmap = host.bitmapImageRepForCachingDisplay(in: host.bounds) else {
+    throw CocoaError(.fileWriteUnknown)
+  }
+  host.cacheDisplay(in: host.bounds, to: bitmap)
+  guard let data = bitmap.representation(using: .png, properties: [:]) else {
+    throw CocoaError(.fileWriteUnknown)
+  }
+  try data.write(to: destination, options: .atomic)
+}
+
+@MainActor
+func captureScenarioCompiler(_ model: WorkbenchModel, at destination: URL) throws {
+  let host = NSHostingView(rootView: PremiumScenarioCompilerView(model: model))
+  host.appearance = NSAppearance(named: .darkAqua)
+  host.frame = NSRect(x: 0, y: 0, width: 1_180, height: 760)
+  host.layoutSubtreeIfNeeded()
+  host.displayIfNeeded()
+  guard let bitmap = host.bitmapImageRepForCachingDisplay(in: host.bounds) else {
+    throw CocoaError(.fileWriteUnknown)
+  }
+  host.cacheDisplay(in: host.bounds, to: bitmap)
+  guard let data = bitmap.representation(using: .png, properties: [:]) else {
+    throw CocoaError(.fileWriteUnknown)
+  }
+  try data.write(to: destination, options: .atomic)
+}
+
+@MainActor
+func captureTrexWatcher(_ model: WorkbenchModel, at destination: URL) throws {
+  let host = NSHostingView(rootView: PremiumTrexWatcherView(model: model))
+  host.appearance = NSAppearance(named: .darkAqua)
+  host.frame = NSRect(x: 0, y: 0, width: 1_180, height: 760)
+  host.layoutSubtreeIfNeeded()
+  host.displayIfNeeded()
+  guard let bitmap = host.bitmapImageRepForCachingDisplay(in: host.bounds) else {
+    throw CocoaError(.fileWriteUnknown)
+  }
+  host.cacheDisplay(in: host.bounds, to: bitmap)
+  guard let data = bitmap.representation(using: .png, properties: [:]) else {
+    throw CocoaError(.fileWriteUnknown)
+  }
+  try data.write(to: destination, options: .atomic)
+}
+
+func percentile95(_ values: [UInt64]) -> UInt64 {
+  precondition(!values.isEmpty)
+  let ordered = values.sorted()
+  let nearestRank = Int(ceil(Double(ordered.count) * 0.95))
+  return ordered[min(max(nearestRank - 1, 0), ordered.count - 1)]
+}
+
+func unpackFixturePayload(
+  snapshotCount: Int,
+  nodeCount: Int,
+  rootChildren: Int
+) throws -> (history: Data, record: Data) {
+  let summaries: [[String: Any]] = (0..<snapshotCount).map { index in
+    [
+      "id": "snapshot-\(index)",
+      "repo_path": "/fixture/repo",
+      "repo_name": "CodeVetter",
+      "commit_sha": String(repeating: String(index % 10), count: 40),
+      "status": "scan_only",
+      "error_message": NSNull(),
+      "agent_used": NSNull(),
+      "model_used": NSNull(),
+      "files_scanned": 1_037 + index,
+      "files_skipped": 80,
+      "runtime_ms": 420,
+      "cost_usd": NSNull(),
+      "started_at": "2026-08-31T00:00:00Z",
+      "completed_at": "2026-08-31T00:00:01Z",
+      "created_at": "2026-08-31T00:00:01Z",
+      "analysis_ready": false,
+    ]
+  }
+  let graphNodes: [[String: Any]] = (0..<nodeCount).map { index in
+    [
+      "id": "node-\(index)",
+      "kind": index.isMultiple(of: 4) ? "workspace" : "source",
+      "label": "Node \(index)",
+      "path": "Sources/Module\(index).swift",
+      "detail": "Bounded structural lead",
+      "sources": ["inventory"],
+    ]
+  }
+  let graphEdges: [[String: Any]] = (1..<nodeCount).map { index in
+    [
+      "from": "node-\(index - 1)",
+      "to": "node-\(index)",
+      "kind": "contains",
+      "evidence": "fixture",
+      "sources": ["inventory"],
+      "trust": "observed",
+    ]
+  }
+  let treeChildren: [[String: Any]] = (0..<rootChildren).map { index in
+    [
+      "name": "Module\(index)",
+      "path": "Sources/Module\(index)",
+      "is_dir": true,
+      "file_count": 1,
+      "children": [],
+    ]
+  }
+  let languages: [[String: Any]] = [
+    ["language": "TypeScript", "files": 540, "bytes": 7_000_000],
+    ["language": "Rust", "files": 290, "bytes": 4_000_000],
+    ["language": "Swift", "files": 120, "bytes": 1_000_000],
+  ]
+  let workspaceUnits: [[String: Any]] = [
+    [
+      "path": "apps/desktop",
+      "name": "Desktop",
+      "kind": "application",
+      "manifest_path": "apps/desktop/package.json",
+      "build_system": "Vite",
+      "file_count": 640,
+      "languages": [["language": "TypeScript", "files": 540, "bytes": 7_000_000]],
+      "scripts": ["test", "lint"],
+      "entrypoints": ["src/main.tsx"],
+      "test_files": ["tests/smoke.spec.ts"],
+      "tags": ["React", "Tauri"],
+    ]
+  ]
+  let recentCommits: [[String: Any]] = (0..<12).map { index in
+    [
+      "sha": String(repeating: String(index % 10), count: 40),
+      "date": "2026-08-31T00:00:00Z",
+      "subject": "Improve bounded native projection \(index)",
+      "files": ["Sources/Module\(index).swift"],
+    ]
+  }
+  let healthFiles: [[String: Any]] = (0..<8).map { index -> [String: Any] in
+    let score = 4.5 + Double(index) / 2
+    return [
+      "path": "Sources/Hotspot\(index).swift",
+      "score": score,
+      "bucket": "review",
+      "lines": 400 + index,
+      "bytes": 20_000 + index,
+      "churn": 10 + index,
+      "has_test_signal": index.isMultiple(of: 2),
+      "refactoring_targets": ["extract bounded projection"],
+    ]
+  }
+  let inventory: [String: Any] = [
+    "repo_path": "/fixture/repo",
+    "repo_name": "CodeVetter",
+    "commit_sha": String(repeating: "a", count: 40),
+    "branch": "feat/native-macos-evidence-workbench",
+    "files_scanned": 1_037,
+    "files_skipped": 80,
+    "bytes_scanned": 12_933_595,
+    "max_files_hit": false,
+    "languages": languages,
+    "manifests": [],
+    "entrypoints": [
+      ["path": "apps/desktop/src/main.tsx", "kind": "app", "reason": "Vite entrypoint"],
+      ["path": "apps/desktop/src-tauri/src/main.rs", "kind": "app", "reason": "Rust entrypoint"],
+    ],
+    "top_level_dirs": [],
+    "docs": [],
+    "config_files": ["package.json", "Cargo.toml"],
+    "stack_tags": ["Tauri", "React", "Rust", "Swift", "Playwright", "Vite", "GitHub Actions"],
+    "workspace_units": workspaceUnits,
+    "repo_graph": [
+      "schema_version": 1,
+      "nodes": graphNodes,
+      "edges": graphEdges,
+      "truncated": nodeCount >= 700,
+    ],
+    "history_brief": [
+      "summary": "Recent changes preserve the execution-backed verification boundary.",
+      "recent_commits": recentCommits,
+      "decisions": [
+        ["marker": "decision", "text": "Rust owns authority", "source": "docs/architecture"]
+      ],
+      "test_hints": [
+        ["path": "tests/native.swift", "reason": "Adjacent projection contract"]
+      ],
+      "sources": ["git"],
+      "truncated": true,
+    ],
+    "repo_health": [
+      "summary": "Deterministic review leads only.",
+      "average_score": 7.8,
+      "hotspot_count": 72,
+      "files_analyzed": 1_037,
+      "files_with_test_signal": 410,
+      "top_files": healthFiles,
+      "truncated": true,
+    ],
+    "coverage": [
+      "strategy": "bounded_projection",
+      "sampled_files": 1_037,
+      "total_files": 1_117,
+      "sample_percent": 92.8,
+      "notes": ["Raw file inventory withheld from the client."],
+    ],
+    "all_files_capped": true,
+    "dir_tree_preview": [
+      "name": "CodeVetter",
+      "path": "",
+      "is_dir": true,
+      "file_count": rootChildren,
+      "children": treeChildren,
+    ],
+  ]
+  let inventoryData = try JSONSerialization.data(withJSONObject: inventory)
+  let record: [String: Any] = summaries[0].merging([
+    "inventory_json": String(decoding: inventoryData, as: UTF8.self),
+    "report_json": NSNull(),
+    "bytes_scanned": 12_933_595,
+  ]) { _, replacement in replacement }
+  let history: [String: Any] = [
+    "schema_version": "codevetter.unpack-history/v1",
+    "generated_at": "2026-08-31T00:00:00Z",
+    "database_available": true,
+    "repo_path": "/fixture/repo",
+    "limit": min(snapshotCount, 100),
+    "returned": snapshotCount,
+    "reports": summaries,
+  ]
+  return (
+    history: try JSONSerialization.data(withJSONObject: history),
+    record: try JSONSerialization.data(withJSONObject: record)
+  )
+}
+
+func nativeSettingsFixtureReceipt(
+  savedKey: String? = nil,
+  reviewTone: String = "thorough"
+) throws -> Data {
+  let rows: [(String, String, String, String, String, String, [[String: String]])] = [
+    (
+      "review_tone", "general", "Default Review Tone", "Default tone for a new review.",
+      "choice", reviewTone,
+      [
+        ["value": "concise", "label": "Concise"],
+        ["value": "thorough", "label": "Thorough"],
+        ["value": "strict", "label": "Strict"],
+      ]
+    ),
+    (
+      "compact_mode", "appearance", "Compact Mode", "Use denser workbench spacing.",
+      "toggle", "false", []
+    ),
+    (
+      "show_line_numbers", "appearance", "Show Line Numbers", "Show source identities.",
+      "toggle", "true", []
+    ),
+    (
+      "show_costs", "appearance", "Show Costs", "Show observed local cost evidence.",
+      "toggle", "true", []
+    ),
+    (
+      "default_adapter", "agents", "Default Adapter", "Preferred coding-agent adapter.",
+      "choice", "claude-code",
+      [
+        ["value": "claude-code", "label": "Claude Code"],
+        ["value": "codex", "label": "Codex"],
+      ]
+    ),
+    (
+      "default_role", "agents", "Default Role", "Role assigned to a new launch.",
+      "choice", "coder", [["value": "coder", "label": "Coder"]]
+    ),
+    (
+      "max_concurrent_agents", "agents", "Max Concurrent Agents", "Bounded local concurrency.",
+      "choice", "3", [["value": "3", "label": "3"]]
+    ),
+    (
+      "claude_cli_path", "agents", "Claude Code CLI", "Optional explicit path.", "text", "",
+      []
+    ),
+    (
+      "codex_cli_path", "agents", "Codex CLI", "Optional explicit path.", "text", "", []
+    ),
+    (
+      "notify_review_done", "notifications", "Review Completed", "Notify on review completion.",
+      "toggle", "true", []
+    ),
+    (
+      "notify_agent_error", "notifications", "Agent Error", "Notify on terminal error.",
+      "toggle", "true", []
+    ),
+    (
+      "notify_task_complete", "notifications", "Task Completed", "Notify on task completion.",
+      "toggle", "false", []
+    ),
+    (
+      "notify_quota_thresholds", "notifications", "Provider Quota Thresholds",
+      "Observed provider-window telemetry only.", "toggle", "true", []
+    ),
+    (
+      "notify_session_usage_thresholds", "notifications", "Session Usage Thresholds",
+      "Indexed session estimates when enabled.", "toggle", "false", []
+    ),
+    (
+      "notification_sound", "notifications", "Notification Sounds", "Play a local tone.",
+      "toggle", "true", []
+    ),
+    (
+      "tray_refresh_cadence_secs", "notifications", "Menu Bar Refresh Cadence",
+      "Polling cadence for observed live usage.", "choice", "300",
+      [
+        ["value": "manual", "label": "Manual only"],
+        ["value": "300", "label": "Every 5 minutes"],
+      ]
+    ),
+    (
+      "native_agent_island_enabled", "agent_island", "Native Agent Island",
+      "Retain the opt-in native presentation preference.", "toggle", "false", []
+    ),
+    (
+      "native_agent_island_speech_muted", "agent_island", "Mute Voice Callouts",
+      "Keep visual status without speaking updates.", "toggle", "false", []
+    ),
+    (
+      "native_agent_island_speak_completion", "agent_island", "Speak Completions",
+      "Announce completed turns.", "toggle", "true", []
+    ),
+    (
+      "native_agent_island_speak_attention", "agent_island", "Speak Attention Requests",
+      "Announce confirmed questions and permissions.", "toggle", "true", []
+    ),
+    (
+      "native_agent_island_speak_failure", "agent_island", "Speak Failures",
+      "Announce failed owned sessions.", "toggle", "true", []
+    ),
+    (
+      "native_agent_island_speech_volume", "agent_island", "Voice Volume",
+      "Set local voice volume.", "choice", "0.8",
+      [
+        ["value": "0.5", "label": "Quiet"],
+        ["value": "0.8", "label": "Balanced"],
+        ["value": "1", "label": "Full"],
+      ]
+    ),
+    (
+      "native_agent_island_speech_rate", "agent_island", "Voice Pace",
+      "Choose a calm local speech rate.", "choice", "0.48",
+      [
+        ["value": "0.4", "label": "Measured"],
+        ["value": "0.48", "label": "Balanced"],
+        ["value": "0.56", "label": "Quick"],
+      ]
+    ),
+    (
+      "native_agent_island_speech_cooldown", "agent_island", "Repeat Cooldown",
+      "Coalesce repeated callouts.", "choice", "30",
+      [
+        ["value": "15", "label": "15 seconds"],
+        ["value": "30", "label": "30 seconds"],
+        ["value": "60", "label": "1 minute"],
+      ]
+    ),
+    (
+      "native_agent_island_quiet_start", "agent_island", "Quiet Hours Start",
+      "Optional local pause hour.", "choice", "",
+      [
+        ["value": "", "label": "Off"],
+        ["value": "20", "label": "8 PM"],
+        ["value": "21", "label": "9 PM"],
+        ["value": "22", "label": "10 PM"],
+        ["value": "23", "label": "11 PM"],
+      ]
+    ),
+    (
+      "native_agent_island_quiet_end", "agent_island", "Quiet Hours End",
+      "Optional local resume hour.", "choice", "",
+      [
+        ["value": "", "label": "Off"],
+        ["value": "6", "label": "6 AM"],
+        ["value": "7", "label": "7 AM"],
+        ["value": "8", "label": "8 AM"],
+        ["value": "9", "label": "9 AM"],
+      ]
+    ),
+    (
+      "native_agent_island_codex_voice", "agent_island", "Codex Voice",
+      "Optional macOS voice identifier.", "text", "", []
+    ),
+    (
+      "native_agent_island_claude_voice", "agent_island", "Claude Voice",
+      "Optional macOS voice identifier.", "text", "", []
+    ),
+  ]
+  let settings: [[String: Any]] = rows.map { row in
+    [
+      "key": row.0,
+      "section": row.1,
+      "label": row.2,
+      "description": row.3,
+      "kind": row.4,
+      "value": row.5,
+      "default_value": row.5,
+      "options": row.6,
+    ]
+  }
+  let savedKeyValue: Any = savedKey.map { $0 as Any } ?? NSNull()
+  return try JSONSerialization.data(withJSONObject: [
+    "schema_version": "codevetter.native-settings/v1",
+    "generated_at": "2026-09-01T00:00:00Z",
+    "database_available": true,
+    "saved_key": savedKeyValue,
+    "settings": settings,
+    "excluded_sensitive_keys": ["github_token"],
+  ])
+}
+
+func opsStatusFixtureReceipt(windowDays: Int) throws -> Data {
+  try JSONSerialization.data(withJSONObject: [
+    "schema_version": "codevetter.ops-status/v1",
+    "generated_at": "2026-09-02T00:00:00Z",
+    "database_available": true,
+    "window_days": windowDays,
+    "billing": [
+      "anthropic_configured": true,
+      "openai_configured": false,
+    ],
+    "webhook": [
+      "configured": true,
+      "flavor": "slack",
+    ],
+    "observability": [
+      [
+        "task_type": "review",
+        "session_count": 28,
+        "success_count": 24,
+        "failure_count": 3,
+        "success_rate_pct": 85.7,
+        "median_duration_seconds": 42.0,
+        "p95_duration_seconds": 118.0,
+      ],
+      [
+        "task_type": "indexed-session",
+        "session_count": 116,
+        "success_count": 116,
+        "failure_count": 0,
+        "success_rate_pct": 100.0,
+        "median_duration_seconds": 780.0,
+        "p95_duration_seconds": 3_240.0,
+      ],
+    ],
+    "excluded_sensitive_keys": [
+      "anthropic_admin_key",
+      "openai_admin_key",
+      "notif_webhook_url",
+    ],
+    "limitations": [
+      "This read-only receipt never returns credentials or webhook URLs.",
+      "It reads stored aggregate evidence only and never contacts a provider or webhook.",
+      "Credential writes, live billing refresh, and webhook tests remain incumbent authority.",
+      "Indexed sessions have no explicit failure signal and remain labelled as an aggregate proxy.",
+    ],
+  ])
+}
+
+func mcpSettingsFixtureReceipt(
+  operation: String,
+  enabled: Bool = false
+) throws -> Data {
+  let audit: [[String: Any]] = (0..<12).map { index in
+    [
+      "id": index + 1,
+      "repo_id": "opaque-repo-id",
+      "server_session": "session-\(index)",
+      "operation": index.isMultiple(of: 2) ? "prepare_review" : "history_search",
+      "status": "ok",
+      "duration_ms": 8 + index,
+      "result_count": 3,
+      "response_bytes": 1_024 + index,
+      "created_at": "2026-09-01T00:00:\(String(format: "%02d", index))Z",
+    ]
+  }
+  let settings: [String: Any] = [
+    "repo_id": "opaque-repo-id",
+    "enabled": enabled,
+    "indexed": true,
+    "indexed_head": String(repeating: "a", count: 40),
+    "current_head": String(repeating: "a", count: 40),
+    "stale": false,
+    "server_path": "/Applications/CodeVetter.app/Contents/MacOS/codevetter-mcp",
+    "client_config": [
+      "mcpServers": [
+        "codevetter-history": [
+          "command": "/Applications/CodeVetter.app/Contents/MacOS/codevetter-mcp",
+          "args": ["--database", "/fixture/codevetter.db", "--repo-id", "opaque-repo-id"],
+        ]
+      ]
+    ],
+    "resource_kinds": ["repository", "release", "commit", "file", "evidence"],
+    "tool_names": [
+      "prepare_review", "history_search", "history_explain", "history_trace", "graph_query",
+      "graph_impact", "graph_path",
+    ],
+    "redaction_rules": [
+      "No raw transcripts, credentials, environment files, or arbitrary file reads",
+      "Sensitive paths remain opaque",
+      "Repository paths never appear in resource URIs or cursors",
+    ],
+    "limits": [
+      "page_size": 50,
+      "graph_nodes": 500,
+      "graph_edges": 1_000,
+      "response_bytes": 1_000_000,
+    ],
+    "recent_audit": audit,
+  ]
+  return try JSONSerialization.data(withJSONObject: [
+    "schema_version": "codevetter.mcp-settings/v1",
+    "generated_at": "2026-09-01T00:00:00Z",
+    "operation": operation,
+    "cleared_audit_rows": operation == "clear_audit" ? 12 : 0,
+    "settings": settings,
+  ])
+}
+
+func historyRootsFixtureReceipt(
+  operation: String,
+  changedRoot: String? = nil
+) throws -> Data {
+  let changedRootValue: Any = changedRoot.map { $0 as Any } ?? NSNull()
+  return try JSONSerialization.data(withJSONObject: [
+    "schema_version": "codevetter.history-roots/v1",
+    "generated_at": "2026-09-02T00:00:00Z",
+    "operation": operation,
+    "database_available": true,
+    "changed_root": changedRootValue,
+    "roots": [
+      [
+        "path": "/fixture/codex",
+        "display_path": "~/Archive/codex",
+        "exists": true,
+        "sessions_available": true,
+        "archived_sessions_available": true,
+      ]
+    ],
+    "limitations": [
+      "Saving a root does not start reconciliation or read transcript content."
+    ],
+  ])
+}
+
+func sessionRetentionFixtureReceipt(operation: String) throws -> Data {
+  let entry: [String: Any] = [
+    "sessionId": "session-protected-fixture",
+    "rows": 42,
+    "estimatedBytes": 32_768,
+    "lastActivity": "2026-08-31T00:00:00Z",
+    "reasons": ["referenced by intent closure", "attached to active work item"],
+  ]
+  let plan: [String: Any] = [
+    "id": "retention-plan:fixture",
+    "planIdentity": "sha256:fixture-plan",
+    "archiveFingerprint": "sha256:fixture-archive",
+    "policy": ["maxAgeDays": 90, "maxArchiveBytes": 2_147_483_648],
+    "archiveRows": 8_000,
+    "archiveBytes": 9_437_184,
+    "candidateRows": 120,
+    "candidateBytes": 262_144,
+    "candidates": [
+      [
+        "sessionId": "session-removable-fixture",
+        "rows": 120,
+        "estimatedBytes": 262_144,
+        "lastActivity": "2025-01-01T00:00:00Z",
+        "reasons": ["older than configured age"],
+      ]
+    ],
+    "protected": [entry],
+    "projectedRows": 7_880,
+    "projectedBytes": 9_175_040,
+    "createdAt": "2026-09-01T00:00:00Z",
+  ]
+  let result: Any =
+    operation == "plan"
+    ? NSNull()
+    : [
+      "checkpointed": operation == "checkpoint",
+      "vacuumed": operation == "checkpoint",
+      "sourceTranscriptsDeleted": false,
+    ]
+  let planValue: Any = operation == "plan" ? plan : NSNull()
+  return try JSONSerialization.data(withJSONObject: [
+    "schema_version": "codevetter.session-retention/v1",
+    "generated_at": "2026-09-01T00:00:00Z",
+    "operation": operation,
+    "plan": planValue,
+    "result": result,
+  ])
+}
+
+func memoryFixtureReceipt(operation: String) throws -> Data {
+  let sourceID = "memory:sha256:fixture"
+  let sources: [[String: Any]] = [
+    [
+      "id": sourceID,
+      "tool": "Codex",
+      "label": "Codex memory registry",
+      "display_path": "~/.codex/memories/MEMORY.md",
+      "exists": true,
+      "readable": true,
+      "file_size_bytes": 8_192,
+      "modified_at": "2026-09-01T18:30:00Z",
+      "source_kind": "markdown",
+      "preview": "Runtime evidence and release boundaries",
+      "note": "Full Markdown memory registry.",
+    ]
+  ]
+  let selectedSourceID: Any = operation == "list" ? NSNull() : sourceID
+  let document: Any =
+    operation == "read"
+    ? [
+      "source_id": sourceID,
+      "content":
+        "# Verification memory\n\n- Bind every claim to executable evidence.\n- Keep release authority explicit.\n- Preserve the incumbent until parity is proven.\n\n## Current native work\n\nThe Evidence Workbench uses a true-black canvas and restrained amber actions.",
+      "truncated": false,
+      "extraction_note": "Showing the full text with secret-looking lines redacted.",
+    ]
+    : NSNull()
+  let diff: Any =
+    operation == "diff"
+    ? [
+      "source_id": sourceID,
+      "has_changes": true,
+      "status": "modified",
+      "diff":
+        "diff --git a/MEMORY.md b/MEMORY.md\n@@ -2 +2 @@\n-Use evidence.\n+Bind every claim to executable evidence.",
+    ]
+    : NSNull()
+  return try JSONSerialization.data(withJSONObject: [
+    "schema_version": "codevetter.memories/v1",
+    "generated_at": "2026-09-02T00:00:00Z",
+    "operation": operation,
+    "selected_source_id": selectedSourceID,
+    "candidate_locations_checked": 79,
+    "sources_total": 1,
+    "sources": sources,
+    "document": document,
+    "diff": diff,
+    "limits": [
+      "max_sources": 128,
+      "max_read_bytes": 524_288,
+      "max_output_chars": 120_000,
+      "sources_truncated": false,
+    ],
+    "limitations": [
+      "This surface is read-only and cannot edit, create, or delete memory sources.",
+      "Agent and MCP projections are unavailable.",
+    ],
+  ])
+}
+
+func rubricFixtureReceipt(
+  operation: String,
+  savedPackID: String? = nil
+) throws -> Data {
+  let definitions: [(String, String, String, [String], Bool)] = [
+    (
+      "product-safety", "Product Safety",
+      "User-facing regressions, broken flows, data loss, and confusing states.",
+      [
+        "Flag behavior changes that can break an existing user workflow.",
+        "Check loading, empty, error, and permission states for user-facing screens.",
+        "Prioritize concrete reproduction steps over style commentary.",
+      ], true
+    ),
+    (
+      "security-boundary", "Security Boundary",
+      "Auth, authorization, secret handling, trust boundaries, and injection risk.",
+      [
+        "Verify server-side authorization, not just hidden client controls.",
+        "Flag secrets, tokens, PII, or prompts that can leak into logs or analytics.",
+        "Check untrusted input before database, shell, network, or model calls.",
+      ], false
+    ),
+    (
+      "agent-handoff", "Agent Handoff",
+      "Review quality for multi-agent workflows and future task continuity.",
+      [
+        "Call out missing tests or verification commands the next agent must run.",
+        "Prefer findings with file paths, line numbers, and a bounded fix.",
+        "Separate real blockers from optional cleanup so agents do not waste context.",
+      ], false
+    ),
+    (
+      "performance-proof", "Performance Proof", "Measured performance regressions.",
+      ["Require a reproducible baseline.", "Reject unsupported improvement claims."], false
+    ),
+  ]
+  let packs: [[String: Any]] = definitions.enumerated().map { index, definition in
+    let preview =
+      ([
+        "CodeVetter review standards pack:",
+        "- Pack: \(definition.1)",
+        "- Focus: \(definition.2)",
+      ] + definition.3.map { "- Check: \($0)" }).joined(separator: "\n")
+    return [
+      "id": definition.0,
+      "name": definition.1,
+      "focus": definition.2,
+      "checks": definition.3,
+      "built_in": index < 3,
+      "active": definition.4,
+      "review_count": 12 - index,
+      "total_findings": 28 - index,
+      "prompt_preview": preview,
+    ]
+  }
+  let savedPackValue: Any = savedPackID.map { $0 as Any } ?? NSNull()
+  return try JSONSerialization.data(withJSONObject: [
+    "schema_version": "codevetter.rubric-settings/v1",
+    "generated_at": "2026-09-01T00:00:00Z",
+    "operation": operation,
+    "active_pack_id": "product-safety",
+    "custom_rules": [],
+    "packs": packs,
+    "saved_pack_id": savedPackValue,
+    "migrated_legacy_config": false,
+  ])
+}
+
+func performanceFixtureReceipt(
+  requestID: String,
+  operation: String,
+  state: String = "succeeded",
+  exitCode: Int = 0,
+  result: String
+) -> String {
+  """
+  {"schema_version":1,"request_id":"\(requestID)","operation":"\(operation)","state":"\(state)","exit_code":\(exitCode),"duration_ms":42,"result":\(result),"stderr_summary":null,"cleanup":{"owned_process_reaped":true,"temporary_profiles_retained":false}}
+  """
+}
+
+func warmVerificationFixture() -> String {
+  let hashA = String(repeating: "a", count: 64)
+  let hashB = String(repeating: "b", count: 64)
+  let sha = String(repeating: "c", count: 40)
+  return """
+    {"id":"stored-warm-fixture","repo_path":"/fixture/repo","created_at":"2026-09-01T00:00:01Z","result":{"schema_version":1,"protocol_version":1,"run_id":"native-warm-fixture","outcome":"passed","started_at":"2026-09-01T00:00:00Z","finished_at":"2026-09-01T00:00:01Z","warm":true,"stale":false,"model_call_count":0,"source":{"target_sha":"\(sha)","change_set_kind":"worktree","change_set_identity":"\(hashA)","config_hash":"\(hashB)","manifest_hash":"\(hashA)","source_hash_before":"\(hashA)","source_hash_after":"\(hashA)"},"observation_policy":{"schema_version":1,"profile_id":"read-only-browser-v1"},"selection":{"changed_paths":["src/checkout.tsx"],"selected_scenario_ids":["checkout-smoke"],"mandatory_smoke_ids":["checkout-smoke"],"fallback_scenario_ids":[],"complete":true,"explanation":"The checkout path selected its declared smoke scenario."},"scenarios":[{"scenario_id":"checkout-smoke","outcome":"passed","duration_ms":184.5}],"timings":[{"stage":"total","duration_ms":212.0}],"observations":[{"id":"observation-1","scenario_id":"checkout-smoke","kind":"accessibility_smoke","disposition":"passed","policy_id":"read-only-browser-v1","message":"Checkout controls retained accessible labels.","occurred_at":"2026-09-01T00:00:00Z"}],"limitations":[{"code":"other","message":"Fixture proves native decoding and rendering only.","affects_confidence":false}],"artifacts":[{"id":"artifact-1","kind":"screenshot","relative_path":"artifacts/warm/checkout.png","sha256":"\(hashB)","bytes":2048,"redacted":true,"created_at":"2026-09-01T00:00:00Z","retained_until":"2026-09-08T00:00:00Z","scenario_id":"checkout-smoke"}],"cancellation":{"state":"not_requested"}}}
+    """
+}
+
+func differentialPreparedFixture() -> String {
+  """
+  {"schema_version":1,"run_id":"native-diff-fixture","status":"ready","reference_sha":"\(String(repeating: "a", count: 40))","candidate_kind":"range","candidate_identity":"\(String(repeating: "b", count: 64))","selection_identity":"\(String(repeating: "c", count: 64))","scenario_count":2,"source_cache_hits":1,"dependency_cache_hit":true,"prepared_bytes":4096,"reason_codes":[],"model_call_count":0,"cleanup_complete":false}
+  """
+}
+
+func differentialStoredFixture() -> String {
+  """
+  {"id":"stored-diff-fixture","repo_path":"/fixture/repo","created_at":"2026-09-01T00:00:01Z","summary":{"schema_version":1,"run_id":"native-diff-fixture","status":"complete","classification":"regressed","plan_identity":"\(String(repeating: "d", count: 64))","reference_sha":"\(String(repeating: "a", count: 40))","candidate_kind":"range","candidate_identity":"\(String(repeating: "b", count: 64))","scenario_count":2,"delta_count":1,"blocking_delta_count":1,"delta_previews":[{"id":"delta-1","scenario_id":"checkout-smoke","kind":"assertion","direction":"candidate_only","blocking":true,"policy_id":"paired-browser-v1"}],"delta_previews_truncated":false,"reason_codes":["candidate_regression"],"comparison_policy_identities":["paired-browser-v1"],"duration_ms":284.5,"cleanup_complete":true,"creates_pass_evidence":false,"model_call_count":0}}
+  """
+}
+
+func scenarioCompilerFixture(action: String) -> String {
+  let hash = String(repeating: "a", count: 64)
+  let sha = String(repeating: "b", count: 40)
+  return """
+    {"schema_version":1,"action":"\(action)","status":"ok","message":"Candidate validated and dry-run passed.","candidate":{"schema_version":1,"candidate_id":"candidate-fixture","candidate_hash":"\(hash)","cache_key":"\(hash)","status":"candidate","created_at":"2026-09-01T00:00:00Z","expires_at":"2026-09-02T00:00:00Z","spec_source_path":"docs/checkout.md","spec_section":"Checkout","spec_hash":"\(hash)","target_sha":"\(sha)","config_hash":"\(hash)","manifest_hash":"\(hash)","provider":{"kind":"local_command","provider":"local","model":"qwen2.5-coder:7b","cost_class":"free","paid_approved":false},"provider_duration_ms":240,"cache_hit":false,"usage":{"input_tokens":120,"output_tokens":80,"estimated_cost_usd":0,"actual_cost_usd":0},"unresolved_requirements":[],"validation":{"qualified":true,"issues":[]},"dry_run":{"status":"passed","duration_ms":180,"summary":"Scenario ran without writes.","diagnostics":[],"evidence_persisted":false,"baselines_updated":false},"files":[{"kind":"scenario","destination":".codevetter/scenarios/checkout.yaml","sha256":"\(hash)","replaces_existing":true,"diff":"+ id: checkout-smoke\\n+ route: /checkout"},{"kind":"provenance","destination":".codevetter/provenance/checkout.json","sha256":"\(hash)","replaces_existing":false,"diff":"+ {\\\"source\\\":\\\"docs/checkout.md\\\"}"}],"accepted_file_hashes":{}},"candidates":[],"cleanup":null}
+    """
+}
+
+func trexWatcherFixture(operation: String) -> String {
+  let headA = String(repeating: "a", count: 40)
+  let headB = String(repeating: "b", count: 40)
+  return """
+    {"schema_version":1,"operation":"\(operation)","watcher":{"repo_path":"/fixture/repo","interval_secs":300,"enabled":true,"base_branch":"main","last_polled_at":"2026-09-01 00:05:00","last_error":null,"created_at":"2026-09-01 00:00:00"},"watchers":[],"runs":[{"id":"watcher-run-fixture","repo_path":"/fixture/repo","pr_number":42,"head_sha":"\(headA)","verdict":"APPROVE","confidence":0.97,"summary":"Checkout and receipt journeys passed in the isolated PR worktree.","status_state":"success","status_error":null,"duration_ms":1842,"ran_at":"2026-09-01T00:05:02Z"},{"id":"watcher-run-limited","repo_path":"/fixture/repo","pr_number":39,"head_sha":"\(headB)","verdict":"NEEDS_REVIEW","confidence":0.61,"summary":"Runtime checks completed, but one browser observation needs maintainer review.","status_state":"pending","status_error":"GitHub status remained pending while evidence was retained.","duration_ms":2310,"ran_at":"2026-09-01T00:02:00Z"}],"inspected_prs":4,"skipped_unchanged":2,"message":"Inspected 4 open PR(s); completed 2 new run(s); skipped 2 unchanged."}
+    """
+}
+
+func usagePeriod(
+  _ period: String,
+  agent: String,
+  generated: UInt64,
+  model: String
+) -> LocalUsagePeriod {
+  let totals = localUsageTotals(generated)
+  let modelUsage = LocalUsageModel(model: model, totals: totals, fallback: false, priced: true)
+  return LocalUsagePeriod(
+    period: period,
+    totals: totals,
+    agents: [LocalUsageAgent(agent: agent, totals: totals, models: [modelUsage])],
+    models: [modelUsage]
+  )
+}
+
+func usageSession(
+  _ id: String,
+  agent: String,
+  activity: String?
+) -> LocalUsageSession {
+  LocalUsageSession(
+    sessionID: id,
+    agent: agent,
+    lastActivity: activity,
+    reasoningOutputTokens: 0,
+    totals: localUsageTotals(10),
+    models: []
+  )
+}
+
+func localUsageTotals(_ generated: UInt64) -> LocalUsageTotals {
+  LocalUsageTotals(
+    inputTokens: generated / 2,
+    cacheCreationTokens: generated / 4,
+    cacheReadTokens: generated * 2,
+    outputTokens: generated - generated / 2 - generated / 4,
+    totalTokens: generated * 3,
+    costUSD: Double(generated) / 100_000
+  )
+}
+
+func usageTotals(_ generated: UInt64) -> [String: Any] {
+  [
+    "input_tokens": generated / 2,
+    "cache_creation_tokens": generated / 4,
+    "cache_read_tokens": generated * 2,
+    "output_tokens": generated / 4,
+    "total_tokens": generated * 3,
+    "cost_usd": Double(generated) / 100_000,
+  ]
+}
+
+@Test
+func supervisedRunnerPassesTheRepositoryFilterToRust() async throws {
+  let fixtureDirectory = FileManager.default.temporaryDirectory
+    .appending(path: "codevetter-filter-\(UUID().uuidString)")
+  try FileManager.default.createDirectory(at: fixtureDirectory, withIntermediateDirectories: true)
+  defer { try? FileManager.default.removeItem(at: fixtureDirectory) }
+
+  let executable = fixtureDirectory.appending(path: "codevetter")
+  let argumentsFile = fixtureDirectory.appending(path: "arguments.txt")
+  let emptyHistory =
+    #"{"schema_version":"codevetter.run-history/v1","generated_at":"2026-08-31T00:00:00Z","repo_path":"/fixture/repo","limit":20,"returned":0,"runs":[]}"#
+  try "#!/bin/sh\nprintf '%s' \"$*\" > '\(argumentsFile.path)'\nprintf '%s\\n' '\(emptyHistory)'\n"
+    .write(
+      to: executable,
+      atomically: true,
+      encoding: .utf8
+    )
+  try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+
+  let runs = try await CodeVetterProcessRunner(executableURL: executable).listRuns(
+    repositoryPath: "/fixture/repo",
+    limit: 20
+  )
+  let arguments = try String(contentsOf: argumentsFile, encoding: .utf8)
+
+  #expect(runs.isEmpty)
+  #expect(arguments.contains("runs --json --limit 20"))
+  #expect(arguments.contains("--repo /fixture/repo"))
+}


### PR DESCRIPTION
Part 4/40 of the dependency-ordered native macOS evidence-workbench stack.

Base: `stack/03-native-workflows`
Head: `stack/04-native-support`

This layer stays within the repository's 40-file, 4,000-addition, and 6,000-gross-line limits. Merge only in stack order.
The top tree is byte-identical to the snapshot qualified in draft PR #203; protected signing, notarization, release, and Tauri cutover remain owner-approval gates.
Tracks #193, #194, #199, #200, #201, and #202 without auto-closing them before the full stack lands.