### PR TITLE
fix: measure native performance gates in Release

### DIFF
--- a/scripts/run-native-checks.mjs
+++ b/scripts/run-native-checks.mjs
@@ -102,6 +102,7 @@ export function nativeCheckCommands({ mode }, environment = process.env) {
         '--json',
         JSON.stringify({
           packagePath: 'apps/macos/CodeVetterPackage',
+          configuration: 'Release',
           parallel: false,
           filter,
         }),

--- a/scripts/run-native-checks.test.mjs
+++ b/scripts/run-native-checks.test.mjs
@@ -30,6 +30,11 @@ test('native automation defaults to the non-activating background lane', () => {
     parallel: false,
   });
   const performanceCommands = commands.slice(1, 6);
+  assert.ok(
+    performanceCommands.every(
+      (command) => JSON.parse(command.arguments[3]).configuration === 'Release'
+    )
+  );
   assert.deepEqual(
     performanceCommands.map((command) => JSON.parse(command.arguments[3]).filter),
     [


### PR DESCRIPTION
## Summary

- run the five isolated Swift performance gates against optimized Release binaries
- keep the 83-test behavior suite and normal macOS compile in Debug
- keep all existing performance budgets and sample counts unchanged
- lock the build-mode contract with a script unit test

## Why

The hosted macOS runner measured the 100-row performance receipt at 184.137 ms in Debug against the existing 150 ms gate, while the same source passed in optimized Release. Absolute runtime budgets should qualify production-like optimized code; Debug remains appropriate for behavior feedback.

## Verification

- node --test scripts/run-native-checks.test.mjs (10 passed)
- Biome check on both changed files
- full background native lane via XcodeBuildMCP: 83 Swift behavior tests, 5 isolated Release performance gates, and macOS Debug application compile all passed
- git diff --check