### PR TITLE
Link GitHub repository with an icon (fleet policy #91)

### DIFF
--- a/apps/landing-page-astro/src/components/Footer.astro
+++ b/apps/landing-page-astro/src/components/Footer.astro
@@ -1,5 +1,6 @@
 ---
 import Icon from './Icon.astro';
+import GitHubIcon from './GitHubIcon.astro';
 
 const cols = [
   {
@@ -32,7 +33,7 @@ const cols = [
     items: [
       { l: 'About', h: '/about' },
       { l: 'Contact', h: '/contact' },
-      { l: 'Source', h: 'https://github.com/Codevetter/codevetter', icon: 'github' },
+      { l: 'Source', h: 'https://github.com/Codevetter/codevetter', icon: 'github', iconOnly: true },
       { l: 'Twitter', h: 'https://x.com/sarthakcodes', icon: 'twitter' },
       { l: 'Email', h: 'mailto:hello@codevetter.dev', icon: 'mail' },
     ],
@@ -72,14 +73,26 @@ const year = new Date().getFullYear();
             <li>
               <a
                 href={it.h}
+                aria-label={it.iconOnly ? 'GitHub repository' : undefined}
+                title={it.iconOnly ? 'GitHub repository' : undefined}
+                target={it.iconOnly ? '_blank' : undefined}
+                rel={it.iconOnly ? 'noopener noreferrer' : undefined}
                 class="flex items-center gap-2 text-sm text-gray-300 hover:text-white transition-colors group"
               >
-                {it.icon && (
+                {it.iconOnly ? (
                   <span class="text-gray-400 group-hover:text-blue-300 transition-colors">
-                    <Icon name={it.icon} width={14} height={14} class="w-3.5 h-3.5" />
+                    <GitHubIcon width={20} height={20} />
                   </span>
+                ) : (
+                  <>
+                    {it.icon && (
+                      <span class="text-gray-400 group-hover:text-blue-300 transition-colors">
+                        <Icon name={it.icon} width={14} height={14} class="w-3.5 h-3.5" />
+                      </span>
+                    )}
+                    {it.l}
+                  </>
                 )}
-                {it.l}
               </a>
             </li>
           ))}

--- a/apps/landing-page-astro/src/components/GitHubIcon.astro
+++ b/apps/landing-page-astro/src/components/GitHubIcon.astro
@@ -1,0 +1,24 @@
+---
+/**
+ * Official GitHub mark — filled icon, 16x16 viewBox.
+ * Used for icon-only links to the repository (fleet policy #91:
+ * never visible "GitHub"/"Source" text).
+ */
+interface Props {
+  class?: string;
+  width?: number | string;
+  height?: number | string;
+}
+const { class: className = '', width = 20, height = 20 } = Astro.props;
+---
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 16 16"
+  width={width}
+  height={height}
+  fill="currentColor"
+  aria-hidden="true"
+  class={className}
+>
+  <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
+</svg>

--- a/apps/landing-page-astro/src/components/Nav.astro
+++ b/apps/landing-page-astro/src/components/Nav.astro
@@ -1,4 +1,5 @@
 ---
+import GitHubIcon from './GitHubIcon.astro';
 const links = [
   { href: '/#features', label: 'Contract' },
   { href: '/#how', label: 'How it works' },
@@ -31,9 +32,13 @@ const links = [
     <div class="flex items-center gap-2">
       <a
         href="https://github.com/Codevetter/codevetter"
-        class="group hidden sm:inline-flex items-center gap-2 h-9 px-4 text-xs font-medium text-gray-400 hover:text-white hover:bg-white/5 transition-all duration-300 rounded-full"
+        aria-label="GitHub repository"
+        title="GitHub repository"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="group hidden sm:inline-flex items-center justify-center h-9 w-9 text-gray-400 hover:text-white hover:bg-white/5 transition-all duration-300 rounded-full"
       >
-        GitHub
+        <GitHubIcon width={20} height={20} />
       </a>
       <a
         href="/#download"

--- a/apps/landing-page-astro/src/pages/about.astro
+++ b/apps/landing-page-astro/src/pages/about.astro
@@ -2,6 +2,7 @@
 import Layout from '@/layouts/Layout.astro';
 import Nav from '@/components/Nav.astro';
 import Footer from '@/components/Footer.astro';
+import GitHubIcon from '@/components/GitHubIcon.astro';
 ---
 
 <Layout
@@ -38,7 +39,7 @@ import Footer from '@/components/Footer.astro';
       <h2 class="mt-8 text-base font-semibold text-white">Open source</h2>
       <p class="mt-2 text-sm">
         CodeVetter is open-source under the ISC license. The source lives at
-        <a href="https://github.com/Codevetter/codevetter" class="text-amber-400 hover:text-amber-300 underline">github.com/Codevetter/codevetter</a>.
+        <a href="https://github.com/Codevetter/codevetter" aria-label="GitHub repository" title="GitHub repository" target="_blank" rel="noopener noreferrer" class="inline-flex items-center align-middle text-amber-400 hover:text-amber-300 transition-colors"><GitHubIcon width={20} height={20} /></a>.
         The current Apple-silicon macOS build is published through GitHub
         Releases with an updater archive.
       </p>

--- a/apps/landing-page-astro/src/pages/benchmark.astro
+++ b/apps/landing-page-astro/src/pages/benchmark.astro
@@ -2,6 +2,7 @@
 import Layout from '@/layouts/Layout.astro';
 import Nav from '@/components/Nav.astro';
 import Footer from '@/components/Footer.astro';
+import GitHubIcon from '@/components/GitHubIcon.astro';
 import dataset from '@/../public/benchmark/codevetter-benchmark-v1.json';
 import results from '@/data/benchmark-results.json';
 
@@ -291,7 +292,7 @@ npm run bench:public -- --reviewer=raw-claude</code></pre>
       <h2 class="mt-12 text-xl font-semibold text-white">Try CodeVetter</h2>
       <p class="mt-2 text-sm text-[--color-text-dim]">
         <a href="/download" class="text-[--color-accent] hover:underline">Download for macOS</a>
-        · <a href="https://github.com/Codevetter/codevetter" class="text-[--color-accent] hover:underline">GitHub</a>
+        · <a href="https://github.com/Codevetter/codevetter" aria-label="GitHub repository" title="GitHub repository" target="_blank" rel="noopener noreferrer" class="inline-flex items-center text-[--color-accent] hover:text-white transition-colors align-middle"><GitHubIcon width={20} height={20} /></a>
         · <a href="https://github.com/Codevetter/codevetter/issues" class="text-[--color-accent] hover:underline">Contribute a case</a>
       </p>
     </article>

--- a/apps/landing-page-astro/src/pages/changelog.astro
+++ b/apps/landing-page-astro/src/pages/changelog.astro
@@ -2,6 +2,7 @@
 import Footer from '@/components/Footer.astro';
 import Nav from '@/components/Nav.astro';
 import Layout from '@/layouts/Layout.astro';
+import GitHubIcon from '@/components/GitHubIcon.astro';
 
 const entries = [
   {
@@ -65,9 +66,13 @@ const entries = [
         </a>
         <a
           href="https://github.com/Codevetter/codevetter"
-          class="border border-[--color-line-2] px-4 py-2.5 text-[--color-text-dim] transition-colors hover:border-[--color-accent] hover:text-white"
+          aria-label="GitHub repository"
+          title="GitHub repository"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="inline-flex items-center justify-center border border-[--color-line-2] px-4 py-2.5 text-[--color-text-dim] transition-colors hover:border-[--color-accent] hover:text-white"
         >
-          Source ↗
+          <GitHubIcon width={20} height={20} />
         </a>
       </div>
 

--- a/apps/landing-page-astro/src/pages/contact.astro
+++ b/apps/landing-page-astro/src/pages/contact.astro
@@ -2,6 +2,7 @@
 import Layout from '@/layouts/Layout.astro';
 import Nav from '@/components/Nav.astro';
 import Footer from '@/components/Footer.astro';
+import GitHubIcon from '@/components/GitHubIcon.astro';
 ---
 
 <Layout
@@ -31,7 +32,7 @@ import Footer from '@/components/Footer.astro';
           — bug reports, feature requests, and verification case contributions
         </li>
         <li>
-          <a href="https://github.com/Codevetter/codevetter" class="text-amber-400 hover:text-amber-300 underline">github.com/Codevetter/codevetter</a>
+          <a href="https://github.com/Codevetter/codevetter" aria-label="GitHub repository" title="GitHub repository" target="_blank" rel="noopener noreferrer" class="inline-flex items-center align-middle text-amber-400 hover:text-amber-300 transition-colors"><GitHubIcon width={20} height={20} /></a>
           — source code and releases
         </li>
       </ul>

--- a/apps/landing-page-astro/src/pages/download.astro
+++ b/apps/landing-page-astro/src/pages/download.astro
@@ -2,6 +2,7 @@
 import Layout from '@/layouts/Layout.astro';
 import Nav from '@/components/Nav.astro';
 import Footer from '@/components/Footer.astro';
+import GitHubIcon from '@/components/GitHubIcon.astro';
 import { currentReleaseUrl } from '@/data/release';
 
 // Port of apps/landing-page/app/download/page.tsx.
@@ -77,11 +78,13 @@ const PLATFORMS: Platform[] = [
         Building from source? See the{' '}
         <a
           href="https://github.com/Codevetter/codevetter"
+          aria-label="GitHub repository"
+          title="GitHub repository"
           target="_blank"
           rel="noopener noreferrer"
-          class="underline hover:text-amber-400"
+          class="inline-flex items-center align-middle text-stone-400 hover:text-amber-400 transition-colors"
         >
-          repo README
+          <GitHubIcon width={20} height={20} />
         </a>{' '}
       — native SwiftUI/AppKit + Rust, pnpm workspaces.
       </p>


### PR DESCRIPTION
## Summary

Per fleet policy sass-maker/saas-maker#91, the public website must link to its own GitHub repository with an icon, never with visible text such as "GitHub", "Source", "Source code", "View on GitHub", or "Inspect the source".

Replaced every visible-text repo-root link on the Astro landing page with an icon-only link using the official GitHub mark.

### Files changed

- **`components/GitHubIcon.astro`** (new) — reusable component with the official GitHub mark SVG (`viewBox="0 0 16 16"`, `fill="currentColor"`, `aria-hidden="true"`)
- **`components/Nav.astro`** — "GitHub" text → icon-only link (same position, same hover styling)
- **`components/Footer.astro`** — "Source" text → icon-only link (icon-only flag added to the item renderer)
- **`pages/benchmark.astro`** — "GitHub" text → icon
- **`pages/about.astro`** — `github.com/Codevetter/codevetter` URL text → icon
- **`pages/contact.astro`** — `github.com/Codevetter/codevetter` URL text → icon
- **`pages/changelog.astro`** — "Source ↗" text → icon
- **`pages/download.astro`** — "repo README" text → icon

All repo-root links now use `aria-label="GitHub repository"`, `title="GitHub repository"`, `target="_blank"`, `rel="noopener noreferrer"`, and no visible text. Deep links to `/issues`, `/blob/`, and code-block `git clone` snippets were left unchanged (they are not repo-root links with banned labels).

#### Test plan

- [x] `pnpm build` (Astro) — 25 pages built, no errors
- [x] `pnpm lint` (Biome) — no issues
- [x] `pnpm knip:strict` — no unused code
- [x] Verified built HTML: every `href="https://github.com/Codevetter/codevetter"` link has `aria-label="GitHub repository"` and no visible text

Generated with [Devin](https://devin.ai)