### PR TITLE
[stack 09/40] Consolidated benchmark corpus I

### DIFF
--- a/benchmarks/native-bridge/README.md
+++ b/benchmarks/native-bridge/README.md
@@ -1,0 +1,31 @@
+# Native bridge benchmark
+
+This benchmark selects the Rust/Swift ownership boundary using the exact
+generated capability registry. It compares:
+
+- an in-process Rust dynamic-library read and Swift JSON decode;
+- the real supervised `codevetter capabilities --json` worker round trip.
+
+The probe intentionally adds no production dependency. Its FFI symbol exposes
+read-only immutable bytes and never passes Rust objects, allocators, database
+handles, or verification policy into Swift.
+
+Build the Rust probe and release CLI, then run the Swift executable through the
+pinned XcodeBuildMCP Swift-package workflow. The committed measurement receipt
+belongs in `evidence/performance/native-bridge-benchmark.json`.
+
+From the repository root:
+
+```bash
+pnpm bench:native-bridge
+```
+
+The command prints the versioned benchmark receipt to stdout and leaves only
+gitignored build products under `artifacts/`, Cargo `target/`, and SwiftPM
+`.build/`.
+
+The selection rule is not “always choose the lowest latency.” Bounded,
+read-only projections may use an in-process bridge when schema and crash gates
+pass. Verification, browser execution, project commands, and other long-running
+or risky work remain supervised workers so cancellation and crash isolation do
+not depend on the UI process.

--- a/benchmarks/native-bridge/capability_bridge.rs
+++ b/benchmarks/native-bridge/capability_bridge.rs
@@ -1,0 +1,19 @@
+//! Read-only FFI probe for measuring a narrow Rust/Swift data boundary.
+//!
+//! This is benchmark code, not the production bridge. It exposes the exact
+//! Rust-generated capability fixture consumed by the native app so the probe
+//! measures boundary overhead without reimplementing product semantics.
+
+static CAPABILITIES: &[u8] = include_bytes!(
+    "../../apps/macos/CodeVetterPackage/Sources/CodeVetterFeature/Resources/capabilities.v1.json"
+);
+
+#[no_mangle]
+pub extern "C" fn codevetter_capabilities_pointer() -> *const u8 {
+    CAPABILITIES.as_ptr()
+}
+
+#[no_mangle]
+pub extern "C" fn codevetter_capabilities_length() -> usize {
+    CAPABILITIES.len()
+}

--- a/benchmarks/public-catch-rate/cases/go-errcheck/label.json
+++ b/benchmarks/public-catch-rate/cases/go-errcheck/label.json
@@ -1,0 +1,16 @@
+{
+  "id": "go-errcheck",
+  "title": "Unchecked error return in Go",
+  "language": "go",
+  "source_file": "source.go",
+  "category": "bug",
+  "ground_truth": [
+    {
+      "id": "ignored-writefile-error",
+      "type": "unchecked_error",
+      "severity": "medium",
+      "location": { "file": "source.go", "lines": [12, 12] },
+      "description": "The error return from os.WriteFile is discarded, so disk-full, permission, and invalid-path failures are silently swallowed and callers assume the config was saved."
+    }
+  ]
+}

--- a/benchmarks/public-catch-rate/cases/go-errcheck/source.go
+++ b/benchmarks/public-catch-rate/cases/go-errcheck/source.go
@@ -1,0 +1,13 @@
+// Case: Ignored error return from a write that can fail.
+package writer
+
+import (
+	"os"
+)
+
+func SaveConfig(path string, contents []byte) {
+	// BUG: WriteFile's error is discarded. If the disk is full, permissions
+	// are wrong, or the path is invalid, the failure is silently swallowed and
+	// callers proceed as if the config was saved.
+	os.WriteFile(path, contents, 0o600)
+}

--- a/benchmarks/public-catch-rate/cases/go-hardcoded-credentials/label.json
+++ b/benchmarks/public-catch-rate/cases/go-hardcoded-credentials/label.json
@@ -1,0 +1,16 @@
+{
+  "id": "go-hardcoded-credentials",
+  "title": "Hardcoded database credentials in Go",
+  "language": "go",
+  "source_file": "source.go",
+  "category": "security",
+  "ground_truth": [
+    {
+      "id": "hardcoded-dsn-credentials",
+      "type": "hardcoded_secret",
+      "severity": "high",
+      "location": { "file": "source.go", "lines": [7, 9] },
+      "description": "Production database username, password, and host are committed in plaintext as package-level constants, exposing credentials to anyone with repository access."
+    }
+  ]
+}

