### PR TITLE
release: cut 1.13.3 to prove the gated release pipeline

### DIFF
--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -1,6 +1,6 @@
 # Project Status
 
-Last updated: 2026-09-05
+Last updated: 2026-09-06
 
 ## Why / What
 
@@ -54,6 +54,21 @@ Internal (fleet):
 - Local SQLite via `rusqlite` in `crates/codevetter-core` — desktop only, no server.
 
 ## Timeline
+
+- **2026-09-06 — First release cut through the gated pipeline (1.13.3):** a
+  patch bump that carries no product change; its purpose is to exercise the
+  release gate landed in #259 end to end, which no run has ever done. The
+  release is created as a draft on an explicitly created tag, `release.yml`
+  verifies the published asset manifest before flipping the draft to
+  published, and `auto-release.yml` waits on the dispatched run and re-verifies
+  the manifest, so a green auto-release run now means a downloadable release
+  exists. `/download` and `/download.md` read the tag, installer filename,
+  update archive, and appcast presence from the GitHub release feed at build
+  time rather than hardcoding them, and `src/data/privacy.ts` is the single
+  source for `/privacy`, `/privacy.md`, and the page JSON-LD. The
+  installed-upgrade proof's incumbent is pinned to `v1.11.1`, whose bundled CLI
+  has the `rubrics` command the proof needs. The shipped tag is cut from `main`
+  at HEAD, so the qualified archive and the repository agree on one commit.
 
 - **2026-09-05 — Usage revalidates on its own (1.13.2):** the Usage section
   keeps itself current while it is open instead of collecting once per

--- a/apps/macos/Config/Shared.xcconfig
+++ b/apps/macos/Config/Shared.xcconfig
@@ -15,8 +15,8 @@ EXECUTABLE_NAME = CodeVetterNative
 // Debug stays isolated from user data; Release owns the production identity.
 PRODUCT_BUNDLE_IDENTIFIER = com.codevetter.desktop
 PRODUCT_BUNDLE_IDENTIFIER[config=Debug] = com.codevetter.desktop.native-preview
-MARKETING_VERSION = 1.13.2
-CURRENT_PROJECT_VERSION = 11302
+MARKETING_VERSION = 1.13.3
+CURRENT_PROJECT_VERSION = 11303
 
 // ==========================================
 // Platform Configuration

--- a/crates/codevetter-core/Cargo.lock
+++ b/crates/codevetter-core/Cargo.lock
@@ -297,7 +297,7 @@ dependencies = [
 
 [[package]]
 name = "codevetter-core"
-version = "1.13.2"
+version = "1.13.3"
 dependencies = [
  "base64",
  "chromiumoxide",
@@ -339,7 +339,7 @@ dependencies = [
 
 [[package]]
 name = "codevetter-transport"
-version = "1.13.2"
+version = "1.13.3"
 dependencies = [
  "codevetter-transport-macros",
  "tokio",
@@ -347,7 +347,7 @@ dependencies = [
 
 [[package]]
 name = "codevetter-transport-macros"
-version = "1.13.2"
+version = "1.13.3"
 
 [[package]]
 name = "colorchoice"

--- a/crates/codevetter-core/Cargo.toml
+++ b/crates/codevetter-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codevetter-core"
-version = "1.13.2"
+version = "1.13.3"
 edition = "2021"
 publish = false
 description = "CodeVetter verification core, CLI, and read-only MCP server"
@@ -24,7 +24,7 @@ path = "src/bin/codevetter-graph.rs"
 [dependencies]
 # Source-compatible command facade while legacy annotations are renamed. This
 # is repository-owned and contains no Tauri, WebView, or windowing runtime.
-tauri = { package = "codevetter-transport", version = "=1.13.2", path = "../codevetter-transport" }
+tauri = { package = "codevetter-transport", version = "=1.13.3", path = "../codevetter-transport" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"

--- a/crates/codevetter-transport-macros/Cargo.toml
+++ b/crates/codevetter-transport-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codevetter-transport-macros"
-version = "1.13.2"
+version = "1.13.3"
 edition = "2021"
 publish = false
 

--- a/crates/codevetter-transport/Cargo.toml
+++ b/crates/codevetter-transport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codevetter-transport"
-version = "1.13.2"
+version = "1.13.3"
 edition = "2021"
 publish = false
 
@@ -8,5 +8,5 @@ publish = false
 name = "tauri"
 
 [dependencies]
-codevetter-transport-macros = { version = "=1.13.2", path = "../codevetter-transport-macros" }
+codevetter-transport-macros = { version = "=1.13.3", path = "../codevetter-transport-macros" }
 tokio = { version = "1", features = ["rt-multi-thread"] }


### PR DESCRIPTION
Refs #252, #253.

No product change. This patch bump exists to run the release gate landed in #259 end to end — no run has ever reached the upload step, and the last six releases (`v1.12.0`..`v1.13.2`) went public with zero assets while every `auto-release.yml` run reported success.

## What merging this proves

- `auto-release.yml` creates the tag and a **draft** release, dispatches `release.yml`, **waits** on that run, and re-verifies the published asset manifest.
- `release.yml` runs `scripts/verify-release-manifest.mjs` before flipping the draft to published, then checks the public appcast URL resolves.
- The installed-upgrade proof's incumbent is pinned to `v1.11.1`, whose bundled CLI has the `rubrics` command the proof seeds data with (#252 / #258).
- `/download` and `/download.md` read the tag, installer filename, update archive, and appcast presence from the release feed at build time, so the page follows whatever this release actually publishes.

Red means the release stays a draft and nothing goes public.

## Version pairing

`MARKETING_VERSION` 1.13.2 → 1.13.3, `CURRENT_PROJECT_VERSION` 11302 → 11303, and the three crates plus their exact `=<version>` path pins and the workspace lockfile move with the app, as 1.13.1 established. `core:qualify-cli` reports `codevetter 1.13.3`.

## Local gates

`lint`, `knip:strict`, `quality:change-size`, `quality:complexity`, `quality:cycles`, `quality:duplication`, `check-docs.mjs`, `test:release-manifest`, `core:qualify-cli` — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)