### PR TITLE
Release 1.13.8: verification readiness and runtime launch fixes

### DIFF
--- a/apps/macos/Config/Shared.xcconfig
+++ b/apps/macos/Config/Shared.xcconfig
@@ -15,8 +15,8 @@ EXECUTABLE_NAME = CodeVetterNative
 // Debug stays isolated from user data; Release owns the production identity.
 PRODUCT_BUNDLE_IDENTIFIER = com.codevetter.desktop
 PRODUCT_BUNDLE_IDENTIFIER[config=Debug] = com.codevetter.desktop.native-preview
-MARKETING_VERSION = 1.13.7
-CURRENT_PROJECT_VERSION = 11307
+MARKETING_VERSION = 1.13.8
+CURRENT_PROJECT_VERSION = 11308
 
 // ==========================================
 // Platform Configuration

--- a/crates/codevetter-core/Cargo.lock
+++ b/crates/codevetter-core/Cargo.lock
@@ -297,7 +297,7 @@ dependencies = [
 
 [[package]]
 name = "codevetter-core"
-version = "1.13.7"
+version = "1.13.8"
 dependencies = [
  "base64",
  "chromiumoxide",
@@ -339,7 +339,7 @@ dependencies = [
 
 [[package]]
 name = "codevetter-transport"
-version = "1.13.7"
+version = "1.13.8"
 dependencies = [
  "codevetter-transport-macros",
  "tokio",
@@ -347,7 +347,7 @@ dependencies = [
 
 [[package]]
 name = "codevetter-transport-macros"
-version = "1.13.7"
+version = "1.13.8"
 
 [[package]]
 name = "colorchoice"

--- a/crates/codevetter-core/Cargo.toml
+++ b/crates/codevetter-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codevetter-core"
-version = "1.13.7"
+version = "1.13.8"
 edition = "2021"
 publish = false
 description = "CodeVetter verification core, CLI, and read-only MCP server"
@@ -24,7 +24,7 @@ path = "src/bin/codevetter-graph.rs"
 [dependencies]
 # Source-compatible command facade while legacy annotations are renamed. This
 # is repository-owned and contains no Tauri, WebView, or windowing runtime.
-tauri = { package = "codevetter-transport", version = "=1.13.7", path = "../codevetter-transport" }
+tauri = { package = "codevetter-transport", version = "=1.13.8", path = "../codevetter-transport" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"

--- a/crates/codevetter-transport-macros/Cargo.toml
+++ b/crates/codevetter-transport-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codevetter-transport-macros"
-version = "1.13.7"
+version = "1.13.8"
 edition = "2021"
 publish = false
 

--- a/crates/codevetter-transport/Cargo.toml
+++ b/crates/codevetter-transport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codevetter-transport"
-version = "1.13.7"
+version = "1.13.8"
 edition = "2021"
 publish = false
 
@@ -8,5 +8,5 @@ publish = false
 name = "tauri"
 
 [dependencies]
-codevetter-transport-macros = { version = "=1.13.7", path = "../codevetter-transport-macros" }
+codevetter-transport-macros = { version = "=1.13.8", path = "../codevetter-transport-macros" }
 tokio = { version = "1", features = ["rt-multi-thread"] }

--- a/docs/operations/release-pipeline.md
+++ b/docs/operations/release-pipeline.md
@@ -75,7 +75,7 @@ in `native-production-qualification.yml`. That incumbent has to satisfy two
 constraints at once:
 
 1. it still carries `CodeVetter_aarch64.app.tar.gz` — only Tauri releases do,
-   and `v1.11.1` is the newest tag with any assets at all; and
+   and `v1.11.1` is the newest retained Tauri tag carrying that archive; and
 2. its bundled `codevetter` CLI understands `rubrics`, because that is how the
    proof seeds the durable record whose survival across upgrade and rollback is
    the thing being proven.
@@ -123,12 +123,16 @@ Exactly these three, and nothing else:
 - `CodeVetter-<version>-arm64.zip`
 - `appcast.xml`
 
-No release has yet published assets under these names — every published asset
-is still Tauri-shaped (`CodeVetter_<version>_aarch64.dmg`), and `v1.11.1` is
-the newest release carrying any. The download page therefore states the
-filename, tag, and update mechanism it reads from the release feed at build
-time rather than this contract; it will name these files as soon as a release
-publishes them. See `apps/landing-page-astro/src/data/release.ts`.
+The published v1.13.7 release carries these three contract assets. Its
+qualified ZIP digest matches the public asset, and hosted evidence confirms
+upgrade from Tauri v1.11.1, relaunch, rollback, and custom-rubric preservation.
+The download page reads the filename and tag from the release feed at build
+time; redeploy it after publishing a new release. See
+`apps/landing-page-astro/src/data/release.ts`.
+
+Appcast signature verification and manual installed-upgrade qualification do
+not exercise an in-app Sparkle update. That remaining behavior is tracked in
+[issue #253](https://github.com/Codevetter/codevetter/issues/253).
 
 ## Key files
 


### PR DESCRIPTION
Prepare the next signed release with the runtime-target readiness fix (#272) and canonical CLI entry-point fix (#273), both already on main. Synchronizes app/build/companion versions to 1.13.8/11308 and corrects the release runbook to reflect the published v1.13.7 assets and remaining Sparkle qualification gap.

Validation: underlying source CI 34280441959 passed; 15 local-check tests, shared-service regression, 18 runtime tests, actual CLI failure/correction receipts, version consistency, docs, lint, and secret checks passed. This PR still requires exact-version CI/native qualification before merge. Merging triggers the existing draft-first signed release pipeline. Issues #272 and #273 remain open until the downloadable package is verified; #253 still tracks the in-app updater gap.