--- a/benchmarks/public-catch-rate/cases/go-hardcoded-credentials/source.go
+++ b/benchmarks/public-catch-rate/cases/go-hardcoded-credentials/source.go
@@ -1,0 +1,14 @@
+// Case: Hardcoded database credentials in a Go service.
+package db
+
+const (
+	// BUG: production database credentials are committed in plaintext.
+	dsnUser = "billing_admin"
+	dsnPass = "supersecret-prod-2024"
+	dsnHost = "10.0.0.5:5432"
+	dsnName = "billing"
+)
+
+func DSN() string {
+	return "postgres://" + dsnUser + ":" + dsnPass + "@" + dsnHost + "/" + dsnName
+}

--- a/benchmarks/public-catch-rate/cases/go-nil-pointer/label.json
+++ b/benchmarks/public-catch-rate/cases/go-nil-pointer/label.json
@@ -1,0 +1,16 @@
+{
+  "id": "go-nil-pointer",
+  "title": "Nil-pointer dereference on missing map value in Go",
+  "language": "go",
+  "source_file": "source.go",
+  "category": "bug",
+  "ground_truth": [
+    {
+      "id": "nil-pointer-missing-user",
+      "type": "nil_dereference",
+      "severity": "medium",
+      "location": { "file": "source.go", "lines": [16, 16] },
+      "description": "FindUser dereferences u.Email without checking that the map lookup returned a non-nil pointer, so a missing id causes a nil pointer dereference and a process crash."
+    }
+  ]
+}

--- a/benchmarks/public-catch-rate/cases/go-nil-pointer/source.go
+++ b/benchmarks/public-catch-rate/cases/go-nil-pointer/source.go
@@ -1,0 +1,15 @@
+// Case: Nil-pointer dereference when a lookup returns no value.
+package user
+
+type User struct {
+	ID    int
+	Email string
+}
+
+func FindUser(users map[int]*User, id int) string {
+	// BUG: FindUser returns the dereferenced Email without checking that the
+	// map lookup returned a non-nil pointer. A missing id causes a nil pointer
+	// dereference and a process crash.
+	u := users[id]
+	return u.Email
+}

--- a/benchmarks/public-catch-rate/cases/go-race-condition/label.json
+++ b/benchmarks/public-catch-rate/cases/go-race-condition/label.json
@@ -1,0 +1,16 @@
+{
+  "id": "go-race-condition",
+  "title": "Data race on a shared map in Go",
+  "language": "go",
+  "source_file": "source.go",
+  "category": "concurrency",
+  "ground_truth": [
+    {
+      "id": "unsynchronized-map-read",
+      "type": "race_condition",
+      "severity": "high",
+      "location": { "file": "source.go", "lines": [21, 21] },
+      "description": "Get reads the shared map without holding the mutex while Set writes to it under the lock, causing a concurrent map read/write data race."
+    }
+  ]
+}

--- a/benchmarks/public-catch-rate/cases/go-race-condition/source.go
+++ b/benchmarks/public-catch-rate/cases/go-race-condition/source.go
@@ -1,0 +1,29 @@
+// Case: Data race on a shared map accessed from concurrent goroutines
+// without synchronization.
+package cache
+
+import (
+	"sync"
+)
+
+type Cache struct {
+	mu   sync.Mutex
+	data map[string]string
+}
+
+func NewCache() *Cache {
+	return &Cache{data: make(map[string]string)}
+}
+
+// Get is called from many goroutines but reads the map without holding mu.
+func (c *Cache) Get(key string) (string, bool) {
+	v, ok := c.data[key] // BUG: unsynchronized concurrent map read
+	return v, ok
+}
+
+// Set holds the lock, but concurrent reads above still race with writes here.
+func (c *Cache) Set(key, value string) {
+	c.mu.Lock()
+	c.data[key] = value
+	c.mu.Unlock()
+}

