### PR TITLE
fix(release): probe a copy of the WAL database so qualification can finish

### DIFF
--- a/apps/macos/Config/Shared.xcconfig
+++ b/apps/macos/Config/Shared.xcconfig
@@ -15,8 +15,8 @@ EXECUTABLE_NAME = CodeVetterNative
 // Debug stays isolated from user data; Release owns the production identity.
 PRODUCT_BUNDLE_IDENTIFIER = com.codevetter.desktop
 PRODUCT_BUNDLE_IDENTIFIER[config=Debug] = com.codevetter.desktop.native-preview
-MARKETING_VERSION = 1.13.4
-CURRENT_PROJECT_VERSION = 11304
+MARKETING_VERSION = 1.13.5
+CURRENT_PROJECT_VERSION = 11305
 
 // ==========================================
 // Platform Configuration

--- a/crates/codevetter-core/Cargo.lock
+++ b/crates/codevetter-core/Cargo.lock
@@ -297,7 +297,7 @@ dependencies = [
 
 [[package]]
 name = "codevetter-core"
-version = "1.13.4"
+version = "1.13.5"
 dependencies = [
  "base64",
  "chromiumoxide",
@@ -339,7 +339,7 @@ dependencies = [
 
 [[package]]
 name = "codevetter-transport"
-version = "1.13.4"
+version = "1.13.5"
 dependencies = [
  "codevetter-transport-macros",
  "tokio",
@@ -347,7 +347,7 @@ dependencies = [
 
 [[package]]
 name = "codevetter-transport-macros"
-version = "1.13.4"
+version = "1.13.5"
 
 [[package]]
 name = "colorchoice"

--- a/crates/codevetter-core/Cargo.toml
+++ b/crates/codevetter-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codevetter-core"
-version = "1.13.4"
+version = "1.13.5"
 edition = "2021"
 publish = false
 description = "CodeVetter verification core, CLI, and read-only MCP server"
@@ -24,7 +24,7 @@ path = "src/bin/codevetter-graph.rs"
 [dependencies]
 # Source-compatible command facade while legacy annotations are renamed. This
 # is repository-owned and contains no Tauri, WebView, or windowing runtime.
-tauri = { package = "codevetter-transport", version = "=1.13.4", path = "../codevetter-transport" }
+tauri = { package = "codevetter-transport", version = "=1.13.5", path = "../codevetter-transport" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"

--- a/crates/codevetter-transport-macros/Cargo.toml
+++ b/crates/codevetter-transport-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codevetter-transport-macros"
-version = "1.13.4"
+version = "1.13.5"
 edition = "2021"
 publish = false
 

--- a/crates/codevetter-transport/Cargo.toml
+++ b/crates/codevetter-transport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codevetter-transport"
-version = "1.13.4"
+version = "1.13.5"
 edition = "2021"
 publish = false
 
@@ -8,5 +8,5 @@ publish = false
 name = "tauri"
 
 [dependencies]
-codevetter-transport-macros = { version = "=1.13.4", path = "../codevetter-transport-macros" }
+codevetter-transport-macros = { version = "=1.13.5", path = "../codevetter-transport-macros" }
 tokio = { version = "1", features = ["rt-multi-thread"] }

--- a/scripts/qualify-native-data-continuity.mjs
+++ b/scripts/qualify-native-data-continuity.mjs
@@ -2,8 +2,17 @@
 
 import { spawnSync } from 'node:child_process';
 import { createHash, randomBytes } from 'node:crypto';
-import { basename, dirname, resolve } from 'node:path';
-import { existsSync, readFileSync, realpathSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, dirname, join, resolve } from 'node:path';
+import {
+  copyFileSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
 const snapshotSchema = 'codevetter.native-data-snapshot/v1';
@@ -156,9 +165,42 @@ export function compareDataSnapshots(before, afterUpgrade, afterRollback) {
   };
 }
 
+// The application database runs in WAL mode, and SQLite cannot open a WAL
+// database through a read-only connection unless the -wal and -shm sidecars
+// already exist: it may not create them, so the open fails with
+// `unable to open database file (14)` before a single statement runs. A
+// cleanly closed application deletes both sidecars, and the upgrade harness
+// terminates the app before every capture — so the sidecar-less database is
+// the normal case here, not an edge case, and `sqlite3 -readonly` could never
+// probe it (#253).
+//
+// The probe therefore never opens the user's database at all. It copies the
+// database and whichever sidecars exist into a private throwaway directory and
+// reads that copy, which keeps the original untouched by construction while
+// letting SQLite rebuild the sidecars it needs to replay commits that are still
+// WAL-resident. Dropping the -wal would silently under-count those commits, so
+// every sidecar present is copied. `PRAGMA query_only=ON` guards each statement.
 function queryDatabase(database) {
   if (!existsSync(sqlite)) throw new Error(`${sqlite} is unavailable`);
-  const integrity = runSqlite(database, 'PRAGMA query_only=ON; PRAGMA quick_check;').trim();
+  const probeRoot = mkdtempSync(join(tmpdir(), 'codevetter-continuity-probe-'));
+  try {
+    return queryDatabaseCopy(copyDatabaseForProbe(database, probeRoot));
+  } finally {
+    rmSync(probeRoot, { recursive: true, force: true });
+  }
+}
+
+function copyDatabaseForProbe(database, probeRoot) {
+  const probe = join(probeRoot, 'codevetter.db');
+  for (const suffix of ['', '-wal', '-shm']) {
+    if (existsSync(`${database}${suffix}`))
+      copyFileSync(`${database}${suffix}`, `${probe}${suffix}`);
+  }
+  return probe;
+}
+
+function queryDatabaseCopy(database) {
+  const integrity = runSqlite(database, 'PRAGMA quick_check;').trim();
   if (integrity !== 'ok') throw new Error(`SQLite quick_check failed: ${integrity || 'no result'}`);
   const tableRows = runJSON(
     database,
@@ -224,7 +266,7 @@ function runJSON(database, sql) {
 }
 
 function runSqlite(database, sql, extraArguments = []) {
-  const result = spawnSync(sqlite, ['-readonly', ...extraArguments, database, sql], {
+  const result = spawnSync(sqlite, [...extraArguments, database, `PRAGMA query_only=ON; ${sql}`], {
     encoding: 'utf8',
     stdio: ['ignore', 'pipe', 'pipe'],
   });

--- a/scripts/qualify-native-data-continuity.test.mjs
+++ b/scripts/qualify-native-data-continuity.test.mjs
@@ -1,9 +1,11 @@
 import assert from 'node:assert/strict';
-import { execFileSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { execFileSync, spawn } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
+import { setTimeout } from 'node:timers/promises';
 
 import {
   captureDataSnapshot,
@@ -11,7 +13,7 @@ import {
   parseArguments,
 } from './qualify-native-data-continuity.mjs';
 
-function withFixture(run) {
+async function withFixture(run) {
   const root = mkdtempSync(join(tmpdir(), 'codevetter-data-continuity-'));
   const appData = join(root, 'com.codevetter.desktop');
   mkdirSync(appData);
@@ -28,14 +30,14 @@ function withFixture(run) {
      INSERT INTO preferences VALUES ('github_token', 'secret-value');`,
   ]);
   try {
-    run({ root, database });
+    return await run({ root, database });
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
 }
 
-test('read-only snapshots preserve incumbent identities while allowing new rows', () => {
-  withFixture(({ database }) => {
+test('read-only snapshots preserve incumbent identities while allowing new rows', async () => {
+  await withFixture(({ database }) => {
     const before = captureDataSnapshot({
       databasePath: database,
       phase: 'before',
@@ -71,8 +73,95 @@ test('read-only snapshots preserve incumbent identities while allowing new rows'
   });
 });
 
-test('comparison fails when an incumbent record disappears', () => {
-  withFixture(({ database }) => {
+function readRowCount(database) {
+  try {
+    return Number(
+      execFileSync('/usr/bin/sqlite3', [database, 'SELECT count(*) FROM cc_projects;'], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      }).trim()
+    );
+  } catch {
+    return -1;
+  }
+}
+
+// Commit through a connection that is killed rather than closed, so the -wal
+// keeps a commit the main database file does not hold yet. A closing connection
+// would checkpoint it away and delete both sidecars.
+async function commitIntoAbandonedWal(database, sql, expectedRows) {
+  const child = spawn('/usr/bin/sqlite3', [database], { stdio: ['pipe', 'ignore', 'ignore'] });
+  try {
+    child.stdin.write(`PRAGMA journal_mode=WAL;\n${sql}\n`);
+    const deadline = Date.now() + 10_000;
+    while (Date.now() < deadline) {
+      // A second reader confirms the commit landed in the -wal. It never
+      // checkpoints on close, because the writer above still holds the database.
+      // It is locked out while the writer switches journal modes, so keep polling.
+      const walBytes = statSync(`${database}-wal`, { throwIfNoEntry: false })?.size ?? 0;
+      if (walBytes > 0 && readRowCount(database) === expectedRows) return;
+      await setTimeout(20);
+    }
+    throw new Error('sqlite3 never committed into the -wal');
+  } finally {
+    child.kill('SIGKILL');
+  }
+}
+
+// The shipped database runs in WAL mode and the upgrade harness terminates the
+// app before every capture, so the probe meets it with whichever sidecars that
+// shutdown happened to leave behind. A read-only connection cannot open a WAL
+// database once a sidecar is missing — it fails with `unable to open database
+// file (14)` before running a statement — which stopped six releases from ever
+// reaching their upload job (#253). Every state below failed that way until the
+// probe started reading a private copy instead.
+for (const [state, removed] of [
+  ['a clean shutdown removed both sidecars', ['-wal', '-shm']],
+  ['a shutdown removed the -wal and left the -shm', ['-wal']],
+  ['a kill left the -wal without its -shm', ['-shm']],
+  ['a kill left both sidecars behind', []],
+]) {
+  test(`the WAL probe reads every committed record when ${state}`, async () => {
+    await withFixture(async ({ database }) => {
+      await commitIntoAbandonedWal(
+        database,
+        "INSERT INTO cc_projects VALUES ('project-2', 'Second project');",
+        2
+      );
+      for (const suffix of removed) rmSync(`${database}${suffix}`, { force: true });
+
+      const before = captureDataSnapshot({
+        databasePath: database,
+        phase: 'before',
+        probeNonce: 'd'.repeat(64),
+      });
+      assert.equal(before.database_integrity, 'ok');
+      // The WAL-resident row counts only when the sidecar carrying it survived.
+      assert.equal(before.table_counts.cc_projects, removed.includes('-wal') ? 1 : 2);
+      assert.equal(before.preserved_record_count, removed.includes('-wal') ? 4 : 5);
+      assert.equal(JSON.stringify(before).includes('Second project'), false);
+    });
+  });
+}
+
+test('the probe leaves the application database and its sidecars untouched', async () => {
+  await withFixture(async ({ database }) => {
+    await commitIntoAbandonedWal(
+      database,
+      "INSERT INTO cc_projects VALUES ('project-2', 'Second project');",
+      2
+    );
+    const digest = (path) =>
+      existsSync(path) ? createHash('sha256').update(readFileSync(path)).digest('hex') : null;
+    const paths = ['', '-wal', '-shm'].map((suffix) => `${database}${suffix}`);
+    const before = paths.map(digest);
+    captureDataSnapshot({ databasePath: database, phase: 'before', probeNonce: 'e'.repeat(64) });
+    assert.deepEqual(paths.map(digest), before);
+  });
+});
+
+test('comparison fails when an incumbent record disappears', async () => {
+  await withFixture(({ database }) => {
     const before = captureDataSnapshot({
       databasePath: database,
       phase: 'before',
@@ -95,9 +184,9 @@ test('comparison fails when an incumbent record disappears', () => {
   });
 });
 
-test('comparison refuses empty baseline evidence', () => {
+test('comparison refuses empty baseline evidence', async () => {
   const query = () => ({ integrity: 'ok', records: [], tableCounts: {} });
-  withFixture(({ database }) => {
+  await withFixture(({ database }) => {
     const before = captureDataSnapshot({
       databasePath: database,
       phase: 'before',


### PR DESCRIPTION
## Summary

- Cut v1.13.5 as the first release where the version came from `pnpm version:sync` rather than hand-editing four files — fixes the version drift that left v1.12.0 through v1.13.2 with no assets.
- Fix the installed-upgrade proof's database probe: SQLite cannot open a WAL-mode database through a read-only connection without sidecars. The probe now copies the database and sidecars into a throwaway directory and reads that copy, keeping the original untouched.
- The existing tests never caught this because their fixture used rollback journal mode. New tests build the fixture in WAL mode and cover all four sidecar states.

## Context

- #253: download page claims were fixed in #262, but releases still shipped no assets because qualification died here.
- #252: the rubrics command issue was fixed by switching the incumbent to v1.11.1. This PR fixes the next blocker that surfaced after that.

#### Test plan

- [ ] CI passes (including native-production-qualification)
- [ ] A release with assets is published

Generated with [Devin](https://devin.ai)