### PR TITLE
release: cut 1.13.4 with the fixed upgrade-proof launch probe

### DIFF
--- a/apps/macos/Config/Shared.xcconfig
+++ b/apps/macos/Config/Shared.xcconfig
@@ -15,8 +15,8 @@ EXECUTABLE_NAME = CodeVetterNative
 // Debug stays isolated from user data; Release owns the production identity.
 PRODUCT_BUNDLE_IDENTIFIER = com.codevetter.desktop
 PRODUCT_BUNDLE_IDENTIFIER[config=Debug] = com.codevetter.desktop.native-preview
-MARKETING_VERSION = 1.13.3
-CURRENT_PROJECT_VERSION = 11303
+MARKETING_VERSION = 1.13.4
+CURRENT_PROJECT_VERSION = 11304
 
 // ==========================================
 // Platform Configuration


### PR DESCRIPTION
Cuts `v1.13.4` — the first tag that contains the #265 launch-probe fix.

**Why a new version rather than re-running v1.13.3.** `release.yml` passes `source_ref: ${{ inputs.tag }}` to the qualification workflow, so a `workflow_dispatch` against `v1.13.3` checks out the tag as it was cut — which predates #265 — and would fail at the same *Qualify isolated upgrade…* step. `v1.13.3` remains a draft with zero assets and is superseded by this cut.

Merging this bumps `Shared.xcconfig`, which triggers `auto-release.yml`: tag + **draft** release, explicit `workflow_dispatch` of `release.yml`, `gh run watch --exit-status` on the build, asset-manifest re-verification, and only then draft → published.

Refs #252, refs #253 — neither closes until assets are actually live.