--- a/benchmarks/public-catch-rate/cases/go-sql-injection/label.json
+++ b/benchmarks/public-catch-rate/cases/go-sql-injection/label.json
@@ -1,0 +1,16 @@
+{
+  "id": "go-sql-injection",
+  "title": "SQL injection via fmt.Sprintf in Go",
+  "language": "go",
+  "source_file": "source.go",
+  "category": "security",
+  "ground_truth": [
+    {
+      "id": "sprintf-sql-injection",
+      "type": "sql_injection",
+      "severity": "high",
+      "location": { "file": "source.go", "lines": [13, 13] },
+      "description": "User-supplied email is interpolated into the SQL query via fmt.Sprintf instead of parameterized placeholders, allowing injection of arbitrary SQL."
+    }
+  ]
+}

--- a/benchmarks/public-catch-rate/cases/go-sql-injection/source.go
+++ b/benchmarks/public-catch-rate/cases/go-sql-injection/source.go
@@ -1,0 +1,15 @@
+// Case: SQL injection via fmt.Sprintf in a Go database query.
+package store
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+func FindByEmail(db *sql.DB, email string) (*sql.Row, error) {
+	// BUG: email is interpolated into the query string with fmt.Sprintf instead
+	// of using parameterized placeholders, allowing SQL injection.
+	q := fmt.Sprintf("SELECT id, email FROM users WHERE email = '%s'", email)
+	row := db.QueryRow(q)
+	return row, row.Err()
+}

--- a/benchmarks/public-catch-rate/cases/java-insecure-random/label.json
+++ b/benchmarks/public-catch-rate/cases/java-insecure-random/label.json
@@ -1,0 +1,16 @@
+{
+  "id": "java-insecure-random",
+  "title": "Predictable PRNG for security tokens in Java",
+  "language": "java",
+  "source_file": "source.java",
+  "category": "security",
+  "ground_truth": [
+    {
+      "id": "predictable-reset-token",
+      "type": "insecure_random",
+      "severity": "high",
+      "location": { "file": "source.java", "lines": [10, 11] },
+      "description": "Reset tokens are generated with java.util.Random, a predictable PRNG whose seed is recoverable from observed outputs, allowing token forgery. SecureRandom should be used instead."
+    }
+  ]
+}

--- a/benchmarks/public-catch-rate/cases/java-insecure-random/source.java
+++ b/benchmarks/public-catch-rate/cases/java-insecure-random/source.java
@@ -1,0 +1,13 @@
+// Case: Using java.util.Random for security-sensitive tokens.
+import java.util.Random;
+
+public class TokenGenerator {
+    private static final Random RNG = new Random();
+
+    // BUG: java.util.Random is a predictable PRNG. Session/reset tokens derived
+    // from it can be guessed by an attacker who observes one output, because
+    // the internal seed is recoverable. Use SecureRandom instead.
+    public static String resetToken() {
+        return Long.toHexString(RNG.nextLong());
+    }
+}

--- a/benchmarks/public-catch-rate/cases/js-eval-injection/label.json
+++ b/benchmarks/public-catch-rate/cases/js-eval-injection/label.json
@@ -1,0 +1,16 @@
+{
+  "id": "js-eval-injection",
+  "title": "Arbitrary code execution via eval() in JavaScript",
+  "language": "javascript",
+  "source_file": "source.js",
+  "category": "security",
+  "ground_truth": [
+    {
+      "id": "eval-on-user-input",
+      "type": "code_injection",
+      "severity": "high",
+      "location": { "file": "source.js", "lines": [7, 7] },
+      "description": "Caller-supplied expression is passed directly to eval(), turning any user-controlled value into executing JavaScript and enabling arbitrary code execution."
+    }
+  ]
+}

--- a/benchmarks/public-catch-rate/cases/js-eval-injection/source.js
+++ b/benchmarks/public-catch-rate/cases/js-eval-injection/source.js
@@ -1,0 +1,12 @@
+// Case: Arbitrary code execution via eval() on user input.
+'use strict';
+
+function buildFilter(expression) {
+  // BUG: the caller-supplied expression is passed straight to eval(), so any
+  // user-controlled value becomes running JavaScript (e.g. stealing cookies
+  // via fetch, or crashing the process).
+  const predicate = eval('(' + expression + ')');
+  return (item) => predicate(item);
+}
+
+module.exports = { buildFilter };

