### PR TITLE
fix(release): scope the window probe's filter to the process, not to windows

### DIFF
--- a/scripts/qualify-native-installed-upgrade.mjs
+++ b/scripts/qualify-native-installed-upgrade.mjs
@@ -233,30 +233,70 @@ async function launchAndObserve(app, appData, kind) {
     cwd: repositoryRoot,
     detached: true,
     env: { ...process.env, CODEVETTER_APP_DATA_DIR: appData },
-    stdio: 'ignore',
+    stdio: ['ignore', 'pipe', 'pipe'],
   });
+  // Retained so a launch that never presents a window can say why. The pipes
+  // have to be drained regardless: a chatty startup otherwise fills the buffer
+  // and blocks the very launch this is trying to observe.
+  const output = [];
+  const retain = (chunk) => {
+    output.push(chunk);
+    if (output.length > 200) output.shift();
+  };
+  child.stdout.setEncoding('utf8').on('data', retain);
+  child.stderr.setEncoding('utf8').on('data', retain);
   try {
-    await waitForVisibleWindow(child, 25_000);
+    await waitForVisibleWindow(child, kind, WINDOW_TIMEOUT_MS, output);
     return { kind, visible_window: true, bundle_identifier: info.CFBundleIdentifier };
   } finally {
     await terminateOwnedProcess(child);
   }
 }
 
