### PR TITLE
chore: guard Tailwind major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,14 @@ updates:
       # simply detects more clones fails the gate without any code changing.
       # Upgrade it deliberately, alongside whatever threshold move it implies.
       - dependency-name: jscpd
+      # The desktop still uses Tailwind 3's PostCSS and JavaScript-config
+      # contract, while the landing workspace already uses Tailwind 4 through
+      # @tailwindcss/vite. A workspace-wide major bump changes both without
+      # performing or qualifying the desktop migration. Keep routine updates
+      # available within each current major and migrate the desktop separately.
+      - dependency-name: tailwindcss
+        update-types:
+          - version-update:semver-major
     labels:
       - dependencies
       - ccusage


### PR DESCRIPTION
## Summary

- keep the desktop Tailwind 3 migration out of routine workspace-wide Dependabot bumps
- continue allowing updates within each workspace's current major
- document why the landing app and desktop need separate treatment

## Verification

- parsed `.github/dependabot.yml` with the repository's installed YAML parser
- `git diff --check`

Closes the recurrence exposed by #190; this does not perform or waive a future desktop Tailwind 4 migration.