--- a/benchmarks/public-catch-rate/cases/js-open-redirect/label.json
+++ b/benchmarks/public-catch-rate/cases/js-open-redirect/label.json
@@ -1,0 +1,16 @@
+{
+  "id": "js-open-redirect",
+  "title": "Open redirect via unvalidated URL in Express",
+  "language": "javascript",
+  "source_file": "source.js",
+  "category": "security",
+  "ground_truth": [
+    {
+      "id": "open-redirect-next-param",
+      "type": "open_redirect",
+      "severity": "medium",
+      "location": { "file": "source.js", "lines": [9, 10] },
+      "description": "The next query parameter is passed directly to res.redirect without an allowlist or same-origin check, enabling phishing redirects off the trusted domain."
+    }
+  ]
+}

--- a/benchmarks/public-catch-rate/cases/js-open-redirect/source.js
+++ b/benchmarks/public-catch-rate/cases/js-open-redirect/source.js
@@ -1,0 +1,14 @@
+// Case: Open redirect via unvalidated user-controlled URL.
+const express = require('express');
+const app = express();
+
+app.get('/login', (req, res) => {
+  // BUG: the `next` query param is used directly in res.redirect without any
+  // allowlist or same-origin check, so an attacker can craft
+  // /login?next=https://evil.example to phish users off the trusted domain.
+  const next = req.query.next;
+  if (next) {
+    return res.redirect(next);
+  }
+  res.redirect('/dashboard');
+});

--- a/benchmarks/public-catch-rate/cases/py-bare-except/label.json
+++ b/benchmarks/public-catch-rate/cases/py-bare-except/label.json
@@ -1,0 +1,16 @@
+{
+  "id": "py-bare-except",
+  "title": "Bare except swallows all errors in Python",
+  "language": "python",
+  "source_file": "source.py",
+  "category": "bug",
+  "ground_truth": [
+    {
+      "id": "bare-except-swallows-errors",
+      "type": "swallowed_error",
+      "severity": "medium",
+      "location": { "file": "source.py", "lines": [9, 11] },
+      "description": "A bare except catches BaseException (including KeyboardInterrupt and SystemExit), hides JSON parse failures, and silently returns an empty dict so callers never learn the config failed to parse."
+    }
+  ]
+}

--- a/benchmarks/public-catch-rate/cases/py-bare-except/source.py
+++ b/benchmarks/public-catch-rate/cases/py-bare-except/source.py
@@ -1,0 +1,16 @@
+# Case: Bare except swallows all errors including KeyboardInterrupt.
+import json
+
+
+def parse_config(raw: str) -> dict:
+    try:
+        return json.loads(raw)
+    except:  # BUG: catches BaseException, hiding bugs, KeyboardInterrupt, and
+            # SystemExit, and returns an empty dict so callers never learn the
+            # config failed to parse.
+        return {}
+
+
+def load_settings(path: str) -> dict:
+    with open(path, "r", encoding="utf-8") as fh:
+        return parse_config(fh.read())

--- a/benchmarks/public-catch-rate/cases/py-command-injection/label.json
+++ b/benchmarks/public-catch-rate/cases/py-command-injection/label.json
@@ -1,0 +1,16 @@
+{
+  "id": "py-command-injection",
+  "title": "Command injection via subprocess shell=True in Python",
+  "language": "python",
+  "source_file": "source.py",
+  "category": "security",
+  "ground_truth": [
+    {
+      "id": "shell-true-command-injection",
+      "type": "command_injection",
+      "severity": "high",
+      "location": { "file": "source.py", "lines": [9, 10] },
+      "description": "subprocess.run is called with shell=True and a string command containing user-controlled host, allowing shell metacharacters to inject arbitrary commands."
+    }
+  ]
+}

--- a/benchmarks/public-catch-rate/cases/py-command-injection/source.py
+++ b/benchmarks/public-catch-rate/cases/py-command-injection/source.py
@@ -1,0 +1,11 @@
+# Case: Command injection via subprocess with shell=True.
+import subprocess
+import sys
+
+
+def ping_host(host: str) -> str:
+    # BUG: shell=True with a string command lets a malicious host value append
+    # shell metacharacters, e.g. "8.8.8.8; rm -rf /" runs an extra command.
+    cmd = f"ping -c 1 {host}"
+    result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+    return result.stdout