-async function waitForVisibleWindow(child, timeoutMs) {
+// A cold GUI launch on a hosted runner follows a full Xcode build and a
+// notarization round trip, so the app competes for a loaded machine.
+const WINDOW_TIMEOUT_MS = 90_000;
+
+// `whose` binds to the nearest preceding collection. Without the parentheses
+// this reads as "windows ... whose unix id is", filtering windows by a property
+// only processes carry, so every poll throws -1728 and the gate can never pass
+// on any machine (#253). The parentheses scope the filter to the process.
+export function buildWindowCountScript(pid) {
+  return `tell application "System Events" to count windows of (first process whose unix id is ${pid})`;
+}
+
+async function waitForVisibleWindow(child, kind, timeoutMs, output = []) {
   const deadline = Date.now() + timeoutMs;
+  let lastObservation = 'the process never appeared in the System Events process list';
   while (Date.now() < deadline) {
-    if (child.exitCode !== null) throw new Error(`Application exited before showing a window`);
-    const script = `tell application "System Events" to count windows of first process whose unix id is ${child.pid}`;
+    if (child.exitCode !== null)
+      throw new Error(
+        `Application exited before showing a window (${kind}, code ${child.exitCode})${formatLaunchOutput(output)}`
+      );
     try {
-      const count = Number(execFileSync('osascript', ['-e', script], { encoding: 'utf8' }).trim());
+      // stderr is piped rather than inherited so a failing poll is reported
+      // once, instead of spraying one -1728 line per 250 ms into the job log.
+      const count = Number(
+        execFileSync('osascript', ['-e', buildWindowCountScript(child.pid)], {
+          encoding: 'utf8',
+          stdio: ['ignore', 'pipe', 'pipe'],
+        }).trim()
+      );
       if (count > 0) return;
-    } catch {
-      // The process may not have registered with System Events yet.
+      lastObservation = 'System Events saw the process but it reported no windows';
+    } catch (error) {
+      lastObservation = `System Events could not read the process: ${String(error.stderr ?? error.message).trim()}`;
     }
     await delay(250);
   }
-  throw new Error(`Application ${child.pid} did not show a visible window within ${timeoutMs} ms`);
+  throw new Error(
+    `Application ${child.pid} (${kind}) did not show a visible window within ${timeoutMs} ms; ${lastObservation}${formatLaunchOutput(output)}`
+  );
+}
+
+function formatLaunchOutput(output) {
+  const text = output.join('').trim();
+  return text ? `\n--- application output ---\n${text.slice(-2000)}` : '';
 }
 
 async function terminateOwnedProcess(child) {

--- a/scripts/qualify-native-installed-upgrade.test.mjs
+++ b/scripts/qualify-native-installed-upgrade.test.mjs
@@ -4,6 +4,7 @@ import test from 'node:test';
 import {
   assertHostedUpgradeContext,
   buildInstalledUpgradeProof,
+  buildWindowCountScript,
   parseArguments,
 } from './qualify-native-installed-upgrade.mjs';
 
@@ -47,6 +48,16 @@ test('hosted upgrade proof requires every launch, rubric, and durable identity',
     launches: input().launches.filter((item) => item.kind !== 'native_relaunch'),
   });
   assert.equal(failed.status, 'failed');
+});
+
+test('the window probe scopes its filter to the process, not to windows', () => {
+  const script = buildWindowCountScript(4321);
+
+  // Regression guard for #253: `count windows of first process whose unix id
+  // is N` binds `whose` to `windows`, which carry no unix id, so System Events
+  // answers -1728 on every poll and no release can ever clear the gate.
+  assert.match(script, /count windows of \(first process whose unix id is 4321\)/);
+  assert.doesNotMatch(script, /windows of first process whose/);
 });
 
 test('execution is restricted to an explicit GitHub-hosted temporary child', () => {


### PR DESCRIPTION
Refs #253.

## The gate that never could pass

`scripts/qualify-native-installed-upgrade.mjs` is the last gate before release assets are uploaded. It has never passed — not once, on any machine.

`waitForVisibleWindow` asked System Events for:

```applescript
count windows of first process whose unix id is <pid>
```

`whose` binds to the nearest preceding collection, so this filters **windows** by `unix id` — a property only processes carry. Every poll answers `-1728 "Can't get unix id of window"`, the `catch` swallows it as "not registered yet", and the launch always times out.

Reproduced locally against the v1.11.1 incumbent, polling both forms side by side against the same live pid:

```
t=0.0s   current=ERR()  parenthesized=0
t=3.2s   current=ERR()  parenthesized=0
...
t=38.9s  current=ERR()  parenthesized=0
```

The current form never returns a number. The parenthesized form does — and against an app that genuinely has a window (Safari) it returns `1`. Parenthesizing the process term is the whole fix.

## Why it stayed hidden

The proof runs only in `native-production-qualification.yml`, which runs only on a release. So each release since the native cutover surfaced exactly one more latent failure instead of all of them at once:

| Release | Run | Failed at |
|---|---|---|
| v1.12.1 | 33929885965 | step 13 — rebuild archives |
| v1.12.2 | 33930948063 | step 15 — Sparkle appcast |
| v1.13.2 | 33962630311 | step 17 — `rubrics` missing from the v1.11.0 incumbent |
| v1.13.3 | 34029077434 | step 17 — this bug |

Worth correcting the record: `release.yml` was **not** failing to trigger. `auto-release.yml` already dispatched it explicitly via `gh workflow run`, and all six broken releases did dispatch and did fail in the build. The regression was always the `qualify` job failing, which skips `publish`, which is why no assets were attached.

## Also in this PR

Making the next failure legible rather than silent — the previous run gave 25 seconds of identical `-1728` lines and no other information:

- Retain the launched app's stdout/stderr and attach it to the thrown error. The pipes have to be drained anyway; a chatty startup would otherwise fill the buffer and block the launch being observed.
- Distinguish "System Events could not read the process" from "the process reported no windows", so a registration/TCC problem is not mistaken for an app that failed to draw.
- Pipe `osascript`'s stderr instead of inheriting it, so a failing poll is reported once rather than every 250 ms.
- Raise the per-launch budget to 90s. A cold GUI launch follows a full Xcode build and a notarization round trip; 25s was tight on a loaded runner. This relaxes only the deadline, not what the gate proves.

## Verification

`node --test scripts/qualify-native-installed-upgrade.test.mjs` — 4/4 pass, including a new regression test pinning the binding. `biome check` clean on both files.

Note this does not by itself guarantee a green release: with the query fixed, the incumbent still reported 0 windows locally over 40s, though that machine already had a CodeVetter instance running, which a single-instance app would defer to. The point of this PR is that the gate can now *report* what it observed instead of failing blind. `native-production-qualification.yml` already accepts `workflow_dispatch`, so the next iteration does not need a release cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)