### PR TITLE
Log CodeVetter download intent and release clicks to App Health

### DIFF
--- a/apps/landing-page-astro/src/components/CTA.astro
+++ b/apps/landing-page-astro/src/components/CTA.astro
@@ -18,6 +18,7 @@ import { currentReleaseUrl } from '@/data/release';
         <div class="mt-10 flex w-full flex-col items-center justify-center gap-3 sm:w-auto sm:flex-row">
           <a
             href={currentReleaseUrl}
+            data-log="download.release"
             class="group inline-flex h-[52px] w-full items-center justify-center gap-2 rounded-full bg-white px-7 text-sm font-medium text-black transition-all hover:bg-gray-100 sm:w-auto"
           >
             <Icon name="download" class="h-4 w-4" width={16} height={16} />

--- a/apps/landing-page-astro/src/components/Hero.astro
+++ b/apps/landing-page-astro/src/components/Hero.astro
@@ -52,6 +52,7 @@ import Icon from './Icon.astro';
         </a>
         <a
           href="#download"
+          data-log="download.intent"
           class="inline-flex h-12 w-full items-center justify-center gap-2 rounded-full border border-white/20 bg-white/[0.03] px-6 text-sm font-medium text-white transition-colors hover:border-white/40 hover:bg-white/[0.06] sm:w-auto"
         >
           <Icon name="apple" class="h-4 w-4 text-gray-300" width={16} height={16} />

--- a/apps/landing-page-astro/src/components/Nav.astro
+++ b/apps/landing-page-astro/src/components/Nav.astro
@@ -42,6 +42,7 @@ const links = [
       </a>
       <a
         href="/#download"
+        data-log="download.intent"
         class="group inline-flex items-center gap-2 h-9 px-5 text-xs font-medium bg-white text-black hover:bg-gray-100 shadow-[0_0_20px_rgba(255,255,255,0.2)] hover:shadow-[0_0_30px_rgba(255,255,255,0.4)] transition-all duration-300 rounded-full"
       >
         Download

--- a/apps/landing-page-astro/src/pages/download.astro
+++ b/apps/landing-page-astro/src/pages/download.astro
@@ -58,6 +58,7 @@ const PLATFORMS: Platform[] = [
 
       <a
         href={currentReleaseUrl}
+        data-log="download.release"
         target="_blank"
         rel="noopener noreferrer"
         class="mt-6 inline-block rounded-md bg-amber-500 px-4 py-2 text-sm font-medium text-stone-950 hover:bg-amber-400"


### PR DESCRIPTION
Part of the fleet-wide App Health integration audit (sass-maker/app-health#55).

## Why

The landing page already loads `/app-health-log.js` with a valid public key, but
no element on the site carries a `data-log` attribute. The snippet only
auto-logs `form.submitted` and `client.error`, so the one thing worth measuring
here never reached the Logs tab.

CodeVetter has no account and no hosted backend. The click through to the GitHub
release is the product's only conversion event, and it was invisible.

## What

- `download.release` on the two links that leave for the GitHub release (home
  CTA, `/download`).
- `download.intent` on the two in-page CTAs that only scroll to `#download`
  (nav button, hero secondary), so intent can be read against conversion.

Four attributes, no new script, no new key, no CSP change (the site has none).

## Verification

- `astro build` — 25 pages, clean; `data-log` renders on the built HTML.
- `biome check apps/landing-page-astro/src` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)