### PR TITLE
release: cut 1.13.5 as the first release with one version

### DIFF
--- a/apps/macos/Config/Shared.xcconfig
+++ b/apps/macos/Config/Shared.xcconfig
@@ -15,8 +15,8 @@ EXECUTABLE_NAME = CodeVetterNative
 // Debug stays isolated from user data; Release owns the production identity.
 PRODUCT_BUNDLE_IDENTIFIER = com.codevetter.desktop
 PRODUCT_BUNDLE_IDENTIFIER[config=Debug] = com.codevetter.desktop.native-preview
-MARKETING_VERSION = 1.13.4
-CURRENT_PROJECT_VERSION = 11304
+MARKETING_VERSION = 1.13.5
+CURRENT_PROJECT_VERSION = 11305
 
 // ==========================================
 // Platform Configuration

--- a/crates/codevetter-core/Cargo.lock
+++ b/crates/codevetter-core/Cargo.lock
@@ -297,7 +297,7 @@ dependencies = [
 
 [[package]]
 name = "codevetter-core"
-version = "1.13.4"
+version = "1.13.5"
 dependencies = [
  "base64",
  "chromiumoxide",
@@ -339,7 +339,7 @@ dependencies = [
 
 [[package]]
 name = "codevetter-transport"
-version = "1.13.4"
+version = "1.13.5"
 dependencies = [
  "codevetter-transport-macros",
  "tokio",
@@ -347,7 +347,7 @@ dependencies = [
 
 [[package]]
 name = "codevetter-transport-macros"
-version = "1.13.4"
+version = "1.13.5"
 
 [[package]]
 name = "colorchoice"

--- a/crates/codevetter-core/Cargo.toml
+++ b/crates/codevetter-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codevetter-core"
-version = "1.13.4"
+version = "1.13.5"
 edition = "2021"
 publish = false
 description = "CodeVetter verification core, CLI, and read-only MCP server"
@@ -24,7 +24,7 @@ path = "src/bin/codevetter-graph.rs"
 [dependencies]
 # Source-compatible command facade while legacy annotations are renamed. This
 # is repository-owned and contains no Tauri, WebView, or windowing runtime.
-tauri = { package = "codevetter-transport", version = "=1.13.4", path = "../codevetter-transport" }
+tauri = { package = "codevetter-transport", version = "=1.13.5", path = "../codevetter-transport" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"

--- a/crates/codevetter-transport-macros/Cargo.toml
+++ b/crates/codevetter-transport-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codevetter-transport-macros"
-version = "1.13.4"
+version = "1.13.5"
 edition = "2021"
 publish = false
 

--- a/crates/codevetter-transport/Cargo.toml
+++ b/crates/codevetter-transport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codevetter-transport"
-version = "1.13.4"
+version = "1.13.5"
 edition = "2021"
 publish = false
 
@@ -8,5 +8,5 @@ publish = false
 name = "tauri"
 
 [dependencies]
-codevetter-transport-macros = { version = "=1.13.4", path = "../codevetter-transport-macros" }
+codevetter-transport-macros = { version = "=1.13.5", path = "../codevetter-transport-macros" }
 tokio = { version = "1", features = ["rt-multi-thread"] }


### PR DESCRIPTION
Follows #267, which made `MARKETING_VERSION` the only version and gated it in both pipelines.

**Why a new cut instead of re-running v1.13.4.** Tag `v1.13.4` points at `0f941090`, where `MARKETING_VERSION` is 1.13.4 but `crates/codevetter-core/Cargo.toml` is still `1.13.3`. The drift is inside the tag, so re-dispatching `release.yml` against it rebuilds the same tree and fails `core:qualify-cli` exactly as before — the failure that left v1.12.0–v1.13.2 with zero assets. The tag has to move past the drift.

**How this bump was made.** One edit to `MARKETING_VERSION`, then `pnpm version:sync`, which derived `CURRENT_PROJECT_VERSION` (11305), the three crate versions, the sibling `=<version>` pins, and `Cargo.lock`. No file in this diff was hand-edited except the first line. `pnpm version:check` reports the tree consistent.

On merge, `auto-release.yml` cuts `v1.13.5` and dispatches `release.yml`, which now runs `version:check` before signing. Expected outcome: four assets on v1.13.5 and the draft published by the manifest gate from #259.

Refs #253.