--- a/benchmarks/public-catch-rate/cases/py-hardcoded-secret/label.json
+++ b/benchmarks/public-catch-rate/cases/py-hardcoded-secret/label.json
@@ -1,0 +1,16 @@
+{
+  "id": "py-hardcoded-secret",
+  "title": "Hardcoded cloud API credentials in Python",
+  "language": "python",
+  "source_file": "source.py",
+  "category": "security",
+  "ground_truth": [
+    {
+      "id": "hardcoded-aws-access-key",
+      "type": "hardcoded_secret",
+      "severity": "high",
+      "location": { "file": "source.py", "lines": [10, 11] },
+      "description": "A live AWS access key id and secret access key are hardcoded in source. Anyone with repository access can extract and abuse these credentials."
+    }
+  ]
+}

--- a/benchmarks/public-catch-rate/cases/py-hardcoded-secret/source.py
+++ b/benchmarks/public-catch-rate/cases/py-hardcoded-secret/source.py
@@ -1,0 +1,25 @@
+# Case: Hardcoded cloud API key committed to source.
+import os
+import requests
+
+
+def fetch_billing(account_id: str) -> dict:
+    # BUG: a live AWS access key is hardcoded in source instead of being read
+    # from a secret manager or environment variable. Anyone with repo access
+    # can impersonate this account.
+    aws_access_key_id = "AKIAIOSFODNN7EXAMPLE"
+    aws_secret_access_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+    region = "us-east-1"
+
+    url = f"https://billing.example.com/{account_id}"
+    resp = requests.get(
+        url,
+        headers={
+            "X-Aws-Key": aws_access_key_id,
+            "X-Aws-Secret": aws_secret_access_key,
+            "X-Aws-Region": region,
+        },
+        timeout=10,
+    )
+    resp.raise_for_status()
+    return resp.json()

--- a/benchmarks/public-catch-rate/cases/py-insecure-deserialization/label.json
+++ b/benchmarks/public-catch-rate/cases/py-insecure-deserialization/label.json
@@ -1,0 +1,16 @@
+{
+  "id": "py-insecure-deserialization",
+  "title": "Insecure pickle deserialization in Python",
+  "language": "python",
+  "source_file": "source.py",
+  "category": "security",
+  "ground_truth": [
+    {
+      "id": "pickle-loads-untrusted",
+      "type": "insecure_deserialization",
+      "severity": "high",
+      "location": { "file": "source.py", "lines": [9, 9] },
+      "description": "pickle.loads is called on a user-supplied base64 blob. pickle can execute arbitrary code during deserialization, so untrusted input lets an attacker run any payload on the server."
+    }
+  ]
+}

--- a/benchmarks/public-catch-rate/cases/py-insecure-deserialization/source.py
+++ b/benchmarks/public-catch-rate/cases/py-insecure-deserialization/source.py
@@ -1,0 +1,11 @@
+# Case: Insecure deserialization of untrusted pickle data.
+import pickle
+import base64
+
+
+def load_state(blob: str) -> dict:
+    # BUG: pickle can execute arbitrary code during deserialization. Decoding
+    # and unpickling a user-supplied blob lets an attacker run any payload on
+    # the server. Use JSON or a restricted schema instead.
+    raw = base64.b64decode(blob)
+    return pickle.loads(raw)

--- a/benchmarks/public-catch-rate/cases/py-path-traversal/label.json
+++ b/benchmarks/public-catch-rate/cases/py-path-traversal/label.json
@@ -1,0 +1,16 @@
+{
+  "id": "py-path-traversal",
+  "title": "Path traversal in a Python file handler",
+  "language": "python",
+  "source_file": "source.py",
+  "category": "security",
+  "ground_truth": [
+    {
+      "id": "path-traversal-unnormalized-join",
+      "type": "path_traversal",
+      "severity": "high",
+      "location": { "file": "source.py", "lines": [9, 9] },
+      "description": "User-supplied report_name is joined into the filesystem path without normalization or containment checks, allowing traversal sequences like ../../etc/passwd to read arbitrary files outside base_dir."
+    }
+  ]
+}

--- a/benchmarks/public-catch-rate/cases/py-path-traversal/source.py
+++ b/benchmarks/public-catch-rate/cases/py-path-traversal/source.py
@@ -1,0 +1,12 @@
+# Case: Path traversal in a file download handler.
+import os
+
+
+def read_report(report_name: str) -> str:
+    base_dir = "/var/app/reports"
+    # BUG: report_name is joined directly into the filesystem path without
+    # normalization or containment checks. A request like
+    # "../../etc/passwd" escapes base_dir and reads arbitrary files.
+    full_path = os.path.join(base_dir, report_name)
+    with open(full_path, "r", encoding="utf-8") as fh:
+        return fh.read()

--- a/benchmarks/public-catch-rate/cases/py-sql-injection/label.json
+++ b/benchmarks/public-catch-rate/cases/py-sql-injection/label.json
@@ -1,0 +1,16 @@
+{
+  "id": "py-sql-injection",
+  "title": "SQL injection via f-string in Python",
+  "language": "python",
+  "source_file": "source.py",
+  "category": "security",
+  "ground_truth": [
+    {
+      "id": "fstring-sql-injection",
+      "type": "sql_injection",
+      "severity": "high",
+      "location": { "file": "source.py", "lines": [8, 8] },
+      "description": "User-supplied name is interpolated into the SQL query via an f-string, allowing injection of arbitrary SQL such as a UNION SELECT to exfiltrate other tables."
+    }
+  ]
+}

--- a/benchmarks/public-catch-rate/cases/py-sql-injection/source.py
+++ b/benchmarks/public-catch-rate/cases/py-sql-injection/source.py
@@ -1,0 +1,9 @@
+# Case: SQL injection via f-string in a Python ORM call.
+import sqlite3
+
+
+def search_products(db: sqlite3.Connection, name: str) -> list:
+    # BUG: name is interpolated into the SQL string with an f-string. A value
+    # like "x' UNION SELECT password FROM users--" appends an arbitrary query.
+    cursor = db.execute(f"SELECT id, name FROM products WHERE name LIKE '%{name}%'")
+    return cursor.fetchall()

--- a/benchmarks/public-catch-rate/cases/py-ssrf/label.json
+++ b/benchmarks/public-catch-rate/cases/py-ssrf/label.json
@@ -1,0 +1,16 @@
+{
+  "id": "py-ssrf",
+  "title": "Server-side request forgery in Python",
+  "language": "python",
+  "source_file": "source.py",
+  "category": "security",
+  "ground_truth": [
+    {
+      "id": "ssrf-unvalidated-url-fetch",
+      "type": "ssrf",
+      "severity": "high",
+      "location": { "file": "source.py", "lines": [9, 9] },
+      "description": "The server fetches a user-supplied URL with no scheme, host, or private-range restrictions, allowing requests to cloud metadata endpoints (e.g. 169.254.169.254) to steal credentials or to internal services for pivoting."
+    }
+  ]
+}

--- a/benchmarks/public-catch-rate/cases/py-ssrf/source.py
+++ b/benchmarks/public-catch-rate/cases/py-ssrf/source.py
@@ -1,0 +1,12 @@
+# Case: Server-side request forgery via a user-supplied URL.
+import requests
+
+
+def fetch_preview(image_url: str) -> bytes:
+    # BUG: the server fetches whatever URL the user supplies, with no scheme,
+    # host, or private-range restrictions. An attacker can point this at
+    # http://169.254.169.254/latest/meta-data/ to read cloud metadata creds or
+    # at internal services to pivot.
+    resp = requests.get(image_url, timeout=5)
+    resp.raise_for_status()
+    return resp.content

--- a/benchmarks/public-catch-rate/cases/py-weak-hash/label.json
+++ b/benchmarks/public-catch-rate/cases/py-weak-hash/label.json
@@ -1,0 +1,16 @@
+{
+  "id": "py-weak-hash",
+  "title": "Weak password hashing with MD5 in Python",
+  "language": "python",
+  "source_file": "source.py",
+  "category": "security",
+  "ground_truth": [
+    {
+      "id": "md5-unsalted-password-hash",
+      "type": "weak_crypto",
+      "severity": "high",
+      "location": { "file": "source.py", "lines": [7, 7] },
+      "description": "Passwords are hashed with unsalted MD5, which is cryptographically broken and trivially reversed with rainbow tables; identical passwords produce identical hashes."
+    }
+  ]
+}

--- a/benchmarks/public-catch-rate/cases/py-weak-hash/source.py
+++ b/benchmarks/public-catch-rate/cases/py-weak-hash/source.py
@@ -1,0 +1,12 @@
+# Case: Using MD5 to hash passwords.
+import hashlib
+
+
+def hash_password(password: str) -> str:
+    # BUG: MD5 is cryptographically broken and unsalted, so identical passwords
+    # produce identical hashes that are trivially cracked via rainbow tables.
+    return hashlib.md5(password.encode()).hexdigest()
+
+
+def verify_password(password: str, stored: str) -> bool:
+    return hash_password(password) == stored

--- a/benchmarks/public-catch-rate/cases/py-zip-bomb/label.json
+++ b/benchmarks/public-catch-rate/cases/py-zip-bomb/label.json
@@ -1,0 +1,16 @@
+{
+  "id": "py-zip-bomb",
+  "title": "Unbounded zip extraction (zip bomb) in Python",
+  "language": "python",
+  "source_file": "source.py",
+  "category": "security",
+  "ground_truth": [
+    {
+      "id": "unbounded-zip-extractall",
+      "type": "resource_exhaustion",
+      "severity": "high",
+      "location": { "file": "source.py", "lines": [9, 9] },
+      "description": "extractall is called without checking uncompressed sizes or compression ratios, so a small zip bomb can decompress to petabytes and exhaust disk and memory."
+    }
+  ]
+}

--- a/benchmarks/public-catch-rate/cases/py-zip-bomb/source.py
+++ b/benchmarks/public-catch-rate/cases/py-zip-bomb/source.py
@@ -1,0 +1,9 @@
+# Case: Zip extraction without size/decompression-ratio limits (zip bomb).
+import zipfile
+
+
+def extract_archive(archive_path: str, dest: str) -> None:
+    # BUG: there is no check on the uncompressed size or the compression ratio.
+    # A 42KB zip can decompress to petabytes, exhausting disk and memory.
+    with zipfile.ZipFile(archive_path) as zf:
+        zf.extractall(dest)

--- a/benchmarks/public-catch-rate/cases/rust-integer-overflow/label.json
+++ b/benchmarks/public-catch-rate/cases/rust-integer-overflow/label.json
@@ -1,0 +1,23 @@
+{
+  "id": "rust-integer-overflow",
+  "title": "Unchecked integer arithmetic in Rust",
+  "language": "rust",
+  "source_file": "source.rs",
+  "category": "bug",
+  "ground_truth": [
+    {
+      "id": "credit-overflow-wrap",
+      "type": "integer_overflow",
+      "severity": "high",
+      "location": { "file": "source.rs", "lines": [11, 11] },
+      "description": "credit uses += on u64 without checked/saturating arithmetic; in release builds an overflowing credit wraps the balance silently, enabling balance manipulation."
+    },
+    {
+      "id": "debit-underflow-wrap",
+      "type": "integer_overflow",
+      "severity": "high",
+      "location": { "file": "source.rs", "lines": [18, 18] },
+      "description": "debit uses -= on u64 without checked arithmetic; an over-debit underflows, panicking in debug or wrapping to a huge balance in release."
+    }
+  ]
+}

--- a/benchmarks/public-catch-rate/cases/rust-integer-overflow/source.rs
+++ b/benchmarks/public-catch-rate/cases/rust-integer-overflow/source.rs
@@ -1,0 +1,20 @@
+// Case: Unchecked arithmetic that panics on overflow and can wrap balances.
+pub struct Account {
+    pub balance: u64,
+}
+
+impl Account {
+    pub fn credit(&mut self, amount: u64) {
+        // BUG: in debug builds this panics on overflow; in release builds it
+        // wraps silently, so crediting a huge amount can roll the balance back
+        // to a small value. Use checked_add / saturating_add explicitly.
+        self.balance += amount;
+    }
+
+    pub fn debit(&mut self, amount: u64) -> u64 {
+        // BUG: subtraction underflow panics in debug and wraps in release,
+        // letting an over-debit produce a huge balance.
+        self.balance -= amount;
+        self.balance
+    }
+}


### PR DESCRIPTION
Part 9/40 of the dependency-ordered native macOS evidence-workbench stack.

Base: `stack/08-native-tests`
Head: `stack/09-benchmark-corpus-01`

This layer stays within the repository's 40-file, 4,000-addition, and 6,000-gross-line limits. Merge only in stack order.
The top tree is byte-identical to the snapshot qualified in draft PR #203; protected signing, notarization, release, and Tauri cutover remain owner-approval gates.
Tracks #193, #194, #199, #200, #201, and #202 without auto-closing them before the full stack lands.